### PR TITLE
P0.2 — DynIsfCache: time-keyed ISF store on the KMP study branch

### DIFF
--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt
@@ -1,0 +1,147 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the read rule of [DynIsfCache].
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `dd9979ca4d`. These are non-regression locks, not a
+ * red-before/green-after proof. The rule they replace lived inline in `OpenAPSAIMIPlugin` on an
+ * `android.util.LongSparseArray`, which returns default values under `unitTests.isReturnDefaultValues`,
+ * so the old behaviour could not be tested at all. Each test below says what the old rule would have
+ * answered.
+ *
+ * See `docs/adr/0003-dynisf-cache-read-path.md`.
+ */
+class DynIsfCacheTest {
+
+    private val minute = 60 * 1000L
+    private val hour = 60 * minute
+
+    /** A time that is a whole multiple of both the 5-minute and the 30-minute bucket. */
+    private val tenAm = 999_999_900_000L
+
+    /**
+     * T1 — the incident of 2026-09-01. The old key was `bucketStart + glucose`, so inside one bucket
+     * the entry with the highest glucose sorted last and won the read. Here the 180 mg/dL sample is
+     * older but would have been served.
+     */
+    @Test
+    fun `newest returns the latest sample even when an earlier one had a higher glucose`() {
+        val cache = DynIsfCache()
+
+        cache.put(atMs = tenAm, isfMgdl = 20.0, glucoseMgdl = 180.0)
+        cache.put(atMs = tenAm + 20 * minute, isfMgdl = 40.0, glucoseMgdl = 120.0)
+
+        assertEquals(40.0, cache.newest()?.isfMgdl)
+        assertEquals(120.0, cache.newest()?.glucoseMgdl)
+    }
+
+    /**
+     * T2 — the age must come from the sample time. The old code recovered a 30-minute bucket start
+     * from the key, so a value written at 10:29 and read at 10:31 was reported as 31 minutes old.
+     */
+    @Test
+    fun `age is measured from the sample time not from a bucket start`() {
+        val cache = DynIsfCache(bucketMs = 30 * minute)
+
+        cache.put(atMs = tenAm + 29 * minute, isfMgdl = 25.0, glucoseMgdl = 140.0)
+        val readAt = tenAm + 31 * minute
+
+        val sample = cache.newest()
+        assertNotNull(sample)
+        assertEquals(2 * minute, readAt - sample!!.atMs)
+    }
+
+    /** T3 — a fresh write after a long silence must win over the warm-up history. */
+    @Test
+    fun `a sample written after a long silence supersedes the warm up history`() {
+        val cache = DynIsfCache()
+
+        cache.put(atMs = tenAm, isfMgdl = 9.0, glucoseMgdl = 260.0)
+        cache.put(atMs = tenAm + 4 * hour, isfMgdl = 33.0, glucoseMgdl = 110.0)
+
+        assertEquals(33.0, cache.newest()?.isfMgdl)
+        assertEquals(tenAm + 4 * hour, cache.newest()?.atMs)
+    }
+
+    /**
+     * T4 — retention drops the oldest entries one by one. The old code called `clear()` above 1000
+     * entries, and the next read then fell back to the static profile ISF.
+     */
+    @Test
+    fun `retention evicts old samples instead of emptying the store`() {
+        val cache = DynIsfCache(bucketMs = 5 * minute, retentionMs = 24 * hour)
+        val step = 48 * hour / 400
+
+        for (i in 0 until 400) {
+            cache.put(atMs = tenAm + i * step, isfMgdl = 20.0 + i % 7, glucoseMgdl = 120.0)
+            assertTrue(cache.newest() != null, "store must never be empty after a write")
+        }
+
+        // At most one entry per 5-minute bucket of the 24-hour window, plus the newest one.
+        assertTrue(cache.size() <= 24 * 60 / 5 + 1, "size was ${cache.size()}")
+        assertTrue(cache.size() < 400)
+        assertEquals(tenAm + 399 * step, cache.newest()?.atMs)
+    }
+
+    /** T5 — the 24-hour average must only see the window it was asked for. */
+    @Test
+    fun `averageSince ignores samples outside the window`() {
+        val cache = DynIsfCache()
+
+        cache.put(atMs = tenAm, isfMgdl = 10.0, glucoseMgdl = 200.0)
+        cache.put(atMs = tenAm + 1 * hour, isfMgdl = 20.0, glucoseMgdl = 150.0)
+        cache.put(atMs = tenAm + 2 * hour, isfMgdl = 30.0, glucoseMgdl = 120.0)
+
+        val average = cache.averageSince(fromMs = tenAm + 1 * hour, toMs = tenAm + 2 * hour)
+
+        assertEquals(25.0, average)
+        assertNull(cache.averageSince(fromMs = tenAm + 10 * hour, toMs = tenAm + 11 * hour))
+    }
+
+    /**
+     * T6 — `Math.floorMod` keeps the buckets right across the epoch. With `%` the remainder of a
+     * negative time is negative, so a sample one minute before the epoch and a sample one minute
+     * after it both land on bucket 0 and the second write erases the first.
+     */
+    @Test
+    fun `keys stay ordered for a timestamp before the epoch`() {
+        val cache = DynIsfCache()
+
+        cache.put(atMs = -1 * minute, isfMgdl = 10.0, glucoseMgdl = 200.0)
+        cache.put(atMs = 1 * minute, isfMgdl = 20.0, glucoseMgdl = 100.0)
+
+        assertEquals(2, cache.size())
+        assertEquals(20.0, cache.newest()?.isfMgdl)
+
+        // Same two samples, written in the other order: the later time must still win.
+        val reversed = DynIsfCache()
+        reversed.put(atMs = 1 * minute, isfMgdl = 20.0, glucoseMgdl = 100.0)
+        reversed.put(atMs = -1 * minute, isfMgdl = 10.0, glucoseMgdl = 200.0)
+
+        assertEquals(2, reversed.size())
+        assertEquals(20.0, reversed.newest()?.isfMgdl)
+    }
+
+    /**
+     * T7 — two writers can aim at the same bucket out of order. At start up the warm up reloads the
+     * database history on a background scope while the first live tick already computes a fresh
+     * value. If the last history row falls in the same 5-minute bucket as that fresh value, a plain
+     * "last writer wins" would let the older row erase the newer one.
+     */
+    @Test
+    fun `an older write does not replace a newer one in the same bucket`() {
+        val cache = DynIsfCache()
+
+        cache.put(atMs = tenAm + 3 * minute, isfMgdl = 40.0, glucoseMgdl = 120.0)
+        cache.put(atMs = tenAm + 1 * minute, isfMgdl = 20.0, glucoseMgdl = 180.0)
+
+        assertEquals(40.0, cache.newest()?.isfMgdl)
+        assertEquals(tenAm + 3 * minute, cache.newest()?.atMs)
+    }
+}

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
@@ -7,8 +7,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Looper
-import android.util.LongSparseArray
-import androidx.core.util.forEach
 import app.aaps.plugins.aps.openAPSAIMI.steps.UnifiedActivityProviderMTR
 import app.aaps.core.data.aps.SMBDefaults
 import app.aaps.core.data.model.GlucoseUnit
