### PR TITLE
docs: verified remaining AIMI KMP delta (2026-09-06)

### DIFF
--- a/_docs/kmp/AIMI_KMP_EXECUTION_PLAN.md
+++ b/_docs/kmp/AIMI_KMP_EXECUTION_PLAN.md
@@ -1,5 +1,14 @@
 # AIMI KMP — execution plan (Android + iOS)
 
+> **2026-09-06 — do not use this file as the live task list.**  
+> Next lots: [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).  
+> Snapshot: [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md).  
+> The freeze SHA `1ae418e106` and the 2026-08-28 “truth” table below are stale.  
+> Today’s reference tip is `origin/dev_OAPSAIMI` @ `c5db5a0333`. The freeze tag
+> `aimi-baseline-2026-08-26` was **not** present in the clone used for that audit.
+>
+> Keep this file for the dual-platform map and the 45-step tick notes.
+
 > **Use this file to code.** The blueprint stays the architecture bible.  
 > **ADR:** [`adr-g0-defaults.md`](adr-g0-defaults.md)  
 > **AIMI freeze:** `aimi-baseline-2026-08-26` = `origin/dev_OAPSAIMI` @ `1ae418e106`  

--- a/_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md
+++ b/_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md
@@ -1,5 +1,12 @@
 # AIMI KMP/iOS — backlog d'implémentation ordonné par gates
 
+> **2026-09-06 — ce fichier reste le backlog long (M0–M12).**  
+> Pour les **prochains lots concrets**, utiliser
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).
+> L'état vérifié est dans [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md).
+> Plusieurs gates M2 (`aimi-engine` réel, replay) ne sont **pas** Done : les modules existent,
+> `evaluate()` est encore un Hold.
+
 > **Usage :** transformer l'étude d'architecture en lots livrables et vérifiables.  
 > **Règle :** une tâche n'est `Done` que si son critère d'acceptation est automatisé ou accompagné
 > d'une preuve archivée.  

--- a/_docs/kmp/AIMI_KMP_MIGRATION_BLUEPRINT.md
+++ b/_docs/kmp/AIMI_KMP_MIGRATION_BLUEPRINT.md
@@ -1,5 +1,10 @@
 # AIMI KMP/iOS — blueprint d'architecture et de migration
 
+> **2026-09-06 — architecture cible, pas l'état du code.**  
+> Snapshot vérifié : [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md).  
+> Lots suivants : [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).  
+> Les SHA ci-dessous (25 août) ne sont plus les tips.
+
 > **Statut :** document directeur consolidé, prêt pour décisions G0.  
 > **Référence auditée :** `dev_OAPSAIMI` à `06e7bc5021ca8fdd976505d1fefb03cc88681c19`.  
 > **Fondation KMP :** `kmp` à `4957c26eb85a71103e649498e7e991cb473e3098`.  

--- a/_docs/kmp/AIMI_KMP_MIGRATION_STUDY.md
+++ b/_docs/kmp/AIMI_KMP_MIGRATION_STUDY.md
@@ -13,8 +13,10 @@ Branch: `kmp-aimi-migration-study`, cut from `kmp` at `4957c26eb8`.
 Written 2026-08-25. All numbers were measured on this machine, on the branches named.
 Reference document under review: `_docs/KMP_IOS_FEASIBILITY.md` (Milos, 2026-08-05, 2115 lines).
 
-> **Mise a jour 2026-09-02, en complement de la banniere ci-dessus.** L'etat courant du portage est
-> dans [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md).
+> **Mise a jour 2026-09-06.** L'etat verifie et les lots restants sont dans
+> [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md) et
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).
+> [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md) reste le journal des lots 0–6i, pas la source de verite.
 >
 > Sur le fond, la banniere ci-dessus a raison et ce rapport avait tort sur un point qui compte :
 > l'annexe 5 a releve la signature du modele (`modelUAM.tflite`, 4 504 octets, entree `[1,18]`

--- a/_docs/kmp/AIMI_PORT_STATE.md
+++ b/_docs/kmp/AIMI_PORT_STATE.md
@@ -1,8 +1,13 @@
 # AIMI port - state of play, and where to start next
 
+> **2026-09-06 — superseded as the live snapshot.** Re-verified status and the remaining
+> lots are in [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md) and
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).
+> This file is still the best diary of lots 0–6i (how the tick and plugin landed). Do not
+> use its file counts, “2 files from commonMain”, or “330 tests” as today’s truth.
+
 Updated 2026-09-02, on `kmp-aimi-migration-study` at `1f6ca62fe8` (the second `kmp` merge).
-**Read this first.** It supersedes the stale parts of the older documents in this folder; each of
-those is marked below with what to still trust it for.
+**Was** “read this first” until 2026-09-06. Keep it for the lot history only.
 
 Tree is clean. `:app:assembleFullDebug` EXIT=0. `:plugins:aps:compileKotlinIosArm64` EXIT=0.
 `:plugins:aps:testAndroidHostTest` **330 tests, 0 failures**. `:ios:shell:checkMigratedModules` EXIT=0.

