### PR TITLE
P0.1 — PkPdLearnedState: shared learned DIA/peak on the KMP study branch

### DIFF
--- a/core/keys/src/commonMain/kotlin/app/aaps/core/keys/LongNonKey.kt
+++ b/core/keys/src/commonMain/kotlin/app/aaps/core/keys/LongNonKey.kt
@@ -22,5 +22,12 @@ enum class LongNonKey(
     // hasn't republished the roster yet). Not exported — re-pair regenerates this.
     NsClientControlPairedAt("nsclient_control_paired_at", 0L, exportable = false),
     LastVacuumRun("last_vacuum_run", 0L),
+
+    // Bumped whenever the PK/PD learned state (aimi_pkpd_state_dia_h / _peak_min) is written from
+    // outside the loop (reset button, insulin preset). Long-lived PkPdIntegration instances cache
+    // that state in memory; they compare this counter on each tick to know they must re-seed from
+    // prefs. Any change is a signal, up or down. So an overflow or a restore from backup are
+    // both safe.
+    OApsAIMIPkpdLearnedStateGeneration("aimi_pkpd_learned_state_generation", 0L),
 }
 

--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/compose/PkpdPresetProfilesLearnedGenerationTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/compose/PkpdPresetProfilesLearnedGenerationTest.kt
@@ -1,0 +1,67 @@
+package app.aaps.plugins.aps.openAPSAIMI.compose
+
+import app.aaps.core.keys.DoubleKey
+import app.aaps.core.keys.LongNonKey
+import app.aaps.core.keys.interfaces.DoubleNonPreferenceKey
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.shared.tests.TestBase
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Generation-bump cases from reference `PkpdPresetProfilesTest` (`origin/dev_OAPSAIMI` @ `c5db5a0333`).
+ * Adapted to study's mockito host-test stack.
+ */
+class PkpdPresetProfilesLearnedGenerationTest : TestBase() {
+
+    private val stored = mutableMapOf<DoubleKey, Double>()
+
+    private fun preferences(): Preferences {
+        val preferences = mock<Preferences>()
+        whenever(preferences.put(any<DoubleNonPreferenceKey>(), any())).thenAnswer { invocation ->
+            val key = invocation.getArgument<DoubleNonPreferenceKey>(0)
+            if (key is DoubleKey) stored[key] = invocation.getArgument(1)
+            null
+        }
+        whenever(preferences.get(any<DoubleKey>())).thenAnswer { invocation ->
+            val key = invocation.getArgument<DoubleKey>(0)
+            stored[key] ?: key.defaultValue
+        }
+        return preferences
+    }
+
+    @Test
+    fun resetPkpdLearnedStateToInitial_bumps_the_generation() {
+        stored.clear()
+        val preferences = preferences()
+        resetPkpdLearnedStateToInitial(preferences)
+        verify(preferences, times(1)).inc(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
+    }
+
+    @Test
+    fun reclampPkpdLearnedStateToBounds_bumps_the_generation() {
+        stored.clear()
+        val preferences = preferences()
+        reclampPkpdLearnedStateToBounds(preferences)
+        verify(preferences, times(1)).inc(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
+    }
+
+    @Test
+    fun applyPkpdInsulinPreset_bumps_the_generation_once() {
+        for (preset in listOf(PkpdInsulinPreset.ULTRA_FAST, PkpdInsulinPreset.RAPID, PkpdInsulinPreset.STANDARD)) {
+            stored.clear()
+            val preferences = preferences()
+            applyPkpdInsulinPreset(preferences, preset)
+            verify(preferences, times(1)).inc(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
+        }
+        stored.clear()
+        val customPreferences = preferences()
+        applyPkpdInsulinPreset(customPreferences, PkpdInsulinPreset.CUSTOM)
+        verify(customPreferences, never()).inc(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
+    }
+}

--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedStateIntegrationTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedStateIntegrationTest.kt
@@ -1,0 +1,436 @@
+package app.aaps.plugins.aps.openAPSAIMI.pkpd
+
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.keys.DoubleKey
+import app.aaps.core.keys.LongNonKey
+import app.aaps.core.keys.interfaces.DoubleNonPreferenceKey
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.plugins.aps.openAPSAIMI.compose.AimiAutonomyMode
+import app.aaps.plugins.aps.openAPSAIMI.compose.AimiBehaviorRuntimeProfile
+import app.aaps.plugins.aps.openAPSAIMI.ports.AimiBehaviorProfileSource
+import app.aaps.shared.tests.TestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+/**
+ * Matching tests for [PkPdLearnedState] from `origin/dev_OAPSAIMI` @ `c5db5a0333`
+ * (`PkPdIntegrationTest` shared-state / generation cases).
+ *
+ * Adapted to study: mockito instead of mockk, and the study constructor also takes
+ * [AimiBehaviorProfileSource]. Clinical tick inputs are copied from the reference tests.
+ */
+class PkPdLearnedStateIntegrationTest : TestBase() {
+
+    @Mock private lateinit var preferences: Preferences
+
+    private val behaviorProfileSource = object : AimiBehaviorProfileSource {
+        override fun read(preferences: Preferences) = AimiBehaviorRuntimeProfile(
+            protectionLevel = 2,
+            mealCaptureLevel = 2,
+            stabilityLevel = 2,
+            physioLevel = 1,
+            autonomyMode = AimiAutonomyMode.AssistedApplication,
+        )
+    }
+
+    private lateinit var integration: PkPdIntegration
+
+    @BeforeEach
+    fun setUp() {
+        integration = engine(preferences)
+    }
+
+    @Test
+    fun clearLearned_drops_values_but_keeps_generation() {
+        val state = PkPdLearnedState()
+        state.estimator = AdaptivePkPdEstimator()
+        state.lastBounds = PkPdBounds()
+        state.lastLearningCfg = PkPdLearningConfig()
+        state.lastPersisted = PkPdParams(6.0, 55.0)
+        state.seenLearnedStateGeneration = 3L
+
+        state.clearLearned()
+
+        assertEquals(null, state.estimator)
+        assertEquals(null, state.lastBounds)
+        assertEquals(null, state.lastLearningCfg)
+        assertEquals(null, state.lastPersisted)
+        assertEquals(3L, state.seenLearnedStateGeneration)
+    }
+
+    @Test
+    fun reset_written_between_two_ticks_reseeds_the_learner_from_prefs() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+
+        tick(1)
+        assertEquals(6.0, learnedDiaHrs(), 0.1)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(1L)
+        tick(2)
+
+        assertEquals(7.5, learnedDiaHrs(), 0.1)
+    }
+
+    @Test
+    fun unchanged_generation_keeps_the_in_memory_learner() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+
+        repeat(4) { tick(it + 1L) }
+        assertEquals(6.0, learnedDiaHrs(), 0.1)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        repeat(4) { tick(it + 5L) }
+
+        assertEquals(6.0, learnedDiaHrs(), 0.1)
+    }
+
+    @Test
+    fun first_tick_adopts_the_stored_generation_without_resetting() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(42L)
+        IsfTddProvider.set(50.0)
+
+        tick(1)
+        assertEquals(6.0, learnedDiaHrs(), 0.1)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        tick(2)
+
+        assertEquals(6.0, learnedDiaHrs(), 0.1)
+    }
+
+    @Test
+    fun reseeded_params_are_clamped_into_current_bounds() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        tick(1)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(99.0)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(1L)
+        tick(2)
+
+        assertEquals(8.0, learnedDiaHrs(), 1e-9)
+    }
+
+    @Test
+    fun two_integrations_sharing_prefs_both_reseed() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val first = engine(preferences)
+        val second = engine(preferences)
+        tick(1, first)
+        tick(1, second)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(1L)
+        tick(2, first)
+        tick(2, second)
+
+        assertEquals(7.5, learnedDiaHrs(first), 0.1)
+        assertEquals(7.5, learnedDiaHrs(second), 0.1)
+    }
+
+    @Test
+    fun generation_change_also_fires_on_a_decreasing_counter() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(5L)
+        IsfTddProvider.set(50.0)
+        tick(1)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(2L)
+        tick(2)
+
+        assertEquals(7.5, learnedDiaHrs(), 0.1)
+    }
+
+    @Test
+    fun preset_change_in_the_same_tick_does_not_overwrite_the_external_reset() {
+        val stored = mutableMapOf<DoubleKey, Double>()
+        val stateful = statefulPreferences(stored)
+        whenever(stateful.get(BooleanKey.OApsAIMIPkpdEnabled)).thenReturn(true)
+        whenever(stateful.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        storePkpdDefaults(stored)
+        IsfTddProvider.set(50.0)
+        val engine = engine(stateful)
+
+        tick(1, engine)
+        assertEquals(6.0, learnedDiaHrs(engine), 1e-9)
+
+        stored[DoubleKey.OApsAIMIPkpdBoundsDiaMaxH] = 5.5
+        stored[DoubleKey.OApsAIMIPkpdStateDiaH] = 4.5
+        whenever(stateful.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(1L)
+        tick(2, engine)
+
+        assertEquals(4.5, learnedDiaHrs(engine), 1e-9)
+        assertEquals(4.5, stored.getValue(DoubleKey.OApsAIMIPkpdStateDiaH), 1e-9)
+    }
+
+    @Test
+    fun read_only_consumer_sees_the_state_learned_by_the_other_consumer() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val reader = engine(preferences, shared)
+        val learner = engine(preferences, shared)
+
+        learningTick(1, reader, allowLearning = false)
+        assertEquals(6.0, learnedDiaHrs(reader), 1e-9)
+
+        for (index in 2L..40L) learningTick(index, learner)
+        val learned = learnedDiaHrs(learner)
+        assertTrue(learned < 6.0 - 1e-6, "the learner did not move the DIA: $learned")
+
+        val readerRuntime = learningTick(41, reader, allowLearning = false)
+        assertNotNull(readerRuntime)
+        assertEquals(learned, readerRuntime!!.params.diaHrs, 1e-9)
+    }
+
+    @Test
+    fun bounds_change_does_not_persist_a_stale_value_from_the_read_only_consumer() {
+        val stored = mutableMapOf<DoubleKey, Double>()
+        val stateful = statefulPreferences(stored)
+        whenever(stateful.get(BooleanKey.OApsAIMIPkpdEnabled)).thenReturn(true)
+        whenever(stateful.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        storePkpdDefaults(stored)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val reader = engine(stateful, shared)
+        val learner = engine(stateful, shared)
+
+        learningTick(1, reader, allowLearning = false)
+        for (index in 2L..201L) learningTick(index, learner)
+        val learned = learnedDiaHrs(learner)
+        assertTrue(learned < 5.9, "the learner did not move the DIA far enough: $learned")
+
+        stored[DoubleKey.OApsAIMIPkpdBoundsDiaMaxH] = 5.9
+        learningTick(202, reader, allowLearning = false)
+
+        assertEquals(learned, stored.getValue(DoubleKey.OApsAIMIPkpdStateDiaH), 0.01)
+    }
+
+    @Test
+    fun read_only_consumer_never_moves_the_shared_learned_state() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val reader = engine(preferences, shared)
+        val learner = engine(preferences, shared)
+
+        learningTick(1, reader, allowLearning = false)
+        for (index in 2L..40L) learningTick(index, learner)
+        val learned = learnedDiaHrs(learner)
+        val acceptedUpdates = acceptedUpdateCount(learner)
+        assertTrue(acceptedUpdates > 0L, "the learner accepted no update")
+
+        for (index in 41L..60L) learningTick(index, reader, allowLearning = false)
+
+        assertEquals(learned, learnedDiaHrs(learner), 1e-9)
+        assertEquals(acceptedUpdates, acceptedUpdateCount(learner))
+    }
+
+    @Test
+    fun shared_learned_state_keeps_isf_fusion_slew_per_consumer() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val reader = engine(preferences, shared)
+        val learner = engine(preferences, shared)
+
+        for (index in 1L..3L) isfTick(index, learner, profileIsf = 50.0)
+
+        val learnerIsf = isfTick(4, learner, profileIsf = 10.0)?.fusedIsf
+        val readerIsf = isfTick(4, reader, profileIsf = 10.0, allowLearning = false)?.fusedIsf
+
+        assertNotNull(learnerIsf)
+        assertNotNull(readerIsf)
+        assertTrue(learnerIsf!! > readerIsf!! + 5.0, "learner=$learnerIsf reader=$readerIsf")
+    }
+
+    @Test
+    fun external_reset_reaches_both_consumers_through_the_shared_state() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val first = engine(preferences, shared)
+        val second = engine(preferences, shared)
+        tick(1, first)
+        tick(1, second)
+
+        whenever(preferences.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(7.5)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(1L)
+        tick(2, first)
+        tick(2, second)
+
+        assertEquals(7.5, learnedDiaHrs(first), 0.1)
+        assertEquals(7.5, learnedDiaHrs(second), 0.1)
+    }
+
+    @Test
+    fun recent_bolus_samples_stay_private_to_each_consumer() {
+        stubEnabled()
+        stubPkpdDefaults(preferences)
+        whenever(preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)).thenReturn(0L)
+        IsfTddProvider.set(50.0)
+        val shared = PkPdLearnedState()
+        val reader = engine(preferences, shared)
+        val learner = engine(preferences, shared)
+        learner.setRecentBolusSamples(listOf(PkpdBolusSample(ageMin = 20.0, units = 2.0)))
+
+        learningTick(1, reader, allowLearning = false)
+
+        assertTrue(learner.reconstructedIobUnits() > 0.0)
+        assertEquals(0.0, reader.reconstructedIobUnits(), 1e-9)
+    }
+
+    private fun engine(
+        prefs: Preferences,
+        state: PkPdLearnedState = PkPdLearnedState(),
+    ) = PkPdIntegration(prefs, state, behaviorProfileSource)
+
+    private fun stubEnabled() {
+        whenever(preferences.get(BooleanKey.OApsAIMIPkpdEnabled)).thenReturn(true)
+    }
+
+    private fun stubPkpdDefaults(target: Preferences) {
+        whenever(target.get(DoubleKey.OApsAIMIPkpdStateDiaH)).thenReturn(6.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdStatePeakMin)).thenReturn(55.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdBoundsDiaMinH)).thenReturn(5.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdBoundsDiaMaxH)).thenReturn(8.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdBoundsPeakMinMin)).thenReturn(35.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdBoundsPeakMinMax)).thenReturn(95.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdMaxDiaChangePerDayH)).thenReturn(0.5)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdMaxPeakChangePerDayMin)).thenReturn(5.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdAnchorDiaH)).thenReturn(4.0)
+        whenever(target.get(DoubleKey.OApsAIMIPkpdAnchorPeakMin)).thenReturn(55.0)
+        whenever(target.get(DoubleKey.OApsAIMIIsfFusionMinFactor)).thenReturn(0.7)
+        whenever(target.get(DoubleKey.OApsAIMIIsfFusionMaxFactor)).thenReturn(1.5)
+        whenever(target.get(DoubleKey.OApsAIMIIsfFusionMaxChangePerTick)).thenReturn(0.2)
+        whenever(target.get(DoubleKey.OApsAIMISmbTailThreshold)).thenReturn(1.0)
+        whenever(target.get(DoubleKey.OApsAIMISmbTailDamping)).thenReturn(0.85)
+        whenever(target.get(DoubleKey.OApsAIMISmbExerciseDamping)).thenReturn(0.8)
+        whenever(target.get(DoubleKey.OApsAIMISmbLateFatDamping)).thenReturn(0.8)
+    }
+
+    private fun storePkpdDefaults(stored: MutableMap<DoubleKey, Double>) {
+        stored[DoubleKey.OApsAIMIPkpdStateDiaH] = 6.0
+        stored[DoubleKey.OApsAIMIPkpdStatePeakMin] = 55.0
+        stored[DoubleKey.OApsAIMIPkpdBoundsDiaMinH] = 4.0
+        stored[DoubleKey.OApsAIMIPkpdBoundsDiaMaxH] = 8.0
+        stored[DoubleKey.OApsAIMIPkpdBoundsPeakMinMin] = 35.0
+        stored[DoubleKey.OApsAIMIPkpdBoundsPeakMinMax] = 95.0
+        stored[DoubleKey.OApsAIMIPkpdMaxDiaChangePerDayH] = 0.5
+        stored[DoubleKey.OApsAIMIPkpdMaxPeakChangePerDayMin] = 5.0
+        stored[DoubleKey.OApsAIMIPkpdAnchorDiaH] = 4.0
+        stored[DoubleKey.OApsAIMIPkpdAnchorPeakMin] = 55.0
+        stored[DoubleKey.OApsAIMIIsfFusionMinFactor] = 0.7
+        stored[DoubleKey.OApsAIMIIsfFusionMaxFactor] = 1.5
+        stored[DoubleKey.OApsAIMIIsfFusionMaxChangePerTick] = 0.2
+        stored[DoubleKey.OApsAIMISmbTailThreshold] = 1.0
+        stored[DoubleKey.OApsAIMISmbTailDamping] = 0.85
+        stored[DoubleKey.OApsAIMISmbExerciseDamping] = 0.8
+        stored[DoubleKey.OApsAIMISmbLateFatDamping] = 0.8
+    }
+
+    private fun statefulPreferences(stored: MutableMap<DoubleKey, Double>): Preferences {
+        val prefs = org.mockito.kotlin.mock<Preferences>()
+        whenever(prefs.put(any<DoubleNonPreferenceKey>(), any())).thenAnswer { invocation ->
+            val key = invocation.getArgument<DoubleNonPreferenceKey>(0)
+            if (key is DoubleKey) stored[key] = invocation.getArgument(1)
+            null
+        }
+        whenever(prefs.get(any<DoubleKey>())).thenAnswer { invocation ->
+            val key = invocation.getArgument<DoubleKey>(0)
+            stored[key] ?: key.defaultValue
+        }
+        return prefs
+    }
+
+    private fun tick(index: Long, target: PkPdIntegration = integration) {
+        target.computeRuntime(
+            epochMillis = index * 5L * 60L * 1000L,
+            bg = 120.0,
+            deltaMgDlPer5 = 0.0,
+            iobU = 0.1,
+            carbsActiveG = 0.0,
+            windowMin = 60,
+            exerciseFlag = false,
+            profileIsf = 50.0,
+            tdd24h = 40.0,
+        )
+    }
+
+    private fun learningTick(
+        index: Long,
+        target: PkPdIntegration,
+        allowLearning: Boolean = true,
+    ) = target.computeRuntime(
+        epochMillis = index * 5L * 60L * 1000L,
+        bg = 120.0,
+        deltaMgDlPer5 = -0.5,
+        iobU = 2.5,
+        carbsActiveG = 0.0,
+        windowMin = 60,
+        exerciseFlag = false,
+        profileIsf = 50.0,
+        tdd24h = 40.0,
+        allowLearning = allowLearning,
+    )
+
+    private fun isfTick(
+        index: Long,
+        target: PkPdIntegration,
+        profileIsf: Double,
+        allowLearning: Boolean = true,
+    ) = target.computeRuntime(
+        epochMillis = index * 5L * 60L * 1000L,
+        bg = 120.0,
+        deltaMgDlPer5 = -0.5,
+        iobU = 2.5,
+        carbsActiveG = 0.0,
+        windowMin = 60,
+        exerciseFlag = false,
+        profileIsf = profileIsf,
+        tdd24h = 40.0,
+        allowLearning = allowLearning,
+    )
+
+    private fun acceptedUpdateCount(target: PkPdIntegration): Long {
+        val snapshot = target.learningStatusSnapshot()
+        assertNotNull(snapshot, "the estimator was not built")
+        return snapshot!!.acceptedUpdateCount
+    }
+
+    private fun learnedDiaHrs(target: PkPdIntegration = integration): Double {
+        val snapshot = target.learningStatusSnapshot()
+        assertNotNull(snapshot, "the estimator was not built")
+        return snapshot!!.params.diaHrs
+    }
+}

