### PR TITLE
Adding adjustment factor input for Dynamic ISF of meal mode.

### DIFF
--- a/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAdapterAIMI.kt
+++ b/plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAdapterAIMI.kt
@@ -42,7 +42,6 @@ import java.text.DecimalFormatSymbols
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import kotlin.math.abs
 import kotlin.math.ln
 import kotlin.math.pow
 import kotlin.math.round
@@ -826,6 +825,7 @@ class DetermineBasalAdapterAIMI internal constructor(private val injector: HasAn
         this.deccelerating_down = if (delta < 0 && (delta > shortAvgDelta || delta > longAvgDelta)) 1 else 0
         this.stable = if (delta>-3 && delta<3 && shortAvgDelta>-3 && shortAvgDelta<3 && longAvgDelta>-3 && longAvgDelta<3) 1 else 0
         val tdd7P = SafeParse.stringToDouble(sp.getString(R.string.key_tdd7, "50"))
+
         var tdd7Days = tddCalculator.averageTDD(tddCalculator.calculate(7, allowMissingDays = false))?.totalAmount?.toFloat() ?: 0.0f
         if (tdd7Days == 0.0f) tdd7Days = tdd7P.toFloat()
         this.tdd7DaysPerHour = tdd7Days / 24
@@ -853,6 +853,7 @@ class DetermineBasalAdapterAIMI internal constructor(private val injector: HasAn
         var tdd = (tddWeightedFromLast8H * 0.33) + (tdd7Days.toDouble() * 0.34) + (tddDaily.toDouble() * 0.33)
         val dynISFadjust = SafeParse.stringToDouble(sp.getString(R.string.key_DynISFAdjust, "120")) / 100.0
         val dynISFadjusthyper = SafeParse.stringToDouble(sp.getString(R.string.key_DynISFAdjusthyper, "150")) / 100.0
+        val mealTimeDynISFAdjFactor = SafeParse.stringToDouble(sp.getString(R.string.key_mealAdjFact, "200"))
 
         tdd = when{
             sportTime -> tdd * 50.0
@@ -860,7 +861,7 @@ class DetermineBasalAdapterAIMI internal constructor(private val injector: HasAn
             lowCarbTime -> tdd * 85.0
             snackTime -> tdd * 65.0
             highCarbTime -> tdd * 500.0
-            mealTime -> tdd * 200.0
+            mealTime -> tdd * mealTimeDynISFAdjFactor
             bg > 180 -> tdd * dynISFadjusthyper
             else -> tdd * dynISFadjust
         }

--- a/plugins/aps/src/main/res/values/strings.xml
+++ b/plugins/aps/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="dynisf_adjust_sensitivity_summary">Uses the last 24h TDD/7D TDD to calculate sensitivity ratio used for increasing or decreasing basal rate, and also adjust glucose target if these options are enabled, in the same way Autosens does. It is recommended to start with this option turned off</string>
     <string name="DynISFAdjust_title" formatted="false">DynamicISF Adjustment Factor %</string>
     <string name="DynISFAdjust_summary" formatted="false">Adjustment factor for DynamicISF. Set more than 100% for more aggressive correction doses, and less than 100% for less aggressive corrections.</string>
+    <string name="DynISFAdjust_Meal_title" formatted="false">DynamicISF Adjustment Factor for the Meal Model %</string>
+    <string name="DynISFAdjust_meal_summary" formatted="false">Adjustment factor for DynamicISF of meal mode</string>
     <string name="high_temptarget_raises_sensitivity_title">High temptarget raises sensitivity</string>
     <string name="high_temptarget_raises_sensitivity_summary"><![CDATA[Raise sensitivity for temptargets >= 100]]></string>
     <string name="low_temptarget_lowers_sensitivity_title">Low temptarget lowers sensitivity</string>
@@ -158,6 +160,9 @@
     <string name="oaps_aimi_shortname">OpenApsAIMI</string>
     <string name="key_aimiweight">key_aimiweight</string>
     <string name="key_tdd7">key_tdd7</string>
+
+
+
     <string name="key_cho">key_cho</string>
     <string name="key_B30_upperBG">key_B30_upperBG</string>
     <string name="key_B30_upperdelta">key_B30_upperdelta</string>
@@ -200,6 +205,7 @@
     <string name="number_iteration_training_summary">Nb time it will try before stopping the loop if it can not get a satisfying result.</string>
     <string name="key_nb_iteration_ML_training">key_nb_iteration_ML_training</string>
     <string name="nb_iteration_ML_training_title">NB iteration stopping the loop</string>
+    <string name="key_mealAdjFact">key_mealAdjFact</string>
 
 
 </resources>

--- a/plugins/aps/src/main/res/xml/pref_openapsaimi.xml
+++ b/plugins/aps/src/main/res/xml/pref_openapsaimi.xml
@@ -92,6 +92,17 @@
             validate:testType="floatNumericRange" />
 
         <app.aaps.core.validators.ValidatingEditTextPreference
+            android:defaultValue="200"
+            android:enabled="true"
+            android:dialogMessage="@string/DynISFAdjust_meal_summary"
+            android:inputType="numberDecimal"
+            android:key="@string/key_mealAdjFact"
+            android:title="@string/DynISFAdjust_Meal_title"
+            validate:floatmaxNumber="500"
+            validate:floatminNumber="1"
+            validate:testType="floatNumericRange" />
+
+        <app.aaps.core.validators.ValidatingEditTextPreference
             android:defaultValue="50"
             android:enabled="true"
             android:dialogMessage="@string/oaps_aimi_morning_factor_summary"


### PR DESCRIPTION
I guess it would be a good idea to let the user set the dynamic insulin sensitivity adjusment factor of any modes. In this commit, the "meal" mode has an input menu item for this, where this attribute can be set. For me the original 200% seemed a bit large.