--- a/_docs/kmp/AIMI_PORT_VERIFICATION.md
+++ b/_docs/kmp/AIMI_PORT_VERIFICATION.md
@@ -1,8 +1,14 @@
 # AIMI port - verification against the `kmp-module-flip` checklist
 
-> **Note, 2026-09-02.** These checklist results were true at `c174fa6f69`. The two findings that
-> matter - the plugin is not registered, and the port is not wired into the app - are still true.
-> Current state is in [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md).
+> **Note, 2026-09-06.** This checklist is from `c174fa6f69` (2026-08-29). It is **not**
+> current. Live status: [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md).
+>
+> The two “still true” lines from 2026-09-02 are now **false**:
+> - `OpenAPSAIMIPlugin` **is** registered (`@MetroIntKey(250)` in `androidMain`).
+> - `:plugins:aps` **is** in `ios/shell` `migratedModules`.
+>
+> The plugin is still Android-only. iOS does not run AIMI. The 2026-08-29 PASS/FAIL table
+> below is left as a historical record.
 
 
 Run 2026-08-29 on `kmp-aimi-migration-study` at `c174fa6f69` (just after the `kmp` merge).

--- a/docs/kmp-migration/DELTA-remaining.md
+++ b/docs/kmp-migration/DELTA-remaining.md
@@ -1,0 +1,133 @@
+# AIMI KMP — remaining delta (prioritized lots)
+
+**Verified:** 2026-09-06  
+**Base:** `kmp-aimi-migration-study` @ `f237f2d3d0`  
+**Reference to catch:** `origin/dev_OAPSAIMI` @ `c5db5a0333`  
+**Companion:** [STATUS.md](STATUS.md)
+
+Rule: one lot is small enough to compile and (where it touches numbers) to check against a baseline. No clinical “improvements”. Medical closed-loop: move or copy behaviour, do not invent it.
+
+Do **not** start by copying `DetermineBasalAIMI2` into `:plugins:aimi-engine`. The live path is still `:plugins:aps`. The Hold stub stays Hold until a later extract lot has a real `evaluate()` with replay.
+
+---
+
+## How to read the priorities
+
+| Priority | Meaning |
+|---|---|
+| **P0** | Reference AIMI moved. Study does not have it. Dose / safety risk if we keep coding as if the trees match. |
+| **P1** | Unblocks a later move (tick toward commonMain, or honest tests). |
+| **P2** | Product / Android-only surface. Does not block iOS engine extract. |
+| **P3** | iOS / Native engine. Only after P0–P1, or in parallel on ports that do not touch the tick. |
+| **P4** | Later (CGM drivers, iOS master app, full product parity). |
+
+---
+
+## P0 — catch `dev_OAPSAIMI` (clinical delta)
+
+These landed on the reference between 2026-09-01 and 2026-09-06. They are **not** on this study tip (except the inline max-SMB ladder).
+
+Do them as **separate lots**. Each lot: copy from `origin/dev_OAPSAIMI`, adapt only KMP primitives already used in `:plugins:aps` (`aimiWallClockMs`, `AapsLock`, kotlinx time, Metro not Hilt/javax if the file has `@Inject`), compile `:plugins:aps`, then `:app:assembleFullDebug`. If the file has tests on reference, bring the tests in the same lot.
+
+| Lot | Files on reference | Gate | Notes |
+|---|---|---|---|
+| **P0.1** | `pkpd/PkPdLearnedState.kt` + its call sites in both `PkPdIntegration` copies | `:plugins:aps:compileAndroidMain` + existing PKPD tests if any can be moved | Shared learned DIA/peak. Added 2026-09-01. Confirm first whether study still has two consumers. If only one copy exists here, **say so and stop** — do not invent a second copy. |
+| **P0.2** | `ISF/DynIsfCache.kt` + `DynIsfCacheTest` | compile + that test | Study plugin only has a “cache empty” **warning**. No cache type. |
+| **P0.3** | `ISF/ObservedSensitivityMeter.kt` + test | compile + test | New 2026-09-04. Wire only the same call sites as reference. |
+| **P0.4** | `ISF/CommandedIsf.kt` + `CommandedIsfOrderTest` | compile + test | New 2026-09-06. “Read the instrument before the brake.” |
+| **P0.5** | `smb/MaxSmbLadder.kt` + the two ladder tests | compile + tests + **diff against study DB2** | Likely an extract. If study’s inline ladder already matches, extract only. If reference changed the rise rule (`f03fa321a6`), take that rule, do not mix. |
+| **P0.6** | `patient/HarmoniaCounterfactual.kt` + `quality/InsulinOriginMeter.kt` + their tests | compile + tests | Pair from `da9bc789ce`. |
+| **P0.7** | `ml/SmbTrainingRowBuffer.kt` + test | compile + test | New 2026-09-05. Android file store can stay androidMain; buffer math can be commonMain if it is pure. |
+| **P0.8** | Tick / plugin call-site sync | line-count + reason-tag review of `DetermineBasalAIMI2` (18 886 vs 19 312) and the 7 later reference commits | **Do not replace the whole file.** Study already has KMP seams (ports, `AimiJson`, TextRef). Cherry-pick the clinical hunks from those 7 commits onto the study file. |
+
+**P0.8 is the hard lot.** Treat P0.1–P0.7 as the types the hunks will need.
+
+Also bring, with P0.8 if they are in those commits: late-fat damping floor (`81e370bfbf`) and “training corpus in the support package” (`02c90656b1`).
+
+**Out of P0:** glucose re-grid `c5db5a0333` is a **loop** change, not only AIMI. Assign it only if the orchestrator wants loop parity too.
+
+---
+
+## P1 — make the Android tick honest and movable
+
+| Lot | Work | Gate | Why this size |
+|---|---|---|---|
+| **P1.1** | Fix the stale header in `ports/AimiCollaboratorPorts.kt` (“no implementation yet”) | docs / comment only | Stops the next agent from re-doing finished ports. |
+| **P1.2** | Inventory remaining `android.*` / `java.time` / `File` / `Atomic*` in `DetermineBasalAIMI2` (16 such imports today) | a checklist in this folder or a short appendix | Needed before any “move DB2 to commonMain” claim. |
+| **P1.3** | Replace `java.time` in DB2 with the same `kotlinx.datetime` aliases already used by collaborators | compile | Three sites were already known (PORT_STATE 6d). Re-measure; do not assume the old list. |
+| **P1.4** | Rewire remaining `File` / `Environment` uses onto `AimiStorage` | compile | `AimiStorageHelper` stays androidMain. |
+| **P1.5** | Drop or wrap `Context` in DB2 | compile | Same pattern as `AimiEmergencySos`: Context stays in the Android impl. |
+| **P1.6** | Port the **pure** AIMI tests from reference whose subject is already in `commonMain` (safety, smb math, recursive, trajectory, …) | `testAndroidHostTest` for each batch of ≤15 files | 259 → 11 is the biggest honesty gap. Do **not** try to land all 259 in one lot. Start with files whose production twin is already commonMain and has no Android import. |
+| **P1.7** | After P0 + P1.3–P1.5: try `DetermineBasalAIMI2` in `commonMain` again | `:plugins:aps:compileKotlinIosArm64` **and** `:app:assembleFullDebug` | Last attempts failed on JSON (now done) then on collaborators (now ported). The remaining wall is platform types in the tick itself. If it fails, paste the compiler list into STATUS; do not guess a 20-file move. |
+
+`:app:assembleFullDebug` remains the Metro-binding gate. `:plugins:aps:compileAndroidMain` alone can hide a missing `@ContributesBinding`.
+
+---
+
+## P2 — leftover product surface (does not block the engine)
+
+| Lot | Work | Decision required |
+|---|---|---|
+| **P2.1** | 17 staging View Activities | Ask before port-as-View. Prefer Compose or drop, like `AuditorReportActivity`. |
+| **P2.2** | Meal Advisor camera / Context Activity | Needs a host screen in current `:ui` navigation. |
+| **P2.3** | `AimiLoopRuntimeGuard` / `AimiSmbSimulator` / diagnostics | Confirm they are still called on reference. If dead, do not port. |
+| **P2.4** | `plugins/source` : remove `includeDagger()` by converting **7** `javax.inject` Dexcom/Libre files to Metro | `:app:assembleFullDebug` | Standing merge conflict with upstream. |
+
+---
+
+## P3 — iOS / Native engine (after P0, or ports only)
+
+`:plugins:aimi-*` already link on iOS. Filling them is **not** the same as making the Android plugin call them.
+
+| Lot | Work | Gate |
+|---|---|---|
+| **P3.1** | Keep `HoldAimiEngine`. Add one **read-only** capture: build `AimiInputSnapshot` from the Android tick inputs (no dose change) | unit test: snapshot round-trip |
+| **P3.2** | iOS `actual` for `AimiStorage` (documents directory) | `compileKotlinIosArm64` |
+| **P3.3** | iOS UAM adapter (TFLite C / chosen runtime) behind `MlUamPort` or today’s handler interface | same UAM vector → same double as Android, on a fixture |
+| **P3.4** | HealthKit behind `AimiHealthContext` / `AimiPhysioSource` | mapping table: HR, steps, **HRV RMSSD vs SDNN**, sleep, skin temp. Missing/Denied/Stale, not silent zero |
+| **P3.5** | Only after replay exists: move `evaluate()` body. Until then the Android plugin remains the only dose path | JVM + iOS simulator parity on a frozen corpus |
+
+**Do not** turn `IosClientConfig.APS` to `true`. That is an iOS **master** app (pumps, BLE heartbeat, Critical Alerts). Out of scope for these lots.
+
+---
+
+## P4 — later
+
+| Lot | Work |
+|---|---|
+| **P4.1** | Flip `:plugins:dexcom_oneplus`, `:plugins:libre3`, `:plugins:libkeks` only when a KMP host needs parse/policy. GATT/NFC stay platform. |
+| **P4.2** | iOS master (SC-C): pump drivers, `bluetooth-central` restore, APNs / Critical Alerts. Not “the next AIMI lot”. |
+| **P4.3** | Fill `:plugins:aimi-learning` / `:plugins:aimi-io` when trainers leave WorkManager. Empty `hello()` is fine until then. |
+| **P4.4** | Trio / XCFramework product wrap — only after P3.5 is real. |
+
+---
+
+## Suggested assignment order for the orchestrator
+
+1. **P0.1 → P0.7** (one agent or one agent per file; no shared edits to DB2 until P0.8).  
+2. **P0.8** (one agent, after the types exist).  
+3. **P1.1** (minutes). **P1.6** can run in parallel on commonMain subjects.  
+4. **P1.2–P1.5** then **P1.7** (tick toward commonMain).  
+5. **P3.1** can start once P0.8 is merged (capture only).  
+6. **P2** and **P4** when product asks.
+
+---
+
+## Recurring failure shapes (still true)
+
+Copy these into every lot brief:
+
+1. A class that implements a port but lacks `@ContributesBinding(AppScope::class)` compiles in `:plugins:aps` and fails only in `:app`.  
+2. `*ResId: Int` almost always became a `TextRef`.  
+3. `Atomic*` / `synchronized` → `AapsLock`; `System.currentTimeMillis()` → `aimiWallClockMs()`; `String.format` → `aimiFmtN`; `java.time` → `kotlinx.datetime`.  
+4. Duplicate top-level types (by **declaration**, not filename).  
+5. Capabilities dropped in the KMP rewrite (restore from `dev_OAPSAIMI` only after confirming they still exist there).  
+6. Do not rebase `dev_OAPSAIMI` onto this branch. Cherry-pick or copy files. Strategy S2 still stands.
+
+---
+
+## What this backlog is not
+
+- Not a new 12-milestone plan. M0–M12 in `_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md` is still the long architecture. **These lots are the next concrete work.**
+- Not permission to change SMB / basal / ISF formulae while “cleaning”.
+- Not a claim that iOS can close the loop.