@@ -91,6 +89,7 @@ import app.aaps.plugins.aps.R
 import app.aaps.plugins.aps.events.EventOpenAPSUpdateGui
 import app.aaps.plugins.aps.events.EventResetOpenAPSGui
 import app.aaps.plugins.aps.openAPS.TddStatus
+import app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCache
 import app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfTrajectoryTuning
 import app.aaps.plugins.aps.openAPSAIMI.ISF.DynamicSensitivityPolicy
 import app.aaps.plugins.aps.openAPSAIMI.ISF.IsfAdjustmentEngine
@@ -114,6 +113,7 @@ import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.IntKey as MetroIntKey
 import dev.zacsweers.metro.binding
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.floor
 import kotlin.math.max
 import app.aaps.plugins.aps.openAPSAIMI.ISF.IsfBlender
@@ -324,15 +324,15 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
                 var count = 0
                 val apsResults =
                     persistenceLayer.getApsResults(dateUtil.now() - T.days(1).msecs(), dateUtil.now())
-                synchronized(dynIsfCacheLock) {
-                    apsResults.forEach {
-                        val glucose = it.glucoseStatus?.glucose ?: return@forEach
-                        val variableSens = it.variableSens ?: return@forEach
-                        val timestamp = it.date
-                        val key = timestamp - timestamp % T.mins(30).msecs() + glucose.toLong()
-                        if (variableSens > 0) dynIsfCache.put(key, variableSens)
-                        count++
-                    }
+                apsResults.forEach {
+                    val glucose = it.glucoseStatus?.glucose ?: return@forEach
+                    val variableSens = it.variableSens ?: return@forEach
+                    // These history rows carry the late DetermineBasal value, so they already hold
+                    // the physiological factor. They are loaded so `getAverageIsfMgdl` has a 24-hour
+                    // window right after a restart; the first refresh of the tick writes a freshly
+                    // computed value on top of them, and that is what `newest()` then serves.
+                    dynIsfCache.put(atMs = it.date, isfMgdl = variableSens, glucoseMgdl = glucose)
+                    count++
                 }
                 aapsLogger.debug(LTag.APS, "Loaded $count variable sensitivity values from database")
             } catch (e: Exception) {
@@ -571,34 +571,32 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
     /**
      * Reads the newest cache entry and records **which source was used** in [IsfSourceTelemetry].
      *
-     * Diagnostic only — it does not change which value is returned. The cache key is
-     * `bucketStart + glucose` (see the warm-up loop), so `valueAt(size - 1)` returns the entry of
-     * the highest glucose in the newest 30-minute bucket, not the most recent one. The bucket start
-     * is recovered from the key to report the age of the value actually used.
+     * Diagnostic only — it does not change which value is returned. [DynIsfCache] is keyed on time
+     * alone, so `newest()` is really the most recent sample, and the sample carries its own write
+     * time, so the age reported here is exact.
      *
-     * See `docs/adr/0003-dynisf-cache-read-path.md`.
+     * A stale value is still returned. It is reported as stale, never turned into `null`: a `null`
+     * makes the caller fall back to the static profile ISF, which is usually lower and would command
+     * **more** insulin. See `docs/adr/0003-dynisf-cache-read-path.md`.
      */
     private fun readNewestDynIsfAndRecordSource(now: Long): Double? {
-        val entry = synchronized(dynIsfCacheLock) {
-            val size = dynIsfCache.size()
-            if (size == 0) null else dynIsfCache.keyAt(size - 1) to dynIsfCache.valueAt(size - 1)
-        }
-        if (entry == null) {
+        val sample = dynIsfCache.newest()
+        if (sample == null) {
             IsfSourceTelemetry.record(IsfSourceTelemetry.SOURCE_PROFILE_FALLBACK, null, null)
             return null
         }
-        val (key, value) = entry
-        val bucketMs = T.mins(30).msecs()
-        val bucketStart = key - key % bucketMs
-        // The key is `bucketStart + glucose`, so the remainder identifies the reading this value was
-        // computed for. Two entries of the same bucket share an age but not a key.
-        val cacheGlucose = key % bucketMs
-        val ageMs = (now - bucketStart).coerceAtLeast(0L)
+        val ageMs = (now - sample.atMs).coerceAtLeast(0L)
         val source =
             if (ageMs > IsfSourceTelemetry.STALE_AFTER_MS) IsfSourceTelemetry.SOURCE_DYNAMIC_STALE
             else IsfSourceTelemetry.SOURCE_DYNAMIC_FRESH
-        IsfSourceTelemetry.record(source, value, ageMs, cacheKey = key, cacheGlucoseMgdl = cacheGlucose)
-        return value
+        IsfSourceTelemetry.record(
+            source,
+            sample.isfMgdl,
+            ageMs,
+            cacheKey = sample.atMs,
+            cacheGlucoseMgdl = sample.glucoseMgdl?.toLong(),
+        )
+        return sample.isfMgdl
     }
 
     override fun getIsfMgdl(profile: Profile, caller: String): Double? {
@@ -612,12 +610,16 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
         if (Looper.myLooper() == Looper.getMainLooper()) {
             // Keep UI path non-blocking; use latest cache and refresh in background.
             val cached = readNewestDynIsfAndRecordSource(start)
-            aimiPluginIoScope.launch { runCatching { calculateVariableIsf(start) } }
+            if (dynIsfRefreshDue(start)) {
+                aimiPluginIoScope.launch { runCatching { calculateVariableIsf(start, useDbShortcut = false) } }
+            }
             return cached?.let { it * multiplier }
         }
 
         val cached = readNewestDynIsfAndRecordSource(start)
-        aimiPluginIoScope.launch { runCatching { calculateVariableIsf(start) } }
+        if (dynIsfRefreshDue(start)) {
+            aimiPluginIoScope.launch { runCatching { calculateVariableIsf(start, useDbShortcut = false) } }
+        }
         profiler.log(
             LTag.APS,
             "getIsfMgdl() CACHE $cached src=${IsfSourceTelemetry.lastSource} " +
@@ -628,27 +630,12 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
     }
 
     override fun getAverageIsfMgdl(timestamp: Long, caller: String): Double? {
-        val (count, sum) = synchronized(dynIsfCacheLock) {
-            if (dynIsfCache.isEmpty()) {
-                return@synchronized -1 to 0.0
-            }
-            var c = 0
-            var s = 0.0
-            val start = timestamp - T.hours(24).msecs()
-            dynIsfCache.forEach { key, value ->
-                if (key in start..timestamp) {
-                    c++
-                    s += value
-                }
-            }
-            c to s
-        }
-        if (count < 0) {
+        if (dynIsfCache.isEmpty()) {
             maybeLogDynIsfCacheEmptyWarning(caller)
             return null
         }
-        val sensitivity = if (count == 0) null else sum / count
-        aapsLogger.debug(LTag.APS, "getAverageIsfMgdl() $sensitivity from $count values ${dateUtil.dateAndTimeAndSecondsString(timestamp)} $caller")
+        val sensitivity = dynIsfCache.averageSince(timestamp - T.hours(24).msecs(), timestamp)
+        aapsLogger.debug(LTag.APS, "getAverageIsfMgdl() $sensitivity over 24 h ${dateUtil.dateAndTimeAndSecondsString(timestamp)} $caller")
         return sensitivity
     }
 
@@ -683,8 +670,23 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
         return pump.pumpDescription.isTempBasalCapable
     }
 
-    private val dynIsfCache = LongSparseArray<Double>()
-    private val dynIsfCacheLock = Any()
+    private val dynIsfCache = DynIsfCache()
+
+    /** Time of the last background refresh that was started, used by [dynIsfRefreshDue]. */
+    private val dynIsfRefreshGate = AtomicLong(0L)
+
+    /**
+     * True at most once per [DYN_ISF_REFRESH_MIN_INTERVAL_MS], for the caller that wins the race.
+     *
+     * `getIsfMgdl` is called many times per tick, and every call used to start a full recomputation
+     * on the background scope. Now that the refresh no longer takes the database short cut it is a
+     * real computation, so it is started once per minute at most.
+     */
+    private fun dynIsfRefreshDue(nowMs: Long): Boolean {
+        val last = dynIsfRefreshGate.get()
+        if (nowMs - last < DYN_ISF_REFRESH_MIN_INTERVAL_MS) return false
+        return dynIsfRefreshGate.compareAndSet(last, nowMs)
+    }
 
     // Exemple de fonction pour pr?dire le delta futur ? partir d'un historique r?cent
     private fun predictedDelta(deltaHistory: List<Double>): Double {
@@ -793,16 +795,36 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
         return recent
     }
     @SuppressLint("DefaultLocale")
+    /**
+     * Estimates the dynamic sensitivity and, on the `CALC` path only, stores it in [dynIsfCache].
+     *
+     * @param useDbShortcut when true, a sensitivity already written to the database for a nearby
+     *   time is reused instead of running the chain again. The loop wants that: it would otherwise
+     *   pay for the whole chain twice on the same tick. The background refresh must not take it.
+     *
+     *   Taking the short cut is exactly what starved the cache: `getApsResultCloseTo` matches within
+     *   5 minutes and the loop really runs about once a minute, so the `DB` path was taken on nearly
+     *   every cycle, the `CALC` path almost never ran, and nothing was ever written.
+     *
+     *   The database row cannot stand in for a recomputation either. It carries the late
+     *   DetermineBasal value, which already holds the physiological factor, while this function
+     *   returns the estimate **without** it. Storing one in place of the other would apply that
+     *   factor twice. See `docs/adr/0002-sensitivity-three-levels.md` and
+     *   `docs/adr/0003-dynisf-cache-read-path.md`.
+     */
     private suspend fun calculateVariableIsf(
         timestamp: Long,
         pkpdScaleForTick: Double = lastPkpdScale,
         fusedSlowIsfOverride: Double? = null,
+        useDbShortcut: Boolean = true,
     ): Pair<String, Double?> {
         if (!preferences.get(BooleanKey.ApsUseDynamicSensitivity)) return "OFF" to null
 
         // 0) cache DB existant
-        val result = persistenceLayer.getApsResultCloseTo(timestamp)
-        if (result?.variableSens != null) return "DB" to result.variableSens
+        if (useDbShortcut) {
+            val result = persistenceLayer.getApsResultCloseTo(timestamp)
+            if (result?.variableSens != null) return "DB" to result.variableSens
+        }
 
         // 1) BG & deltas actuels
         val glucose = glucoseStatusProvider.glucoseStatusData?.glucose ?: return "GLUC" to null
@@ -928,11 +950,7 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
         )
 
         // 11) cache
-        val key = timestamp - timestamp % T.mins(30).msecs() + glucose.toLong()
-        synchronized(dynIsfCacheLock) {
-            if (dynIsfCache.size > 1000) dynIsfCache.clear()
-            dynIsfCache.put(key, blended)
-        }
+        dynIsfCache.put(atMs = timestamp, isfMgdl = blended, glucoseMgdl = glucose)
 
         return "CALC" to blended
     }
@@ -2335,5 +2353,11 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
             // Wave1 G1: product surface is the guided Compose screen only — raw key dump removed.
             items = listOf(aimiComposePkpdSetupItem()),
         )
+
+    companion object {
+
+        /** Shortest gap between two background dynamic ISF refreshes. */
+        private const val DYN_ISF_REFRESH_MIN_INTERVAL_MS = 60_000L
+    }
 
 }

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
@@ -675,8 +675,11 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
     /** Time of the last background refresh that was started, used by [dynIsfRefreshDue]. */
     private val dynIsfRefreshGate = AtomicLong(0L)
 