--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedStateIntegrationTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedStateIntegrationTest.kt
@@ -19,8 +19,15 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 
 /**
- * Matching tests for [PkPdLearnedState] from `origin/dev_OAPSAIMI` @ `c5db5a0333`
- * (`PkPdIntegrationTest` shared-state / generation cases).
+ * Matching tests for [PkPdLearnedState] from `origin/dev_OAPSAIMI` @ `0761e9c00a`
+ * (`PkPdIntegrationTest`).
+ *
+ * The two regressions that fail without the shared holder:
+ * - [read_only_consumer_sees_the_state_learned_by_the_other_consumer]
+ * - [bounds_change_does_not_persist_a_stale_value_from_the_read_only_consumer]
+ *
+ * Plus the four 0761e9c guard tests (read-only does not learn; ISF slew per consumer;
+ * external reset reaches both; bolus samples stay private).
  *
  * Adapted to study: mockito instead of mockk, and the study constructor also takes
  * [AimiBehaviorProfileSource]. Clinical tick inputs are copied from the reference tests.

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -71,6 +71,7 @@ import app.aaps.plugins.aps.openAPSAIMI.model.PumpCaps
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdCsvLogger
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.MealAggressionContext
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdIntegration
+import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdLearnedState
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkpdBolusSample
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdLogRow
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.IsfTddProvider
@@ -1253,6 +1254,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
     private val profileUtil: ProfileUtil,
     private val fabricPrivacy: FabricPrivacy,
     private val preferences: Preferences,
+    private val pkPdLearnedState: PkPdLearnedState,
     private val gestationalAutopilot: app.aaps.plugins.aps.openAPSAIMI.advisor.gestation.GestationalAutopilot,
     private val auditorOrchestrator: AimiAuditor,
     private val behaviorProfileSource: AimiBehaviorProfileSource,
@@ -10334,7 +10336,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             .getOrNull()
     }
     private var csvPrimaryStorageDeniedLogged = false
-    private val pkpdIntegration = PkPdIntegration(preferences, behaviorProfileSource)
+    private val pkpdIntegration = PkPdIntegration(preferences, pkPdLearnedState, behaviorProfileSource)
     //private val tempFile = File(externalDir, "temp.csv")
     private var bgacc = 0.0
     private var predictedSMB = 0.0f

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
@@ -124,6 +124,7 @@ import app.aaps.plugins.aps.openAPSAIMI.pkpd.InsulinActivityStage
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.InsulinKineticsAuthority
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkpdLearningDiagnostics
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdIntegration
+import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdLearnedState
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdCsvLogger
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkPdRuntime
 import app.aaps.plugins.aps.openAPSAIMI.pkpd.PkpdSmbTailDamping
@@ -174,6 +175,7 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
     private val iobCobCalculator: IobCobCalculator,
     private val hardLimits: HardLimits,
     private val preferences: Preferences,
+    private val pkPdLearnedState: PkPdLearnedState,
     private val sp: SP,
     protected val dateUtil: DateUtil,
     private val processedTbrEbData: ProcessedTbrEbData,
@@ -400,7 +402,7 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
     override var lastAPSResult: APSResult? = null
     override fun usingDynamicIsf(): Boolean = preferences.get(BooleanKey.ApsUseDynamicSensitivity)
     override fun offersDynamicSensitivity(): Boolean = true
-    private val pkpdIntegration = PkPdIntegration(preferences, behaviorProfileSource)
+    private val pkpdIntegration = PkPdIntegration(preferences, pkPdLearnedState, behaviorProfileSource)
     private var lastPkpdScale: Double = 1.0
     // Dans votre classe principale (ou plugin), vous pouvez d?clarer :
     private val kalmanISFCalculator = KalmanISFCalculator(tddCalculator, preferences, aapsLogger)

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdIntegration.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdIntegration.kt
@@ -3,6 +3,7 @@ package app.aaps.plugins.aps.openAPSAIMI.pkpd
 import app.aaps.plugins.aps.openAPSAIMI.ports.AimiBehaviorProfileSource
 import app.aaps.core.keys.BooleanKey
 import app.aaps.core.keys.DoubleKey
+import app.aaps.core.keys.LongNonKey
 import app.aaps.core.keys.interfaces.Preferences
 import app.aaps.plugins.aps.openAPSAIMI.patient.CausalStateId
 import app.aaps.plugins.aps.openAPSAIMI.patient.CausalStatePosterior
@@ -14,6 +15,7 @@ import kotlin.math.max
 
 class PkPdIntegration(
     private val preferences: Preferences,
+    private val learnedState: PkPdLearnedState,
     private val behaviorProfileSource: AimiBehaviorProfileSource,
 ) {
 
@@ -53,15 +55,46 @@ class PkPdIntegration(
     )
 
     private var cachedStructuralConfig: StructuralConfig? = null
-    private var estimator: AdaptivePkPdEstimator? = null
-    private var lastBounds: PkPdBounds? = null
-    private var lastLearningCfg: PkPdLearningConfig? = null
     private var fusion: IsfFusion? = null
     private var lastFusionBounds: IsfFusionBounds? = null
     private var damping: SmbDamping? = null
     private var lastTailPolicy: TailAwareSmbPolicy? = null
-    private var lastPersisted: PkPdParams? = null
     private var recentBolusSamples: List<PkpdBolusSample> = emptyList()
+
+    // The learned state lives in [PkPdLearnedState], so both consumers read one single value.
+    // These are views on the holder, not fields: the rest of the class does not change.
+    private var estimator: AdaptivePkPdEstimator?
+        get() = learnedState.estimator
+        set(value) {
+            learnedState.estimator = value
+        }
+    private var lastBounds: PkPdBounds?
+        get() = learnedState.lastBounds
+        set(value) {
+            learnedState.lastBounds = value
+        }
+    private var lastLearningCfg: PkPdLearningConfig?
+        get() = learnedState.lastLearningCfg
+        set(value) {
+            learnedState.lastLearningCfg = value
+        }
+    private var lastPersisted: PkPdParams?
+        get() = learnedState.lastPersisted
+        set(value) {
+            learnedState.lastPersisted = value
+        }
+
+    /**
+     * Last generation counter this instance acted on.
+     * `null` means it was never read yet (fresh process): adopt the value without resetting,
+     * because prefs are already the seed source on the first tick. Only a *change* between two
+     * ticks means someone wrote the learned state from outside the loop.
+     */
+    private var seenLearnedStateGeneration: Long?
+        get() = learnedState.seenLearnedStateGeneration
+        set(value) {
+            learnedState.seenLearnedStateGeneration = value
+        }
 
     @Synchronized
     fun setRecentBolusSamples(samples: List<PkpdBolusSample>) {
@@ -105,6 +138,7 @@ class PkPdIntegration(
     ): PkPdRuntime? {
         val structural = readStructuralConfig()
         val previousStructural = cachedStructuralConfig
+        adoptExternalLearnedStateReset()
         if (previousStructural != null && previousStructural != structural) {
             applyStructuralConfigChange(previousStructural, structural)
         }
@@ -303,6 +337,28 @@ class PkPdIntegration(
         )
     }
 
+    /**
+     * Detects a learned-state write done outside the loop (reset button, insulin preset).
+     * Drops the in-memory learner so this tick re-seeds from prefs via [readLearnedSeed].
+     * It does not touch the fusion/damping caches on purpose: they hold no learned PK/PD state.
+     *
+     * It must run first in the tick, before the structural config is compared. An insulin preset
+     * changes the bounds and writes the learned state in one gesture, and
+     * [applyStructuralConfigChange] persists the old in-memory value when the bounds change. With
+     * the learner already dropped here, that persist is a no-op and cannot overwrite the new
+     * value. Running it while PK/PD is off is safe too: [clearAllCaches] wipes everything anyway.
+     */
+    private fun adoptExternalLearnedStateReset() {
+        val generation = preferences.get(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
+        val seen = seenLearnedStateGeneration
+        seenLearnedStateGeneration = generation
+        if (seen == null || seen == generation) return
+        estimator = null
+        lastBounds = null
+        lastLearningCfg = null
+        lastPersisted = null
+    }
+
     private fun applyStructuralConfigChange(old: StructuralConfig, new: StructuralConfig) {
         estimator?.let { persistStateIfNeeded(it.params(), new.bounds) }
 
@@ -325,15 +381,14 @@ class PkPdIntegration(
     }
 
     private fun clearAllCaches() {
-        estimator = null
+        learnedState.clearLearned()
         fusion = null
         damping = null
-        lastBounds = null
         lastFusionBounds = null
         lastTailPolicy = null
-        lastLearningCfg = null
         cachedStructuralConfig = null
-        lastPersisted = null
+        // seenLearnedStateGeneration is kept on purpose: turning OApsAIMIPkpdEnabled off and on
+        // again must not look like an external reset on the next tick.
     }
 
     private fun aggregateActivityState(

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdIntegration.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdIntegration.kt
@@ -360,6 +360,8 @@ class PkPdIntegration(
     }
 
     private fun applyStructuralConfigChange(old: StructuralConfig, new: StructuralConfig) {
+        // Same persist as 0761e9c00a. The stale write is gone because [estimator] is now the
+        // shared learned holder, not a private seed frozen on the read-only consumer.
         estimator?.let { persistStateIfNeeded(it.params(), new.bounds) }
 
         val learningInputsChanged = old.bounds != new.bounds ||

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/compose/PkpdPresetProfiles.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/compose/PkpdPresetProfiles.kt
@@ -1,6 +1,7 @@
 package app.aaps.plugins.aps.openAPSAIMI.compose
 
 import app.aaps.core.keys.DoubleKey
+import app.aaps.core.keys.LongNonKey
 import app.aaps.core.keys.interfaces.Preferences
 
 /**
@@ -82,6 +83,7 @@ fun reclampPkpdLearnedStateToBounds(preferences: Preferences) {
     val peak = preferences.get(DoubleKey.OApsAIMIPkpdStatePeakMin).coerceIn(bPeakLo, bPeakHi)
     preferences.putClamped(DoubleKey.OApsAIMIPkpdStateDiaH, dia)
     preferences.putClamped(DoubleKey.OApsAIMIPkpdStatePeakMin, peak)
+    bumpPkpdLearnedStateGeneration(preferences)
 }
 
 /**
@@ -97,6 +99,16 @@ fun resetPkpdLearnedStateToInitial(preferences: Preferences) {
     val bPeakHi = preferences.get(DoubleKey.OApsAIMIPkpdBoundsPeakMinMax)
     preferences.putClamped(DoubleKey.OApsAIMIPkpdStateDiaH, diaInit.coerceIn(bDiaLo, bDiaHi))
     preferences.putClamped(DoubleKey.OApsAIMIPkpdStatePeakMin, peakInit.coerceIn(bPeakLo, bPeakHi))
+    bumpPkpdLearnedStateGeneration(preferences)
+}
+
+/**
+ * Marks the learned state in prefs as replaced from outside the loop, so every live PK/PD engine
+ * instance re-seeds from prefs. Used only by the two writers in this file, and always AFTER the
+ * OApsAIMIPkpdState* writes, never before.
+ */
+private fun bumpPkpdLearnedStateGeneration(preferences: Preferences) {
+    preferences.inc(LongNonKey.OApsAIMIPkpdLearnedStateGeneration)
 }
 
 /**

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedState.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedState.kt
@@ -10,9 +10,9 @@ import kotlin.concurrent.Volatile
 /**
  * Single owner of the learned PK/PD state for the whole process.
  *
- * Two `@SingleIn` consumers build their own [PkPdIntegration]: the loop plugin, which only reads
- * the learned kinetics, and the AIMI determine-basal engine, which is the only one allowed to
- * learn. Without a shared owner the reader keeps the values it read at start up for ever, so the
+ * Study has **one** [PkPdIntegration] class and **two** instances: [app.aaps.plugins.aps.openAPSAIMI.OpenAPSAIMIPlugin]
+ * (read-only) and `DetermineBasalaimiSMB2` in `DetermineBasalAIMI2.kt` (the only learner).
+ * Without a shared owner the reader keeps the values it read at start up for ever, so the
  * prediction kinetics never follow what the learner found.
  *
  * Only the learned state is shared. Everything else stays per consumer on purpose:
@@ -20,8 +20,9 @@ import kotlin.concurrent.Volatile
  *   about three times faster per loop tick;
  * - the recent bolus samples change `pkpdScale`, so sharing them would change the ISF that doses.
  *
- * Copied from `origin/dev_OAPSAIMI` @ `c5db5a0333`. KMP adaptations only: Metro instead of
- * Hilt/javax, `kotlin.concurrent.Volatile`, and [AapsLock] instead of `@Synchronized`.
+ * Source: `origin/dev_OAPSAIMI` @ `0761e9c00a`. KMP adaptations only: Metro `@SingleIn(AppScope)`
+ * instead of javax `@Singleton`, `kotlin.concurrent.Volatile`, and [AapsLock] instead of
+ * `@Synchronized` (`@Synchronized` is JVM-only; this type is commonMain).
  */
 @SingleIn(AppScope::class)
 class PkPdLearnedState @Inject constructor() {

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedState.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/PkPdLearnedState.kt
@@ -1,0 +1,63 @@
+package app.aaps.plugins.aps.openAPSAIMI.pkpd
+
+import app.aaps.core.interfaces.concurrent.AapsLock
+import app.aaps.core.interfaces.concurrent.withLock
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlin.concurrent.Volatile
+
+/**
+ * Single owner of the learned PK/PD state for the whole process.
+ *
+ * Two `@SingleIn` consumers build their own [PkPdIntegration]: the loop plugin, which only reads
+ * the learned kinetics, and the AIMI determine-basal engine, which is the only one allowed to
+ * learn. Without a shared owner the reader keeps the values it read at start up for ever, so the
+ * prediction kinetics never follow what the learner found.
+ *
+ * Only the learned state is shared. Everything else stays per consumer on purpose:
+ * - the ISF fusion holds a per call slew limiter, so sharing it would let the dosing ISF move
+ *   about three times faster per loop tick;
+ * - the recent bolus samples change `pkpdScale`, so sharing them would change the ISF that doses.
+ *
+ * Copied from `origin/dev_OAPSAIMI` @ `c5db5a0333`. KMP adaptations only: Metro instead of
+ * Hilt/javax, `kotlin.concurrent.Volatile`, and [AapsLock] instead of `@Synchronized`.
+ */
+@SingleIn(AppScope::class)
+class PkPdLearnedState @Inject constructor() {
+    // Each consumer guards its own PkPdIntegration with its own lock, so the two locks do not
+    // order these writes against each other. The loop can also run two ticks on two threads of
+    // the same pool. @Volatile is what makes a value written by one consumer visible to the
+    // other one. It is enough here: every field holds one reference and is written inside a
+    // single tick, so there is no read-modify-write to make atomic.
+    private val clearLock = AapsLock()
+
+    @Volatile
+    internal var estimator: AdaptivePkPdEstimator? = null
+
+    @Volatile
+    internal var lastBounds: PkPdBounds? = null
+
+    @Volatile
+    internal var lastLearningCfg: PkPdLearningConfig? = null
+
+    @Volatile
+    internal var lastPersisted: PkPdParams? = null
+
+    @Volatile
+    internal var seenLearnedStateGeneration: Long? = null
+
+    /**
+     * Drops the learned values so the next tick seeds again from prefs.
+     * [seenLearnedStateGeneration] is kept on purpose: turning PK/PD off and on again must not
+     * look like an external reset on the next tick.
+     */
+    fun clearLearned() {
+        clearLock.withLock {
+            estimator = null
+            lastBounds = null
+            lastLearningCfg = null
+            lastPersisted = null
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.1** uniquement. Source : `origin/dev_OAPSAIMI` @ **`0761e9c00a`**. Boucle médicale fermée : copie du comportement, aucune formule clinique changée.

### Inventaire study (faits orchestrateur — pas deux *classes*)
- `PkPdLearnedState` était **absent**.
- **Une** classe `PkPdIntegration` : `plugins/aps/src/androidMain/.../pkpd/PkPdIntegration.kt`.
- **Deux instances** du même type :
  1. `OpenAPSAIMIPlugin` ≈ L405 (lecteur)
  2. `DetermineBasalaimiSMB2` dans `DetermineBasalAIMI2.kt` ≈ L10339 (learner)
- Grep `PkPdIntegration(` : ces deux sites + le test. **Pas** de benches / scenarios sur study (`EngineBenchmarks`, `*ScenarioTest*` absents). Pas de 2ᵉ classe inventée.

### Copié / adapté
- `PkPdLearnedState` → **commonMain**. Metro `@SingleIn(AppScope::class)` + `@Inject` (pas javax `@Singleton`). Cinq champs `@Volatile` comme 0761e9c. `clearLearned()` ne touche pas `seenLearnedStateGeneration`. `@Synchronized` (JVM) → `AapsLock` (commonMain).
- Constructeur : 2ᵉ paramètre **obligatoire** `learnedState: PkPdLearnedState` (pas de défaut). 3ᵉ paramètre study existant : `behaviorProfileSource`.
- Champs appris délégués à `learnedState.*`. Fusion ISF, damping SMB, `recentBolusSamples`, config structurelle restent **par consommateur**.
- `applyStructuralConfigChange` garde le `persist` de 0761e9c ; l’écriture périmée disparaît parce que `estimator` est le holder partagé, plus une graine privée du lecteur.
- Même singleton injecté dans plugin + tick (passage constructeur uniquement dans `DetermineBasalAIMI2`, pas de hunk P0.8).

### Tests (0761e9c)
Les deux régressions qui échouent sans le holder :
- `read_only_consumer_sees_the_state_learned_by_the_other_consumer`
- `bounds_change_does_not_persist_a_stale_value_from_the_read_only_consumer`

Plus les 4 gardes 0761e9c. Portés en `androidHostTest` + mockito (pas mockk).

### Hors scope
P0.2–P0.8, `isfRateLimitAuthority`, déplacement du tick vers commonMain, iOS `APS=true`.

### Preuves
```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:testAndroidHostTest
  --tests '...pkpd.PkPdLearnedStateIntegrationTest'          → 14/14
  --tests '...compose.PkpdPresetProfilesLearnedGenerationTest' → 3/3
```
`:app:assembleFullDebug` **non lancé** (trop lourd). Binding Metro = classe concrète `@Inject` `@SingleIn`, comme `PhysioAggregator`.

## EN

Lot **P0.1** only. Source: `origin/dev_OAPSAIMI` @ **`0761e9c00a`**. Medical closed-loop: copy behaviour, no clinical formula change.

### Study inventory (orchestrator facts — not two *classes*)
- `PkPdLearnedState` was **absent**.
- **One** `PkPdIntegration` class: `plugins/aps/src/androidMain/.../pkpd/PkPdIntegration.kt`.
- **Two instances** of that type:
  1. `OpenAPSAIMIPlugin` ≈ L405 (reader)
  2. `DetermineBasalaimiSMB2` in `DetermineBasalAIMI2.kt` ≈ L10339 (learner)
- Grep `PkPdIntegration(`: those two sites + the test. **No** benches/scenarios on study (`EngineBenchmarks`, `*ScenarioTest*` missing). No second class invented.

### What was copied / adapted
- `PkPdLearnedState` → **commonMain**. Metro `@SingleIn(AppScope::class)` + `@Inject` (not javax `@Singleton`). Five `@Volatile` fields as in 0761e9c. `clearLearned()` does not reset `seenLearnedStateGeneration`. `@Synchronized` (JVM) → `AapsLock` (commonMain).
- Constructor: required 2nd param `learnedState: PkPdLearnedState` (no default). Study’s existing 3rd param `behaviorProfileSource` kept.
- Learned fields delegated to `learnedState.*`. ISF fusion, SMB damping, `recentBolusSamples`, structural config stay **per consumer**.
- `applyStructuralConfigChange` keeps the 0761e9c persist; the stale write is gone because `estimator` is the shared holder, not the reader’s private seed.
- Same process-wide singleton passed into plugin + tick (constructor pass-through only in `DetermineBasalAIMI2`; no P0.8 hunks).

### Tests (0761e9c)
The two regressions that fail without the holder:
- `read_only_consumer_sees_the_state_learned_by_the_other_consumer`
- `bounds_change_does_not_persist_a_stale_value_from_the_read_only_consumer`

Plus the four 0761e9c guards. Ported to `androidHostTest` + mockito (not mockk).

### Out of scope
P0.2–P0.8, `isfRateLimitAuthority`, moving the tick to commonMain, iOS `APS=true`.

### Evidence
```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:testAndroidHostTest
  --tests '...pkpd.PkPdLearnedStateIntegrationTest'          → 14/14
  --tests '...compose.PkpdPresetProfilesLearnedGenerationTest' → 3/3
```
`:app:assembleFullDebug` **not run** (too heavy). Metro binding is a concrete `@Inject` `@SingleIn` class, same pattern as `PhysioAggregator`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7eb1c71-12ea-4fc8-9d52-88b1d67061d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7eb1c71-12ea-4fc8-9d52-88b1d67061d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