--- a/docs/kmp-migration/README.md
+++ b/docs/kmp-migration/README.md
@@ -1,0 +1,10 @@
+# AIMI KMP migration — live notes
+
+Start here. Older studies live under `_docs/kmp/` and are history.
+
+| File | What it is |
+|---|---|
+| [STATUS.md](STATUS.md) | Verified snapshot (date-stamped) |
+| [DELTA-remaining.md](DELTA-remaining.md) | Prioritized remaining lots |
+
+Last verification: **2026-09-06** against `kmp-aimi-migration-study` @ `f237f2d3d0` and `origin/dev_OAPSAIMI` @ `c5db5a0333`.

--- a/docs/kmp-migration/STATUS.md
+++ b/docs/kmp-migration/STATUS.md
@@ -1,0 +1,232 @@
+# AIMI / OpenApsAIMI KMP status
+
+**Verified:** 2026-09-06  
+**This branch tip (when measured):** `kmp-aimi-migration-study` @ `f237f2d3d0` (2026-09-03)  
+**Reference tip:** `origin/dev_OAPSAIMI` @ `c5db5a0333` (2026-09-06)  
+**Merge-base:** `283a184f60` (2026-08-25, nightscout dependabot)  
+**Ahead / behind reference:** study is **875** unique commits ahead, **2746** behind.
+
+This file is the live snapshot. Older notes under `_docs/kmp/` are history. They were useful, but several claims are now false. See [DELTA-remaining.md](DELTA-remaining.md) for the next lots.
+
+**Not re-run in this session:** `:app:assembleFullDebug`, `:plugins:aps:compileKotlinIosArm64`, `:plugins:aps:testAndroidHostTest`. Last written claim of those gates being green is 2026-09-03 in `_docs/kmp/AIMI_PORT_STATE.md`. Treat that as last-known, not re-proven today.
+
+---
+
+## 1. Two-line summary
+
+The Android AIMI **plugin path is live in the KMP tree**: `OpenAPSAIMIPlugin` sits in `androidMain` and registers itself with `@MetroIntKey(250)`. A large share of AIMI math is already in `commonMain`.
+
+That is **not** “AIMI runs on iOS”. The 18 886-line tick is still Android-only. The dedicated `:plugins:aimi-engine` module is still a **Hold stub**. iOS is still a **follower** (`APS = false`). And `dev_OAPSAIMI` moved the dose path again on 2026-09-04…06.
+
+---
+
+## 2. What is already shared (verified)
+
+### 2.1 Repo-wide KMP spine
+
+| Item | Count today | Notes |
+|---|---:|---|
+| Modules with `kotlin("multiplatform")` | **34** | Includes `:plugins:aps`, `:plugins:aimi-*`, `:ios:shell`, core, database, UI, workflow |
+| `commonMain` Kotlin files (whole repo) | **2203** | Up from the Aug 25 study (~1002) |
+| `iosMain` Kotlin files (whole repo) | **75** | None of them are `openAPSAIMI` |
+| `expect` declarations (repo) | **11 files** | UI/platform (`TextRef`, `AapsLock`, map picker, …). **Zero** in AIMI |
+| iOS app | **yes** | `ios/app/AAPSClient.xcodeproj` + `ios/shell` |
+| iOS product kind | **follower** | `IosClientConfig.APS = false`, `PUMPCONTROL = false`, `PUMPDRIVERS = false`, `AAPSCLIENT = true` |
+
+`:ios:shell` `migratedModules` already lists `:plugins:aps` and all five `:plugins:aimi-*` modules.
+
+### 2.2 AIMI inside `:plugins:aps`
+
+Package: `app.aaps.plugins.aps.openAPSAIMI`.
+
+| Source set | `.kt` files | Code lines | Role |
+|---|---:|---:|---|
+| `commonMain` | **339** | **47 554** | Math, models, safety, recursive belief, most physio/advisor types |
+| `androidMain` | **109** | **50 515** | Tick, plugin, Health Connect, TFLite/ONNX, trainers, Compose screens, SOS |
+| `iosMain` | **0** | 0 | No AIMI actuals. Only `loop/IosLoopNotifier.kt` exists in this module |
+| `androidHostTest` (AIMI package) | **11** | — | Small math tests only |
+| `commonTest` (AIMI) | **0** | — | The two `commonTest` files in `:plugins:aps` are loop/TDD, not AIMI |
+
+`commonMain` AIMI has **no** `android.*` / `java.io` / `org.json` imports. JSON construction uses the local `AimiJson` / `JsonObj` shim over kotlinx serialization.
+
+Largest first-level `commonMain` packages (file count):
+
+`physio` 51 · `advisor` 34 · `pkpd` 29 · `safety` 24 · `recursive` 22 · root 20 · `patient` 19 · `wcycle` 10 · `scenario` / `basal` / `autodrive` 9 each.
+
+WCycle **is still in live `commonMain`** (10 files). Commit `a4a303eac6` only deleted **staging copies**. The commit subject is misleading.
+
+### 2.3 Dedicated AIMI KMP modules (scaffolding only)
+
+These compile for JVM + `iosArm64` + `iosSimulatorArm64` and are linked by `ios/shell`. **`:plugins:aps` does not depend on them.** Nothing in the running plugin calls them.
+
+| Module | What is actually there |
+|---|---|
+| `:plugins:aimi-contracts` | Envelope DTOs (`AimiInputSnapshot`, `AimiTickResult`, …) + `hello()` |
+| `:plugins:aimi-engine` | `AimiEngine.evaluate(...)` implemented only by `HoldAimiEngine` → always `Hold("ENGINE_NOT_EXTRACTED")` |
+| `:plugins:aimi-learning` | `hello()` |
+| `:plugins:aimi-io` | `hello()` |
+| `:plugins:aimi-testkit` | empty snapshot helpers + a hello test |
+
+So: **module graph for an extracted engine exists. The engine does not.**
+
+### 2.4 Plugin registration and ports
+
+- `OpenAPSAIMIPlugin` is in `androidMain`, Metro `@MetroIntKey(250)`, `@Inject` constructor.
+- `ApsPluginRegistrations` still lists only AMA / SMB / AutoISF (210–230). AIMI is **not** in that object. That is fine: AIMI self-registers.
+- Eight collaborator ports in `ports/AimiCollaboratorPorts.kt` **do have Android implementations** (`AuditorOrchestrator`, `TpoOrchestrator`, `AimiSmbComparator`, `AndroidAimiEmergencySos`, `ContextLLMClient`, `HealthContextRepository`, `AIMIPhysioDataRepositoryMTR`, `AndroidAimiBehaviorProfileSource`). The file header that still says “no implementation yet” is **stale**.
+- `ports/Ports.kt` (`Clock`, `PkpdPort`, `MlUamPort`, actuators) is a **planned** extract surface. The live tick does not call it.
+- Storage seam exists: `AimiStorage` (common) / `AndroidAimiStorage` + `AimiStorageHelper` (android).
+- UAM model is still `app/src/main/assets/modelUAM.tflite`. `AimiModelHandler` is androidMain + TensorFlow Lite.
+
+### 2.5 CGM plugins that AIMI cares about
+
+| Module | KMP? | Files | iOS |
+|---|---|---:|---|
+| `:plugins:source` | **yes** | Dexcom ONE+ / Libre 3 **Activities stay androidMain** (29 android files vs 2 common countdown composables) | no drivers |
+| `:plugins:dexcom_oneplus` | **no** (`com.android.library`) | 72 kt | no |
+| `:plugins:libre3` | **no** | 107 kt | no |
+| `:plugins:libkeks` | **no** | 24 | no |
+
+`:plugins:source` still has Metro `includeDagger()` for **7** `javax.inject` leftovers (PORT_STATE said 14; that number is now wrong).
+
+---
+
+## 3. What is partial
+
+| Area | Shared today | Still Android | iOS |
+|---|---|---|---|
+| Dose tick `DetermineBasalaimiSMB2` | many callees in commonMain | **the 18 886-line class itself** (`Context`, `File`, `java.time`, `Atomic*`) | not compiled |
+| Plugin shell | some prefs/keys | `OpenAPSAIMIPlugin` 2 337 lines | not registered; `APS=false` |
+| UAM / TFLite | schema + `aimiNeuralNetwork` math in commonMain | `AimiModelHandler`, model asset, LiteRT | no adapter |
+| On-device trainers | some math | WorkManager workers, file stores | no |
+| Health / steps | snapshot types + ports | Health Connect repo/workers | no HealthKit |
+| Auditor / TPO | models, some rules | orchestrators, notifications, LLM | chip port is common; impl android |
+| Meal vision | models / prompt parse in commonMain | HTTP providers, Activities parked | no |
+| Compose Control Center / PKPD / Hormonitor | some types | screens in androidMain | no |
+| Extracted `evaluate()` | interface + Hold stub | unused | unused |
+
+**A `commonMain` compile of `:plugins:aps` is not “AIMI runs on Native”.** iOS compiles the shared callees and `IosLoopNotifier`. It does not compile the tick.
+
+---
+
+## 4. What remains Android-only or parked
+
+### 4.1 Live androidMain (must stay or be seamed)
+
+The tick and the plugin. Health Connect. TFLite / ONNX. Autodrive / basal trainers and workers. SOS SMS. Compose screens. File-backed history readers. Phone step services.
+
+### 4.2 Staging leftovers (17 Kotlin files)
+
+`_docs/kmp/staging/openAPSAIMI-android-wip/` is **not** on any source set. Remaining files are legacy View Activities and a few support types:
+
+- `AimiModeSettingsActivity`, `AimiProfileAdvisorActivity`
+- `MealAdvisorActivity`, `MealAdvisorCameraActivity`
+- `ContextActivity` + ViewModel / adapter / gauge binder
+- Health Connect / SOS permission Activities
+- `AimiSmbSimulator`, `AimiDiagnosticsManager`, `AimiLoopRuntimeGuard`
+- `AIMICompositeStepsProviderMTR`, `AIMIHealthConnectStepsProviderMTR`
+- `StateTransitionManager`, `AimiMemberInjectors`
+
+These do **not** block the plugin from compiling. Porting a View Activity as-is is often the wrong call (see Auditor trampoline → `EventShowDialog` + Overview chip).
+
+---
+
+## 5. Diff vs `dev_OAPSAIMI` (plugin area)
+
+Reference still uses `plugins/aps/src/main/...` (plain Android). Study split that tree into `commonMain` / `androidMain`.
+
+By **basename**:
+
+| | count |
+|---|---:|
+| Names on both sides | **421** |
+| Only on reference | **28** |
+| Only on study | **37** (KMP seams, ports, Android adapters, extra host tests) |
+
+### 5.1 Only on reference — new clinical / extract files (high priority)
+
+Added on reference **after or around** the study tip. Study’s `DetermineBasalAIMI2.kt` does **not** mention these names (except the inline max-SMB ladder tags):
+
+| File | First landed on reference | Why it matters |
+|---|---|---|
+| `ISF/CommandedIsf.kt` | 2026-09-06 `db21308e6c` | Read each instrument before the brake it measures |
+| `ISF/ObservedSensitivityMeter.kt` | 2026-09-04 `eb84e078f5` | Passive observed sensitivity |
+| `ISF/DynIsfCache.kt` | 2026-09-03 `dd9979ca4d` | Fresh ISF cache (no `class DynIsfCache` on study) |
+| `patient/HarmoniaCounterfactual.kt` | 2026-09-05 `da9bc789ce` | Cost of refusing Harmonia |
+| `quality/InsulinOriginMeter.kt` | 2026-09-05 `da9bc789ce` | Who actually decided the insulin |
+| `smb/MaxSmbLadder.kt` | 2026-09-05 `f03fa321a6` | Extract of the maxSMB ladder; **logic still inline** in study DB2 (`lastMaxSmbLadderBranch`) |
+| `ml/SmbTrainingRowBuffer.kt` | 2026-09-05 `7f8aa0109c` | SMB training rows / outcomes |
+| `pkpd/PkPdLearnedState.kt` | 2026-09-01 `0761e9c00a` | Shared learned DIA/peak between the two `PkPdIntegration` copies |
+
+`MaxSmbLadder` may be an extract of behaviour study already has. The others look like **new reference behaviour** that study does not have under those names.
+
+### 5.2 Only on reference — Activities / DI still parked on study
+
+The 17 staging files above, plus `AuditorReportActivity` / `AuditorStatusIndicator` (already replaced on study by the Overview chip), `AIMIStepsProviderModuleMTR` (Hilt module; study is Metro), and `AIMI_ORCHESTRATION_ROADMAP.md`.
+
+### 5.3 Tick / plugin size drift
+
+| File | Study | Reference | Δ (ref − study) |
+|---|---:|---:|---:|
+| `DetermineBasalAIMI2.kt` | 18 886 | 19 312 | **+426** |
+| `OpenAPSAIMIPlugin.kt` | 2 337 | 2 333 | −4 |
+
+Sample of overlapping math files (`SmbQuantizer`, `SafetyNet`, `RecursiveBeliefEngine`) is 0-line drift. `AdaptivePkPdEstimator` is +2 on reference. **This is not a full numeric-literal audit.** Overlapping files were not re-diffed one by one today.
+
+Recent reference AIMI commits **after** study tip `f237f2d3d0` (2026-09-03 23:39):
+
+1. `eb84e078f5` observed sensitivity  
+2. `81e370bfbf` late-fat damping floor  
+3. `f03fa321a6` confirmed-rise SMB ceiling  
+4. `da9bc789ce` decision owner + Harmonia counterfactual  
+5. `7f8aa0109c` SMB training row buffer  
+6. `db21308e6c` instrument-before-brake  
+7. `02c90656b1` training corpus / running profile in support package  
+8. later same day: `c5db5a0333` loop glucose re-grid (not only AIMI)
+
+### 5.4 Tests
+
+| | Reference `src/test/.../openAPSAIMI` | Study AIMI `androidHostTest` |
+|---|---:|---:|
+| Files | **259** | **11** |
+
+Almost the whole AIMI test corpus is **not** on the KMP study branch. `:plugins:aps` has 44 host-test files in total (SMB/AMA/AutoISF + 11 AIMI). PORT_STATE’s “330 tests” was the **whole module**, last claimed 2026-09-03, **not re-counted as methods today**.
+
+---
+
+## 6. Corrections to older docs
+
+| Old claim | Reality 2026-09-06 |
+|---|---|
+| “DetermineBasalAIMI2 is 2 files from `commonMain`” (`AIMI_PORT_STATE` §1) | The tick **compiles in `androidMain`**. It is not in `commonMain`. Remaining work is seams + JSON already done, not “two files”. |
+| “Plugin is not registered” (`AIMI_PORT_VERIFICATION`) | **False.** `@MetroIntKey(250)` in `androidMain`. |
+| “AIMI commonMain 356 / androidMain 100” (PORT_STATE 6h) | **339 / 109** for the `openAPSAIMI` package. Counting method in the old note may have included extras. |
+| “`aimi-engine` is the place the tick lives” (blueprint / backlog M2) | Modules exist. **Evaluate is Hold.** Live tick is still `:plugins:aps`. |
+| “Room / Dagger untouched” (Aug 25 study) | Already retired. Database modules are KMP. Metro is the DI. |
+| “No iOS app” (Aug 25 study) | Retired. Follower app exists. Master on iPhone does not. |
+| Freeze tag `aimi-baseline-2026-08-26` = `1ae418e106` | Tag **not present** in this clone. Do not treat that SHA as today’s reference. Today’s reference tip is `c5db5a0333`. |
+| WCycle removed | Staging copies removed. **Live WCycle sources remain.** |
+
+---
+
+## 7. Uncertainties (do not guess)
+
+1. **Build gates were not re-run today.** Last written green assemble / iOS klib / 330 host tests: 2026-09-03.
+2. **Numeric fidelity** of the 421 overlapping files vs current `dev_OAPSAIMI` was not re-diffed. Older lots used a literal-multiset check; that check is stale against this week’s reference.
+3. **`MaxSmbLadder`:** extract vs behaviour change. Study still has ladder tags inside DB2. Compare before porting, do not paste blindly.
+4. **`PkPdLearnedState`:** reference added it so two `PkPdIntegration` copies share learned DIA/peak. Study has one `PkPdIntegration.kt` in androidMain. Whether the two-copy bug exists here was **not** proven.
+5. **`HarmoniaDecisionEngine`:** no file of that name on either tip. Tests on reference use that name; implementation is `HarmoniaHarmonizer` / types in `HarmoniaDecision.kt` / logic inside DB2.
+6. **Clinical behaviour:** this study branch and `dev_OAPSAIMI` are **not** the same AIMI. Do not ship the KMP plugin as “current AIMI” until the §5.1 files and the 426-line tick delta are reconciled — or an explicit decision says the freeze stays 2026-09-03.
+
+---
+
+## 8. What “done” would mean (unchanged goal)
+
+Android + iOS from **one** `commonMain` engine, no clinical rewrite.
+
+Today:
+
+- Android plugin path: **reachable in a KMP app graph** (last-known assemble green).
+- Shared math: **large, real, not extracted**.
+- iOS: **shared spine + follower UI**. No AIMI tick. No pump. No HealthKit. No TFLite.
+- Extracted engine API: **stub**.

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ports/AimiCollaboratorPorts.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ports/AimiCollaboratorPorts.kt
@@ -33,8 +33,10 @@ import app.aaps.plugins.aps.openAPSAIMI.safety.CorrectionAggressionGate
  * pulls in `SmsManager` and `LocationManager`. The loop needs one or two members of each. Naming just
  * those members here means the implementations can stay on Android.
  *