+    /** Shortest gap between two background dynamic ISF refreshes. Field, not a companion: this class is Metro-injected. */
+    private val dynIsfRefreshMinIntervalMs = 60_000L
+
     /**
-     * True at most once per [DYN_ISF_REFRESH_MIN_INTERVAL_MS], for the caller that wins the race.
+     * True at most once per [dynIsfRefreshMinIntervalMs], for the caller that wins the race.
      *
      * `getIsfMgdl` is called many times per tick, and every call used to start a full recomputation
      * on the background scope. Now that the refresh no longer takes the database short cut it is a
@@ -684,7 +687,7 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
      */
     private fun dynIsfRefreshDue(nowMs: Long): Boolean {
         val last = dynIsfRefreshGate.get()
-        if (nowMs - last < DYN_ISF_REFRESH_MIN_INTERVAL_MS) return false
+        if (nowMs - last < dynIsfRefreshMinIntervalMs) return false
         return dynIsfRefreshGate.compareAndSet(last, nowMs)
     }
 
@@ -2353,11 +2356,5 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
             // Wave1 G1: product surface is the guided Compose screen only — raw key dump removed.
             items = listOf(aimiComposePkpdSetupItem()),
         )
-
-    companion object {
-
-        /** Shortest gap between two background dynamic ISF refreshes. */
-        private const val DYN_ISF_REFRESH_MIN_INTERVAL_MS = 60_000L
-    }
 
 }

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCache.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCache.kt
@@ -26,11 +26,12 @@ import app.aaps.core.interfaces.concurrent.withLock
  * emptied in one go: a wholesale `clear()` made the very next read fall back to the static profile
  * ISF, which is a different quantity.
  *