- * These have no implementation yet. The classes that will implement them are still outside every
- * source set; they get their supertype when they move into `androidMain`.
+ * Each port has exactly one Android implementation in `androidMain` (AuditorOrchestrator,
+ * TpoOrchestrator, AimiSmbComparator, AndroidAimiEmergencySos, ContextLLMClient,
+ * HealthContextRepository, AIMIPhysioDataRepositoryMTR, AndroidAimiBehaviorProfileSource).
+ * iOS has no implementations yet.
  */
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR — résumé

Audit du delta **réel** pour porter AIMI / OpenApsAIMI vers KMP (Android + iOS), re-mesuré le **2026-09-06** sur `kmp-aimi-migration-study` @ `f237f2d3d0` contre `origin/dev_OAPSAIMI` @ `c5db5a0333`.

**Déjà là**
- 34 modules KMP ; 2203 fichiers `commonMain` ; app iOS suiveuse réelle (`APS = false`).
- AIMI dans `:plugins:aps` : **339** fichiers / 47,5 kLOC en `commonMain`, **109** / 50,5 kLOC en `androidMain`.
- Le plugin Android est **enregistré** (`@MetroIntKey(250)`). Huit ports collaborateurs ont déjà une implémentation Android.
- Les modules `:plugins:aimi-*` compilent JVM + iOS, mais `evaluate()` est encore un **Hold**.

**Partiel**
- Le tick `DetermineBasalaimiSMB2` (18 886 lignes) reste Android (`Context`, `File`, `java.time`).
- `commonMain` compile pour iOS **n’est pas** « AIMI tourne sur Native ».
- Tests AIMI : **11** sur l’étude vs **259** sur la référence.

**Reste (priorité)**
1. **P0** — rattraper `dev_OAPSAIMI` (7 commits AIMI du 4–6 sept. : ISF, Harmonia, ladder SMB, buffer d’entraînement, PKPD partagé). Le tick a **+426** lignes sur la référence.
2. **P1** — seams du tick (`java.time` / `File` / `Context`) puis nouvel essai `commonMain` ; porter les tests purs par lots de ≤15.
3. **P3** — capture `AimiInputSnapshot` sans changer la dose ; adaptateurs iOS (stockage, UAM, HealthKit) plus tard.
4. **P2 / P4** — Activities View restantes, CGM Android-only, master iOS : plus tard.

**Pas fait dans ce PR** : pas de changement clinique. Un commentaire périmé dans `AimiCollaboratorPorts` a été corrigé.

Les anciens fichiers `_docs/kmp/*` pointent maintenant vers `docs/kmp-migration/`.

## EN — summary

Re-verified remaining AIMI / OpenApsAIMI KMP delta on **2026-09-06**. Study tip `f237f2d3d0` vs reference `c5db5a0333`. Merge-base is 2026-08-25. Study is 875 commits ahead and **2746 behind** the reference.