- * Source: `origin/dev_OAPSAIMI` @ `dd9979ca4d`. KMP adaptations only: [AapsLock] instead of
- * `@Synchronized` (`@Synchronized` is JVM-only; this type is commonMain), and a [MutableMap] keyed
- * the same way as the reference `TreeMap` (`TreeMap` is JVM-only). "Newest" is still the highest
- * key, never insertion order and never glucose. `floorMod` is the same rule as `Math.floorMod`
- * for a positive modulus.
+ * Source: `origin/dev_OAPSAIMI` @ `dd9979ca4d`. Study wiring matches [IsfBlender] /
+ * [IsfAdjustmentEngine]: commonMain, no Metro `@Inject` (one plugin-owned instance, constructed
+ * as a field on `OpenAPSAIMIPlugin`). KMP adaptations only: [AapsLock] instead of `@Synchronized`
+ * (`@Synchronized` is JVM-only), and a [MutableMap] keyed the same way as the reference `TreeMap`
+ * (`TreeMap` is JVM-only). "Newest" is still the highest key, never insertion order and never
+ * glucose. `floorMod` is the same rule as `Math.floorMod` for a positive modulus.
  *
  * See `docs/adr/0003-dynisf-cache-read-path.md`.
  *

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCache.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCache.kt
@@ -1,0 +1,132 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import app.aaps.core.interfaces.concurrent.AapsLock
+import app.aaps.core.interfaces.concurrent.withLock
+
+/**
+ * Small time-keyed store for the dynamic ISF values the loop computes.
+ *
+ * ## Why the key is only a time
+ *
+ * The store this class replaces was keyed on `bucketStart + glucose`, and it read the newest value
+ * as "the last key". Keys are kept sorted, so that read returned the entry of the **highest glucose
+ * of the newest bucket**, not the most recent entry. While glucose was falling, the value stayed
+ * pinned to the one computed at the peak of the bucket. A time and a glucose must never be added
+ * into one scalar that is then used for ordering.
+ *
+ * Here the key is the start of the time bucket only, so "last key" means "most recent". The exact
+ * sample time is kept inside [Sample], so the age of a value is measured from when it was written,
+ * not from the start of its bucket. The glucose it was computed for is kept as plain data and never
+ * takes part in ordering.
+ *
+ * Writes are ordered, not "last writer wins": inside one bucket, an older write never replaces a
+ * newer one. Two writers really do aim at the same bucket out of order at start up.
+ *
+ * Old entries are dropped one by one when they fall out of the retention window. The store is never
+ * emptied in one go: a wholesale `clear()` made the very next read fall back to the static profile
+ * ISF, which is a different quantity.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `dd9979ca4d`. KMP adaptations only: [AapsLock] instead of
+ * `@Synchronized` (`@Synchronized` is JVM-only; this type is commonMain), and a [MutableMap] keyed
+ * the same way as the reference `TreeMap` (`TreeMap` is JVM-only). "Newest" is still the highest
+ * key, never insertion order and never glucose. `floorMod` is the same rule as `Math.floorMod`
+ * for a positive modulus.
+ *
+ * See `docs/adr/0003-dynisf-cache-read-path.md`.
+ *
+ * @param bucketMs width of one time bucket. Two writes inside the same bucket share a key, so the
+ *   later one replaces the earlier one.
+ * @param retentionMs how long a sample is kept before it is evicted.
+ */
+class DynIsfCache(
+    private val bucketMs: Long = 5 * 60 * 1000L,
+    private val retentionMs: Long = 24 * 60 * 60 * 1000L,
+) {
+
+    /**
+     * One stored sensitivity value.
+     *
+     * @param isfMgdl the sensitivity, mg/dL per U.
+     * @param glucoseMgdl the glucose this value was computed for, when it is known.
+     * @param atMs the exact time the value was written. Ages are measured from this, not from the
+     *   bucket start.
+     */
+    data class Sample(val isfMgdl: Double, val glucoseMgdl: Double?, val atMs: Long)
+
+    // Dedicated lock: @Synchronized is JVM-only. Same monitor contract as the reference methods.
+    private val lock = AapsLock()
+
+    // TreeMap is JVM-only. Keys stay the bucket start; newest = max key, same as lastEntry().
+    private val samples = mutableMapOf<Long, Sample>()
+
+    /**
+     * Stores one value and drops what is older than the retention window.
+     *
+     * A value that is not finite or not above zero is ignored: it cannot be a sensitivity.
+     */
+    fun put(atMs: Long, isfMgdl: Double, glucoseMgdl: Double?) {
+        lock.withLock {
+            if (!isfMgdl.isFinite() || isfMgdl <= 0.0) return@withLock
+            // floorMod, not %: a negative time would give a negative remainder with %, and the
+            // resulting key would sort after a later time.
+            val key = atMs - floorMod(atMs, bucketMs)
+            // Two writers can aim at the same bucket out of order. At start up the warm up reloads the
+            // database history on a background scope while the first live tick already computes a fresh
+            // value. With plain "last writer wins", a history row landing in the same bucket would erase
+            // that fresh value. Only a write that is at least as recent may replace what is there.
+            val existing = samples[key]
+            if (existing == null || existing.atMs <= atMs) {
+                samples[key] = Sample(isfMgdl = isfMgdl, glucoseMgdl = glucoseMgdl, atMs = atMs)
+            }
+            // Eviction runs on every call, accepted or refused, and its window is measured from the
+            // newest sample the store holds rather than from this call's time. A late write then cannot
+            // drop entries that are still inside the window, and cannot leave the store unbounded
+            // either.
+            val newestAtMs = lastEntryValue()?.atMs ?: return@withLock
+            val oldestKept = newestAtMs - retentionMs
+            while (samples.isNotEmpty()) {
+                val firstKey = samples.keys.minOrNull() ?: break
+                if (firstKey >= oldestKept) break
+                samples.remove(firstKey)
+            }
+        }
+    }
+
+    /** The most recent sample, or `null` when nothing is stored. Never chosen by glucose. */
+    fun newest(): Sample? = lock.withLock { lastEntryValue() }
+
+    /**
+     * Mean sensitivity of the samples written in `[fromMs, toMs]`.
+     *
+     * Returns `null` when the window holds no sample.
+     */
+    fun averageSince(fromMs: Long, toMs: Long): Double? = lock.withLock {
+        var count = 0
+        var sum = 0.0
+        for (sample in samples.values) {
+            if (sample.atMs in fromMs..toMs) {
+                count++
+                sum += sample.isfMgdl
+            }
+        }
+        if (count == 0) null else sum / count
+    }
+
+    /** How many samples are stored. */
+    fun size(): Int = lock.withLock { samples.size }
+
+    /** True when nothing is stored. */
+    fun isEmpty(): Boolean = lock.withLock { samples.isEmpty() }
+
+    /** Highest key's sample — same as `TreeMap.lastEntry()?.value`. */
+    private fun lastEntryValue(): Sample? = samples.maxByOrNull { it.key }?.value
+
+    /**
+     * Remainder with the sign of [m], matching `Math.floorMod` when [m] is positive.
+     * `%` on a negative time is negative and would collapse two buckets onto key 0.
+     */
+    private fun floorMod(x: Long, m: Long): Long {
+        val r = x % m
+        return if (r < 0) r + m else r
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt
@@ -1,10 +1,10 @@
 package app.aaps.plugins.aps.openAPSAIMI.ISF
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Locks the read rule of [DynIsfCache].
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.Test
  * `android.util.LongSparseArray`, which returns default values under `unitTests.isReturnDefaultValues`,
  * so the old behaviour could not be tested at all. Each test below says what the old rule would have
  * answered.
+ *
+ * Study source set: [DynIsfCache] is commonMain and has no mocks, so the tests live in `commonTest`
+ * (`kotlin.test`) — same layout as `TddStatusTest`, not `androidHostTest` (mockito/Robolectric).
  *
  * See `docs/adr/0003-dynisf-cache-read-path.md`.
  */
@@ -54,7 +57,7 @@ class DynIsfCacheTest {
 
         val sample = cache.newest()
         assertNotNull(sample)
-        assertEquals(2 * minute, readAt - sample!!.atMs)
+        assertEquals(2 * minute, readAt - sample.atMs)
     }
 
     /** T3 — a fresh write after a long silence must win over the warm-up history. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.2** uniquement.

- **Clinique** = reference `origin/dev_OAPSAIMI` @ **`dd9979ca4d`** (inchangé sur le tip `c5db5a0333`).
- **Câblage** = study tip post-#71 : **commonMain** + champ plugin (`private val dynIsfCache = DynIsfCache()`), **pas Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Preuve = **`:plugins:aps:jvmTest`** → DynIsfCacheTest **7/7**.

Pas de copie aveugle Hilt/javax/`TreeMap`/`@Synchronized`.

### Re-vérif study
- **Une** classe plugin AIMI : `androidMain` `OpenAPSAIMIPlugin` (Metro `@Inject` `@SingleIn`). Pas de 2ᵉ copie Android.
- Consommateurs `DynIsfCache` : **ce plugin seulement**. `DetermineBasalAIMI2` ne tient pas le store (hunks dd9979ca4d = télémétrie).
- Pattern frère : `IsfBlender` / `IsfAdjustmentEngine` = commonMain, **champ** `private val` sur le plugin, **pas** Metro. `PkPdLearnedState` est Metro parce que **deux** consommateurs partagent l’état — ce n’est pas le cas ici.
- Type dans **commonMain** (pur, comme les autres fichiers ISF).
- Pas de `aimiWallClockMs` dans le store : les horodatages sont des arguments (`atMs` / `fromMs` / `toMs`), comme le reference. Le plugin garde `dateUtil.now()`.
- Pas de 2ᵉ pile Android-only, pas de Hilt, pas de `StringKey.exportable`.

### Copié / adapté
- `DynIsfCache` → **commonMain**. `AapsLock` à la place de `@Synchronized`, `MutableMap` à la place de `TreeMap`. « Newest » = clé max. `floorMod` = même règle que `Math.floorMod` pour un module positif.

### Sites câblés (`OpenAPSAIMIPlugin` androidMain)
1. Warm-up : `put(atMs = it.date, isfMgdl, glucoseMgdl)`.
2. `readNewestDynIsfAndRecordSource` : `newest()` ; âge = `now - sample.atMs`.
3. `getAverageIsfMgdl` : `averageSince(timestamp - 24h, timestamp)` sur `atMs`.
4. Chemin `CALC` : `put(atMs = timestamp, …)` ; plus de `clear()` wholesale.
5. Refresh fond : `useDbShortcut = false` + throttle 60 s — **comportement d’écriture** du reference (sinon le raccourci DB affame encore le store). `invoke()` garde le raccourci (défaut `true`). Champ d’intervalle, pas de `companion` sur la classe Metro.

`DetermineBasalAIMI2` **non modifié**. Pas de `recordCalcPath`. Pas de plancher Kalman.

### Tests (`commonTest` + `jvmTest`)
Les 7 verrous dd9979ca4d sont dans **`commonTest`**, assertions **`kotlin.test`**.

Fichier : `plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt`.

Tâche lancée : **`:plugins:aps:jvmTest --tests '…DynIsfCacheTest'`** → **7/7**.

### ADR 0003
`docs/adr/0003-dynisf-cache-read-path.md` est **absent** de l’arbre study. Le KDoc pointe seulement vers ce chemin, **même formulation que le reference**. Pas de fichier ADR ajouté.

### Hors scope
P0.3–P0.8, `DetermineBasalAIMI2`, Kalman floor, `IsfSourceTelemetry.recordCalcPath`, iOS `APS=true`.

### Preuves
```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCacheTest'
  → 7/7 (0 skipped, 0 failures)
```

### Questions ouvertes
- `recordCalcPath` / `isf_calc_path` + `isf_cache_size` restent sur le tip reference.

## EN

Lot **P0.2** only.

- **Clinical** = reference `origin/dev_OAPSAIMI` @ **`dd9979ca4d`** (unchanged on tip `c5db5a0333`).
- **Wiring** = study tip after #71: **commonMain** + plugin field (`private val dynIsfCache = DynIsfCache()`), **not Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Evidence = **`:plugins:aps:jvmTest`** → DynIsfCacheTest **7/7**.

Not a blind Hilt/javax/`TreeMap`/`@Synchronized` copy.

### Study re-check
- **One** AIMI plugin class: androidMain `OpenAPSAIMIPlugin` (Metro `@Inject` `@SingleIn`). No second Android copy.
- `DynIsfCache` consumers: **this plugin only**. `DetermineBasalAIMI2` does not own the store (dd9979ca4d hunks were telemetry).
- Sibling pattern: `IsfBlender` / `IsfAdjustmentEngine` = commonMain, plugin **field**, **not** Metro. `PkPdLearnedState` is Metro because **two** consumers share state — not the case here.
- Type in **commonMain** (pure, like the other ISF files).
- No `aimiWallClockMs` inside the store: times are arguments, as in the reference. Plugin keeps `dateUtil.now()`.
- No second Android-only stack, no Hilt, no `StringKey.exportable`.

### What was copied / adapted
- `DynIsfCache` → **commonMain**. `AapsLock` instead of `@Synchronized`, `MutableMap` instead of `TreeMap`. Newest = max key. `floorMod` matches `Math.floorMod` for a positive modulus.

### Call sites wired (`OpenAPSAIMIPlugin` androidMain)
1. Warm-up: `put(atMs = it.date, isfMgdl, glucoseMgdl)`.
2. `readNewestDynIsfAndRecordSource`: `newest()`; age = `now - sample.atMs`.
3. `getAverageIsfMgdl`: `averageSince(timestamp - 24h, timestamp)` on `atMs`.
4. `CALC` path: `put(atMs = timestamp, …)`; no wholesale `clear()`.
5. Background refresh: `useDbShortcut = false` + 60 s throttle — reference **write-path** behaviour (otherwise the DB shortcut still starves the store). `invoke()` keeps the shortcut (default `true`). Interval is a field, not a companion on the Metro class.

`DetermineBasalAIMI2` **untouched**. No `recordCalcPath`. No Kalman floor.

### Tests (`commonTest` + `jvmTest`)
The seven dd9979ca4d locks are in **`commonTest`**, assertions **`kotlin.test`**.

File: `plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/DynIsfCacheTest.kt`.

Task run: **`:plugins:aps:jvmTest --tests '…DynIsfCacheTest'`** → **7/7**.

### ADR 0003
`docs/adr/0003-dynisf-cache-read-path.md` is **absent** from the study tree. KDoc points at that path only, **same wording as the reference**. No ADR file added.

### Out of scope
P0.3–P0.8, `DetermineBasalAIMI2`, Kalman floor, `IsfSourceTelemetry.recordCalcPath`, iOS `APS=true`.

### Evidence
```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCacheTest'
  → 7/7 (0 skipped, 0 failures)
```

### Open questions
- `recordCalcPath` / `isf_calc_path` + `isf_cache_size` remain on the reference tip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eec64f6-64a2-4454-ac95-1b5289cfd740?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eec64f6-64a2-4454-ac95-1b5289cfd740&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