**Already shared**
- 34 KMP modules; iOS follower app exists; AIMI math is largely in `:plugins:aps` `commonMain` (339 files).
- Android plugin path is live (`OpenAPSAIMIPlugin` @ 250). Collaborator ports are implemented on Android.
- `:plugins:aimi-engine` is a Hold stub and is **not** called by the plugin.

**Partial / remaining**
- The 18 886-line tick is still `androidMain`. Zero AIMI `iosMain`.
- Reference added clinical files this week that study does not have (`CommandedIsf`, `ObservedSensitivityMeter`, `DynIsfCache`, `HarmoniaCounterfactual`, `InsulinOriginMeter`, `SmbTrainingRowBuffer`, `PkPdLearnedState`). `MaxSmbLadder` may already be inline in study’s tick — compare before copying.
- AIMI host tests: 11 vs 259.

**Next lots for the orchestrator** (see `docs/kmp-migration/DELTA-remaining.md`)
1. P0.1–P0.7: one file (and its test) per lot from `dev_OAPSAIMI`.
2. P0.8: cherry-pick clinical hunks onto study’s tick — **do not replace the whole file**.
3. P1.6: port pure commonMain tests in batches of ≤15.
4. P1.3–P1.7: platform seams, then retry moving the tick to `commonMain`.
5. P3.1: read-only `AimiInputSnapshot` capture. Do **not** set `IosClientConfig.APS = true`.

**Uncertainties**
- `:app:assembleFullDebug` / iOS klib / the old “330 tests” claim were **not** re-run in this session (last written green: 2026-09-03).
- Overlapping files were not re-diffed one-by-one for numeric fidelity against this week’s reference.

## Files

- `docs/kmp-migration/STATUS.md`
- `docs/kmp-migration/DELTA-remaining.md`
- Banners on stale `_docs/kmp/*`
- Comment-only fix in `AimiCollaboratorPorts.kt`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d891cda6-e7d1-4b05-875d-09e005ccd5fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d891cda6-e7d1-4b05-875d-09e005ccd5fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

