### PR TITLE
docs(kmp): STATUS/DELTA refresh after P0.1 #71

### DIFF
--- a/_docs/kmp/AIMI_KMP_EXECUTION_PLAN.md
+++ b/_docs/kmp/AIMI_KMP_EXECUTION_PLAN.md
@@ -1,5 +1,15 @@
 # AIMI KMP — execution plan (Android + iOS)
 
+> **2026-09-06 — do not use this file as the live task list.**  
+> Next lots: [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).  
+> Snapshot: [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md).  
+> The freeze SHA `1ae418e106` and the 2026-08-28 “truth” table below are stale.  
+> Today’s study tip is `kmp-aimi-migration-study` @ `6f66e63565` (P0.1 DONE via PR #71).  
+> Today’s reference tip is `origin/dev_OAPSAIMI` @ `c5db5a0333`. The freeze tag
+> `aimi-baseline-2026-08-26` was **not** present in the clone used for that audit.
+>
+> Keep this file for the dual-platform map and the 45-step tick notes.
+
 > **Use this file to code.** The blueprint stays the architecture bible.  
 > **ADR:** [`adr-g0-defaults.md`](adr-g0-defaults.md)  
 > **AIMI freeze:** `aimi-baseline-2026-08-26` = `origin/dev_OAPSAIMI` @ `1ae418e106`  

--- a/_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md
+++ b/_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md
@@ -1,5 +1,13 @@
 # AIMI KMP/iOS — backlog d'implémentation ordonné par gates
 
+> **2026-09-06 — ce fichier reste le backlog long (M0–M12).**  
+> Pour les **prochains lots concrets**, utiliser
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).  
+> L'état vérifié est dans [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md)
+> (tip `6f66e63565` ; **P0.1 PkPdLearnedState = DONE**, PR #71).  
+> Plusieurs gates M2 (`aimi-engine` réel, replay) ne sont **pas** Done : les modules existent,
+> `evaluate()` est encore un Hold.
+
 > **Usage :** transformer l'étude d'architecture en lots livrables et vérifiables.  
 > **Règle :** une tâche n'est `Done` que si son critère d'acceptation est automatisé ou accompagné
 > d'une preuve archivée.  

--- a/_docs/kmp/AIMI_KMP_MIGRATION_BLUEPRINT.md
+++ b/_docs/kmp/AIMI_KMP_MIGRATION_BLUEPRINT.md
@@ -1,5 +1,11 @@
 # AIMI KMP/iOS — blueprint d'architecture et de migration
 
+> **2026-09-06 — architecture cible, pas l'état du code.**  
+> Snapshot vérifié : [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md)
+> (tip `6f66e63565`, P0.1 DONE).  
+> Lots suivants : [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).  
+> Les SHA ci-dessous (25 août) ne sont plus les tips.
+
 > **Statut :** document directeur consolidé, prêt pour décisions G0.  
 > **Référence auditée :** `dev_OAPSAIMI` à `06e7bc5021ca8fdd976505d1fefb03cc88681c19`.  
 > **Fondation KMP :** `kmp` à `4957c26eb85a71103e649498e7e991cb473e3098`.  

--- a/_docs/kmp/AIMI_KMP_MIGRATION_STUDY.md
+++ b/_docs/kmp/AIMI_KMP_MIGRATION_STUDY.md
@@ -13,8 +13,11 @@ Branch: `kmp-aimi-migration-study`, cut from `kmp` at `4957c26eb8`.
 Written 2026-08-25. All numbers were measured on this machine, on the branches named.
 Reference document under review: `_docs/KMP_IOS_FEASIBILITY.md` (Milos, 2026-08-05, 2115 lines).
 
-> **Mise a jour 2026-09-02, en complement de la banniere ci-dessus.** L'etat courant du portage est
-> dans [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md).
+> **Mise a jour 2026-09-06.** L'etat verifie et les lots restants sont dans
+> [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md) et
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md)
+> (tip `6f66e63565` ; P0.1 DONE via PR #71 ; l'ancien snapshot PR #69 @ `f237f2d3d0` n'est plus HEAD).
+> [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md) reste le journal des lots 0–6i, pas la source de verite.
 >
 > Sur le fond, la banniere ci-dessus a raison et ce rapport avait tort sur un point qui compte :
 > l'annexe 5 a releve la signature du modele (`modelUAM.tflite`, 4 504 octets, entree `[1,18]`

--- a/_docs/kmp/AIMI_PORT_STATE.md
+++ b/_docs/kmp/AIMI_PORT_STATE.md
@@ -1,8 +1,16 @@
 # AIMI port - state of play, and where to start next
 
+> **2026-09-06 — superseded as the live snapshot.** Re-verified status and the remaining
+> lots are in [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md) and
+> [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md).
+> Study tip today: `6f66e63565` (P0.1 `PkPdLearnedState` **DONE**, PR #71).
+> This file is still the best diary of lots 0–6i (how the tick and plugin landed). Do not
+> use its file counts, “2 files from commonMain”, or “330 tests” as today’s truth.
+> The assemble / iOS / 330-test lines below are **last-known 2026-09-03**, not re-run on
+> `6f66e63565`. The previous living-doc tip `f237f2d3d0` (PR #69) is no longer HEAD.
+
 Updated 2026-09-02, on `kmp-aimi-migration-study` at `1f6ca62fe8` (the second `kmp` merge).
-**Read this first.** It supersedes the stale parts of the older documents in this folder; each of
-those is marked below with what to still trust it for.
+**Was** “read this first” until 2026-09-06. Keep it for the lot history only.
 
 Tree is clean. `:app:assembleFullDebug` EXIT=0. `:plugins:aps:compileKotlinIosArm64` EXIT=0.
 `:plugins:aps:testAndroidHostTest` **330 tests, 0 failures**. `:ios:shell:checkMigratedModules` EXIT=0.

--- a/_docs/kmp/AIMI_PORT_VERIFICATION.md
+++ b/_docs/kmp/AIMI_PORT_VERIFICATION.md
@@ -1,8 +1,15 @@
 # AIMI port - verification against the `kmp-module-flip` checklist
 
-> **Note, 2026-09-02.** These checklist results were true at `c174fa6f69`. The two findings that
-> matter - the plugin is not registered, and the port is not wired into the app - are still true.
-> Current state is in [AIMI_PORT_STATE.md](AIMI_PORT_STATE.md).
+> **Note, 2026-09-06.** This checklist is from `c174fa6f69` (2026-08-29). It is **not**
+> current. Live status: [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md)
+> (tip `6f66e63565`, P0.1 DONE).
+>
+> The two “still true” lines from 2026-09-02 are now **false**:
+> - `OpenAPSAIMIPlugin` **is** registered (`@MetroIntKey(250)` in `androidMain`).
+> - `:plugins:aps` **is** in `ios/shell` `migratedModules`.
+>
+> The plugin is still Android-only. iOS does not run AIMI. The 2026-08-29 PASS/FAIL table
+> below is left as a historical record.
 
 
 Run 2026-08-29 on `kmp-aimi-migration-study` at `c174fa6f69` (just after the `kmp` merge).

--- a/_docs/kmp/README.md
+++ b/_docs/kmp/README.md
@@ -7,8 +7,8 @@
 
 ## Document à exécuter
 
-**Lots concrets aujourd'hui :** [`docs/kmp-migration/DELTA-remaining.md`](../kmp-migration/DELTA-remaining.md)  
-**Snapshot vérifié :** [`docs/kmp-migration/STATUS.md`](../kmp-migration/STATUS.md)
+**Lots concrets aujourd'hui :** [`docs/kmp-migration/DELTA-remaining.md`](../../docs/kmp-migration/DELTA-remaining.md)  
+**Snapshot vérifié :** [`docs/kmp-migration/STATUS.md`](../../docs/kmp-migration/STATUS.md)
 (tip `6f66e63565`, **P0.1 DONE** via PR #71 ; l'ancien tip `f237f2d3d0` / PR #69 n'est plus HEAD).
 
 [`AIMI_KMP_EXECUTION_PLAN.md`](AIMI_KMP_EXECUTION_PLAN.md) reste la carte W1–W8 / One+ / Libre 3,

--- a/_docs/kmp/README.md
+++ b/_docs/kmp/README.md
@@ -7,8 +7,12 @@
 
 ## Document à exécuter
 
-[`AIMI_KMP_EXECUTION_PLAN.md`](AIMI_KMP_EXECUTION_PLAN.md) dit quoi faire maintenant
-(semaines 1–8, One+/Libre 3, contrat KMP, go/no-go).  
+**Lots concrets aujourd'hui :** [`docs/kmp-migration/DELTA-remaining.md`](../kmp-migration/DELTA-remaining.md)  
+**Snapshot vérifié :** [`docs/kmp-migration/STATUS.md`](../kmp-migration/STATUS.md)
+(tip `6f66e63565`, **P0.1 DONE** via PR #71 ; l'ancien tip `f237f2d3d0` / PR #69 n'est plus HEAD).
+
+[`AIMI_KMP_EXECUTION_PLAN.md`](AIMI_KMP_EXECUTION_PLAN.md) reste la carte W1–W8 / One+ / Libre 3,
+pas la liste des prochains lots P0.  
 [`adr-g0-defaults.md`](adr-g0-defaults.md) fige hôte Trio, CGM One+/G7 d'abord, VirtualPump jusqu'à W8.
 
 ## Document d'architecture

--- a/docs/kmp-migration/DELTA-remaining.md
+++ b/docs/kmp-migration/DELTA-remaining.md
@@ -1,0 +1,142 @@
+# AIMI KMP — remaining delta (prioritized lots)
+
+**Verified:** 2026-09-06 (refresh post-P0.1)  
+**Base:** `kmp-aimi-migration-study` @ `6f66e63565` (PR #71 merged)  
+**Previous measurement:** PR #69 @ `f237f2d3d0` — superseded as HEAD  
+**Reference to catch:** `origin/dev_OAPSAIMI` @ `c5db5a0333`  
+**Companion:** [STATUS.md](STATUS.md)
+
+Rule: one lot is small enough to compile and (where it touches numbers) to check against a baseline. No clinical “improvements”. Medical closed-loop: move or copy behaviour, do not invent it.
+
+Do **not** start by copying `DetermineBasalAIMI2` into `:plugins:aimi-engine`. The live path is still `:plugins:aps`. The Hold stub stays Hold until a later extract lot has a real `evaluate()` with replay.
+
+**ML order (REFERENCE #70 §6, user-confirmed — do not invert):** SMB = TFLite first, then `AimiNeuralNetwork` + CSV. Basal = heuristic `BasalLearner` first, then NN + CSV. **No live TFLite on basal.**
+
+**KMP method:** adapt to Metro / sourcesets / `commonMain` vs `androidMain` already on this study. Paste-from-`dev_OAPSAIMI` is wrong. See STATUS §2.7.
+
+---
+
+## How to read the priorities
+
+| Priority | Meaning |
+|---|---|
+| **P0** | Reference AIMI moved. Study does not have it. Dose / safety risk if we keep coding as if the trees match. |
+| **P1** | Unblocks a later move (tick toward commonMain, or honest tests). |
+| **P2** | Product / Android-only surface. Does not block iOS engine extract. |
+| **P3** | iOS / Native engine. Only after P0–P1, or in parallel on ports that do not touch the tick. |
+| **P4** | Later (CGM drivers, iOS master app, full product parity). |
+
+---
+
+## P0 — catch `dev_OAPSAIMI` (clinical delta)
+
+These landed on the reference between 2026-09-01 and 2026-09-06. **P0.1 is on this tip.** The rest are not (except the inline max-SMB ladder).
+
+Do remaining lots as **separate lots**. Each lot: copy from `origin/dev_OAPSAIMI`, adapt only KMP primitives already used in `:plugins:aps` (`aimiWallClockMs`, `AapsLock`, kotlinx time, Metro not Hilt/javax if the file has `@Inject`), compile `:plugins:aps`, then `:app:assembleFullDebug` if the lot claims the plugin is live. If the file has tests on reference, bring the tests in the same lot.
+
+| Lot | Files on reference | Status | Gate / notes |
+|---|---|---|---|
+| **P0.1** | `pkpd/PkPdLearnedState.kt` + call sites on the two `PkPdIntegration` **instances** | **DONE** — PR #71 @ `6f66e63565` | Shared holder in **commonMain**, Metro `@SingleIn(AppScope)`, `@Inject`. One class, two instances (plugin reader + tick learner). Claimed: `compileAndroidMain` SUCCESS; `PkPdLearnedStateIntegrationTest` 14/14; `PkpdPresetProfilesLearnedGenerationTest` 3/3. `:app:assembleFullDebug` **not re-run**. |
+| **P0.2** | `ISF/DynIsfCache.kt` + `DynIsfCacheTest` | **Pending.** In flight on another cloud (PR #72). **Do not start implementing it here.** | Study still has only a “cache empty” warning. No `class DynIsfCache`. |
+| **P0.3** | `ISF/ObservedSensitivityMeter.kt` + test | Pending | New 2026-09-04. Wire only the same call sites as reference. |
+| **P0.4** | `ISF/CommandedIsf.kt` + `CommandedIsfOrderTest` | Pending | New 2026-09-06. “Read the instrument before the brake.” |
+| **P0.5** | `smb/MaxSmbLadder.kt` + the two ladder tests | Pending | Likely an extract. If study’s inline ladder already matches, extract only. If reference changed the rise rule (`f03fa321a6`), take that rule, do not mix. |
+| **P0.6** | `patient/HarmoniaCounterfactual.kt` + `quality/InsulinOriginMeter.kt` + their tests | Pending | Pair from `da9bc789ce`. |
+| **P0.7** | `ml/SmbTrainingRowBuffer.kt` + test | Pending | New 2026-09-05. Android file store can stay androidMain; buffer math can be commonMain if it is pure. |
+| **P0.8** | Tick / plugin call-site sync | Pending | **Do not replace the whole file.** Study already has KMP seams (ports, `AimiJson`, TextRef) plus the P0.1 constructor pass-through. Cherry-pick the clinical hunks onto the study file. Line count today: study 18 888 vs reference 19 312 (**+424**). |
+
+**P0.8 is the hard lot.** Treat P0.2–P0.7 as the types the hunks will need.
+
+Also bring, with P0.8 if they are in those commits: late-fat damping floor (`81e370bfbf`) and “training corpus in the support package” (`02c90656b1`).
+
+**Out of P0:** glucose re-grid `c5db5a0333` is a **loop** change, not only AIMI. Assign it only if the orchestrator wants loop parity too.
+
+---
+
+## P1 — make the Android tick honest and movable
+
+| Lot | Work | Gate | Why this size |
+|---|---|---|---|
+| **P1.1** | Fix the stale header in `ports/AimiCollaboratorPorts.kt` (“no implementation yet”) | docs / comment only | Still stale on this tip (PR #69’s comment fix never landed). Stops the next agent from re-doing finished ports. |
+| **P1.2** | Inventory remaining `android.*` / `java.time` / `File` / `Atomic*` in `DetermineBasalAIMI2` | a checklist in this folder or a short appendix | Needed before any “move DB2 to commonMain” claim. Re-measure; do not assume the old “16 imports” list. |
+| **P1.3** | Replace `java.time` in DB2 with the same `kotlinx.datetime` aliases already used by collaborators | compile | Three sites were already known (PORT_STATE 6d). Re-measure. |
+| **P1.4** | Rewire remaining `File` / `Environment` uses onto `AimiStorage` | compile | `AimiStorageHelper` stays androidMain. |
+| **P1.5** | Drop or wrap `Context` in DB2 | compile | Same pattern as `AimiEmergencySos`: Context stays in the Android impl. |
+| **P1.6** | Port the **pure** AIMI tests from reference whose subject is already in `commonMain` | `testAndroidHostTest` for each batch of ≤15 files | 259 → 13 is still the honesty gap. Do **not** land all 259 in one lot. |
+| **P1.7** | After P0 + P1.3–P1.5: try `DetermineBasalAIMI2` in `commonMain` again | `:plugins:aps:compileKotlinIosArm64` **and** `:app:assembleFullDebug` | Remaining wall is platform types in the tick itself. If it fails, paste the compiler list into STATUS; do not guess a 20-file move. |
+
+`:app:assembleFullDebug` remains the Metro-binding gate. `:plugins:aps:compileAndroidMain` alone can hide a missing `@ContributesBinding`. That assemble is **last-known** (2026-09-03), not proven on `6f66e63565`.
+
+---
+
+## P2 — leftover product surface (does not block the engine)
+
+| Lot | Work | Decision required |
+|---|---|---|
+| **P2.1** | 17 staging View Activities | Ask before port-as-View. Prefer Compose or drop, like `AuditorReportActivity`. |
+| **P2.2** | Meal Advisor camera / Context Activity | Needs a host screen in current `:ui` navigation. |
+| **P2.3** | `AimiLoopRuntimeGuard` / `AimiSmbSimulator` / diagnostics | Confirm they are still called on reference. If dead, do not port. |
+| **P2.4** | `plugins/source` : remove `includeDagger()` by converting **7** `javax.inject` Dexcom/Libre files to Metro | `:app:assembleFullDebug` | Standing merge conflict with upstream. |
+
+---
+
+## P3 — iOS / Native engine (after P0, or ports only)
+
+`:plugins:aimi-*` already link on iOS. Filling them is **not** the same as making the Android plugin call them.
+
+| Lot | Work | Gate |
+|---|---|---|
+| **P3.1** | Keep `HoldAimiEngine`. Add one **read-only** capture: build `AimiInputSnapshot` from the Android tick inputs (no dose change) | unit test: snapshot round-trip |
+| **P3.2** | iOS `actual` for `AimiStorage` (documents directory) | `compileKotlinIosArm64` |
+| **P3.3** | iOS UAM adapter (TFLite C / chosen runtime) behind `MlUamPort` or today’s handler interface | same UAM vector → same double as Android, on a fixture |
+| **P3.4** | HealthKit behind `AimiHealthContext` / `AimiPhysioSource` | mapping table: HR, steps, **HRV RMSSD vs SDNN**, sleep, skin temp. Missing/Denied/Stale, not silent zero |
+| **P3.5** | Only after replay exists: move `evaluate()` body. Until then the Android plugin remains the only dose path | JVM + iOS simulator parity on a frozen corpus |
+
+**Do not** turn `IosClientConfig.APS` to `true`. That is an iOS **master** app (pumps, BLE heartbeat, Critical Alerts). Out of scope for these lots.
+
+---
+
+## P4 — later
+
+| Lot | Work |
+|---|---|
+| **P4.1** | Flip `:plugins:dexcom_oneplus`, `:plugins:libre3`, `:plugins:libkeks` only when a KMP host needs parse/policy. GATT/NFC stay platform. |
+| **P4.2** | iOS master (SC-C): pump drivers, `bluetooth-central` restore, APNs / Critical Alerts. Not “the next AIMI lot”. |
+| **P4.3** | Fill `:plugins:aimi-learning` / `:plugins:aimi-io` when trainers leave WorkManager. Empty `hello()` is fine until then. |
+| **P4.4** | Trio / XCFramework product wrap — only after P3.5 is real. |
+
+---
+
+## Suggested assignment order for the orchestrator
+
+1. **P0.1 = done.** Do not re-open it.  
+2. **P0.2 = in flight elsewhere.** Wait; do not start a second `DynIsfCache`.  
+3. **P0.3 → P0.7** (one agent or one agent per file; no shared edits to DB2 until P0.8).  
+4. **P0.8** (one agent, after the remaining types exist).  
+5. **P1.1** (minutes). **P1.6** can run in parallel on commonMain subjects.  
+6. **P1.2–P1.5** then **P1.7** (tick toward commonMain).  
+7. **P3.1** can start once P0.8 is merged (capture only).  
+8. **P2** and **P4** when product asks.
+
+---
+
+## Recurring failure shapes (still true)
+
+Copy these into every lot brief:
+
+1. A class that implements a port but lacks `@ContributesBinding(AppScope::class)` compiles in `:plugins:aps` and fails only in `:app`.  
+2. `*ResId: Int` almost always became a `TextRef`.  
+3. `Atomic*` / `synchronized` → `AapsLock`; `System.currentTimeMillis()` → `aimiWallClockMs()`; `String.format` → `aimiFmtN`; `java.time` → `kotlinx.datetime`.  
+4. Duplicate top-level types (by **declaration**, not filename).  
+5. Capabilities dropped in the KMP rewrite (restore from `dev_OAPSAIMI` only after confirming they still exist there).  
+6. Do not rebase `dev_OAPSAIMI` onto this branch. Cherry-pick or copy files. Strategy S2 still stands.  
+7. Do not paste Hilt / `src/main` / javax `@Singleton` from the reference. Metro + sourcesets on this study are the host world (STATUS §2.7).
+
+---
+
+## What this backlog is not
+
+- Not a new 12-milestone plan. M0–M12 in `_docs/kmp/AIMI_KMP_IMPLEMENTATION_BACKLOG.md` is still the long architecture. **These lots are the next concrete work.**
+- Not permission to change SMB / basal / ISF formulae while “cleaning”.
+- Not a claim that iOS can close the loop.
+- Not permission to implement P0.2 while another agent already has it.

--- a/docs/kmp-migration/README.md
+++ b/docs/kmp-migration/README.md
@@ -1,0 +1,12 @@
+# AIMI KMP migration — live notes
+
+Start here. Older studies live under `_docs/kmp/` and are history.
+
+| File | What it is |
+|---|---|
+| [STATUS.md](STATUS.md) | Verified snapshot (date-stamped) |
+| [DELTA-remaining.md](DELTA-remaining.md) | Prioritized remaining lots |
+
+Last verification: **2026-09-06** (refresh after P0.1 / PR #71) on `kmp-aimi-migration-study` @ `6f66e63565` vs `origin/dev_OAPSAIMI` @ `c5db5a0333`.
+
+The previous living-doc measurement was PR #69 @ `f237f2d3d0`. That tip is **behind** today’s HEAD (kmp merge + P0.1).

--- a/docs/kmp-migration/STATUS.md
+++ b/docs/kmp-migration/STATUS.md
@@ -1,0 +1,229 @@
+# AIMI / OpenApsAIMI KMP status
+
+**Verified:** 2026-09-06 (refresh post-P0.1)  
+**This branch tip (when measured):** `kmp-aimi-migration-study` @ `6f66e63565` (2026-09-06, merge of PR #71)  
+**Previous living-doc measurement:** PR #69 @ `f237f2d3d0` (2026-09-03 tip). **Do not treat that SHA as HEAD.**  
+**Reference tip:** `origin/dev_OAPSAIMI` @ `c5db5a0333` (2026-09-06)  
+**Merge-base:** `283a184f60` (2026-08-25, nightscout dependabot)  
+**Ahead / behind reference:** study is **984** unique commits ahead, **2746** behind (re-counted today).
+
+This file is the live snapshot. Older notes under `_docs/kmp/` are history. See [DELTA-remaining.md](DELTA-remaining.md) for the next lots.
+
+**Gates — last-known, not re-proven on this tip.** `:app:assembleFullDebug`, `:plugins:aps:compileKotlinIosArm64`, and the whole-module “330 tests / 0 failures” claim were last written green on **2026-09-03** in `_docs/kmp/AIMI_PORT_STATE.md`, measured at an older SHA. The tip has since moved (`kmp` merge `196179309b` + fallout `9e2b5bd40e` + P0.1 `6f66e63565`). **Do not claim those gates green without a fresh run.** P0.1 itself claimed `:plugins:aps:compileAndroidMain` SUCCESS and two targeted host-test classes green; it did **not** re-run `:app:assembleFullDebug`.
+
+---
+
+## 1. Two-line summary
+
+The Android AIMI **plugin path is live in the KMP tree**: `OpenAPSAIMIPlugin` sits in `androidMain` and registers itself with `@MetroIntKey(250)`. A large share of AIMI math is already in `commonMain`. **P0.1 `PkPdLearnedState` is DONE** (PR #71, this tip).
+
+That is **not** “AIMI runs on iOS”. The ~18 888-line tick is still Android-only. The dedicated `:plugins:aimi-engine` module is still a **Hold stub**. iOS is still a **follower** (`APS = false`). And `dev_OAPSAIMI` still has later clinical files that study does not (`DynIsfCache`, `CommandedIsf`, …). **P0.2+ stay pending.** `DynIsfCache` is in flight on another agent — do not start a second copy.
+
+---
+
+## 2. What is already shared (verified)
+
+### 2.1 Repo-wide KMP spine
+
+| Item | Count today | Notes |
+|---|---:|---|
+| Modules with `kotlin("multiplatform")` | **34** | Same count as PR #69; includes `:plugins:aps`, `:plugins:aimi-*`, `:ios:shell` |
+| `commonMain` Kotlin files (whole repo) | **2232** | Was 2203 at `f237f2d3d0`. Rise is the later `kmp` merge, not AIMI |
+| `iosMain` Kotlin files (whole repo) | **84** | Was 75. Still **none** are `openAPSAIMI` |
+| `expect` declarations (repo) | **14 files** | Was 11. UI/platform. **Zero** in AIMI |
+| iOS app | **yes** | `ios/app/AAPSClient.xcodeproj` + `ios/shell` |
+| iOS product kind | **follower** | `IosClientConfig.APS = false`, `PUMPCONTROL = false`, `PUMPDRIVERS = false`, `AAPSCLIENT = true` |
+
+`:ios:shell` `migratedModules` already lists `:plugins:aps` and all five `:plugins:aimi-*` modules.
+
+### 2.2 AIMI inside `:plugins:aps`
+
+Package: `app.aaps.plugins.aps.openAPSAIMI`.
+
+| Source set | `.kt` files | Code lines | Role |
+|---|---:|---:|---|
+| `commonMain` | **340** | **47 630** | +1 file / +~76 LOC vs PR #69: `pkpd/PkPdLearnedState.kt` |
+| `androidMain` | **109** | **50 576** | Tick, plugin, Health Connect, TFLite/ONNX, trainers, Compose, SOS |
+| `iosMain` | **0** | 0 | No AIMI actuals. Only `loop/IosLoopNotifier.kt` exists in this module |
+| `androidHostTest` (AIMI package) | **13** | — | Was 11. + `PkPdLearnedStateIntegrationTest` + `PkpdPresetProfilesLearnedGenerationTest` |
+| `commonTest` (AIMI) | **0** | — | The two `commonTest` files in `:plugins:aps` are loop/TDD, not AIMI |
+
+`commonMain` AIMI has **no** `android.*` / `java.io` / `org.json` imports. JSON construction uses the local `AimiJson` / `JsonObj` shim over kotlinx serialization.
+
+Largest first-level `commonMain` packages (file count):
+
+`physio` 51 · `advisor` 34 · `pkpd` **30** · `safety` 24 · `recursive` 22 · root 20 · `patient` 19 · `wcycle` 10 · `scenario` / `basal` / `autodrive` 9 each.
+
+WCycle **is still in live `commonMain`** (10 files). Commit `a4a303eac6` only deleted **staging copies**.
+
+### 2.3 Dedicated AIMI KMP modules (scaffolding only)
+
+These compile for JVM + `iosArm64` + `iosSimulatorArm64` and are linked by `ios/shell`. **`:plugins:aps` does not depend on them.** Nothing in the running plugin calls them.
+
+| Module | What is actually there |
+|---|---|
+| `:plugins:aimi-contracts` | Envelope DTOs (`AimiInputSnapshot`, `AimiTickResult`, …) + `hello()` |
+| `:plugins:aimi-engine` | `AimiEngine.evaluate(...)` implemented only by `HoldAimiEngine` → always `Hold("ENGINE_NOT_EXTRACTED")` |
+| `:plugins:aimi-learning` | `hello()` |
+| `:plugins:aimi-io` | `hello()` |
+| `:plugins:aimi-testkit` | empty snapshot helpers + a hello test |
+
+So: **module graph for an extracted engine exists. The engine does not.**
+
+### 2.4 Plugin registration, ports, P0.1 holder
+
+- `OpenAPSAIMIPlugin` is in `androidMain`, Metro `@MetroIntKey(250)`, `@Inject` constructor.
+- `ApsPluginRegistrations` still lists only AMA / SMB / AutoISF (210–230). AIMI is **not** in that object. That is fine: AIMI self-registers.
+- Eight collaborator ports in `ports/AimiCollaboratorPorts.kt` **do have Android implementations**. The file header that still says “no implementation yet” is **stale** (P1.1 still pending; docs-only lot does not touch it).
+- `ports/Ports.kt` (`Clock`, `PkpdPort`, `MlUamPort`, actuators) is a **planned** extract surface. The live tick does not call it.
+- Storage seam exists: `AimiStorage` (common) / `AndroidAimiStorage` + `AimiStorageHelper` (android).
+- UAM model is still `app/src/main/assets/modelUAM.tflite`. `AimiModelHandler` is androidMain + TensorFlow Lite.
+
+**P0.1 DONE (PR #71, this tip).** `PkPdLearnedState` lives in `commonMain` (`plugins/aps/src/commonMain/.../pkpd/PkPdLearnedState.kt`). Metro `@SingleIn(AppScope::class)` + `@Inject` (same pattern as `PhysioAggregator`). `@Synchronized` (JVM) → `AapsLock`. Study has **one** `PkPdIntegration` class (`androidMain`) and **two instances** of that type: `OpenAPSAIMIPlugin` ≈ L405 (reader) and `DetermineBasalaimiSMB2` in `DetermineBasalAIMI2.kt` ≈ L10339 (learner). Same process-wide holder is constructor-injected into both. Learned fields are shared; ISF fusion, SMB damping, `recentBolusSamples`, structural config stay per consumer.
+
+P0.1 test claim (not re-run in this docs lot): `PkPdLearnedStateIntegrationTest` 14/14 and `PkpdPresetProfilesLearnedGenerationTest` 3/3 on `:plugins:aps:testAndroidHostTest`. `:app:assembleFullDebug` **was not run** on that lot.
+
+### 2.5 CGM plugins that AIMI cares about
+
+| Module | KMP? | Files | iOS |
+|---|---|---:|---|
+| `:plugins:source` | **yes** | Dexcom ONE+ / Libre 3 **Activities stay androidMain** | no drivers |
+| `:plugins:dexcom_oneplus` | **no** (`com.android.library`) | 72 kt | no |
+| `:plugins:libre3` | **no** | 107 kt | no |
+| `:plugins:libkeks` | **no** | 24 | no |
+
+`:plugins:source` still has Metro `includeDagger()` for **7** `javax.inject` leftovers (PORT_STATE said 14; that number is wrong).
+
+### 2.6 ML pipeline (user-confirmed — REFERENCE #70 §6)
+
+Do **not** contradict this. Cartography lives in PR #70 (`docs/kmp-migration/REFERENCE-dev_OAPSAIMI-openapsaimi.md` on `dev_OAPSAIMI`); the order was re-checked in code and confirmed by the user.
+
+| Path | First value | Then | Live TFLite? |
+|---|---|---|---|
+| **SMB** | TFLite (`AimiUamHandler.predictSmbUam` / `modelUAM.tflite`) | `AimiNeuralNetwork` (`AimiSmbTrainer`) refine + train on `oapsaimiML2_records.csv` | **Yes** (Android-only) |
+| **Basal** | Heuristic `BasalLearner` / internal factor | Same house JSON net trains on `basal_adaptive_records.csv` | **No.** `model.tflite` is a commented leftover |
+
+Refine + train on the SMB hot path sit behind `OApsAIMIMLtraining` (default **false**). TFLite / ONNX are Android-only. The portable piece is the house JSON + CSV net. This is **not** “TFLite first on both paths”.
+
+### 2.7 How to port on this study (one-liner)
+
+Ports on `kmp-aimi-migration-study` must follow the **Milos KMP world already on this tree** (Metro, `commonMain` / `androidMain` / `iosMain` sourcesets, existing seams). Paste-from-`dev_OAPSAIMI` (Hilt, `src/main`, javax `@Singleton`, `org.json`, JVM-only locks) is the wrong method. A full patterns map may land in a sibling doc under this folder if another agent owns it.
+
+---
+
+## 3. What is partial
+
+| Area | Shared today | Still Android | iOS |
+|---|---|---|---|
+| Dose tick `DetermineBasalaimiSMB2` | many callees in commonMain | **the 18 888-line class itself** (`Context`, `File`, `java.time`, `Atomic*`) | not compiled |
+| Plugin shell | some prefs/keys | `OpenAPSAIMIPlugin` 2 339 lines | not registered; `APS=false` |
+| Learned PK/PD | **`PkPdLearnedState` in commonMain** | two `PkPdIntegration` instances in androidMain | holder is common; consumers are not |
+| UAM / TFLite | schema + `aimiNeuralNetwork` math in commonMain | `AimiModelHandler`, model asset, LiteRT | no adapter |
+| On-device trainers | some math | WorkManager workers, file stores | no |
+| Health / steps | snapshot types + ports | Health Connect repo/workers | no HealthKit |
+| Auditor / TPO | models, some rules | orchestrators, notifications, LLM | chip port is common; impl android |
+| Meal vision | models / prompt parse in commonMain | HTTP providers, Activities parked | no |
+| Compose Control Center / PKPD / Hormonitor | some types | screens in androidMain | no |
+| Extracted `evaluate()` | interface + Hold stub | unused | unused |
+
+**A `commonMain` compile of `:plugins:aps` is not “AIMI runs on Native”.** iOS compiles the shared callees and `IosLoopNotifier`. It does not compile the tick.
+
+---
+
+## 4. What remains Android-only or parked
+
+### 4.1 Live androidMain (must stay or be seamed)
+
+The tick and the plugin. Health Connect. TFLite / ONNX. Autodrive / basal trainers and workers. SOS SMS. Compose screens. File-backed history readers. Phone step services.
+
+### 4.2 Staging leftovers (17 Kotlin files)
+
+`_docs/kmp/staging/openAPSAIMI-android-wip/` is **not** on any source set. Remaining files are legacy View Activities and a few support types (same list as PR #69). They do **not** block the plugin from compiling.
+
+---
+
+## 5. Diff vs `dev_OAPSAIMI` (plugin area)
+
+Reference still uses `plugins/aps/src/main/...` (plain Android). Study split that tree into `commonMain` / `androidMain`.
+
+PR #69 basename counts (421 both / 28 only-ref / 37 only-study) were measured at `f237f2d3d0`. They were **not** re-diffed file-by-file today. After P0.1, `PkPdLearnedState.kt` is **no longer** “only on reference”.
+
+### 5.1 Only on reference — remaining clinical / extract files
+
+Study still has **no** `class DynIsfCache` (plugin only has a “cache empty” warning). `DetermineBasalAIMI2.kt` does **not** mention the other names below (except the inline max-SMB ladder tags):
+
+| File | First landed on reference | Status on study |
+|---|---|---|
+| `pkpd/PkPdLearnedState.kt` | 2026-09-01 `0761e9c00a` | **DONE** — commonMain, PR #71 |
+| `ISF/DynIsfCache.kt` | 2026-09-03 `dd9979ca4d` | **Pending (P0.2).** In flight elsewhere. Do not start a second implementation. |
+| `ISF/ObservedSensitivityMeter.kt` | 2026-09-04 `eb84e078f5` | Pending (P0.3) |
+| `ISF/CommandedIsf.kt` | 2026-09-06 `db21308e6c` | Pending (P0.4) |
+| `smb/MaxSmbLadder.kt` | 2026-09-05 `f03fa321a6` | Pending (P0.5). Logic still **inline** in study DB2 |
+| `patient/HarmoniaCounterfactual.kt` | 2026-09-05 `da9bc789ce` | Pending (P0.6) |
+| `quality/InsulinOriginMeter.kt` | 2026-09-05 `da9bc789ce` | Pending (P0.6) |
+| `ml/SmbTrainingRowBuffer.kt` | 2026-09-05 `7f8aa0109c` | Pending (P0.7) |
+
+### 5.2 Only on reference — Activities / DI still parked on study
+
+The 17 staging files, plus `AuditorReportActivity` / `AuditorStatusIndicator` (already replaced on study by the Overview chip), `AIMIStepsProviderModuleMTR` (Hilt module; study is Metro), and `AIMI_ORCHESTRATION_ROADMAP.md`.
+
+### 5.3 Tick / plugin size drift
+
+| File | Study today | Reference (PR #69) | Δ (ref − study) |
+|---|---:|---:|---:|
+| `DetermineBasalAIMI2.kt` | 18 888 | 19 312 | **+424** |
+| `OpenAPSAIMIPlugin.kt` | 2 339 | 2 333 | −6 |
+
+P0.1 added constructor pass-through only on the tick (no P0.8 clinical hunks). Reference line counts were **not** re-measured today.
+
+Recent reference AIMI commits after the old study tip `f237f2d3d0` are unchanged: observed sensitivity, late-fat floor, confirmed-rise SMB ceiling, Harmonia counterfactual, SMB training buffer, instrument-before-brake, training corpus in the support package, then loop glucose re-grid `c5db5a0333` (not only AIMI).
+
+### 5.4 Tests
+
+| | Reference `src/test/.../openAPSAIMI` | Study AIMI `androidHostTest` |
+|---|---:|---:|
+| Files | **259** (PR #69 count) | **13** |
+
+Almost the whole AIMI test corpus is **not** on the KMP study branch. PORT_STATE’s “330 tests” was the **whole `:plugins:aps` module**, last claimed 2026-09-03, **not re-counted as methods today**, and **not re-run on tip `6f66e63565`**.
+
+---
+
+## 6. Corrections to older docs
+
+| Old claim | Reality 2026-09-06 (this tip) |
+|---|---|
+| Living snapshot is `f237f2d3d0` / PR #69 | **False.** HEAD is `6f66e63565`. PR #69 was never merged; its numbers are the previous measurement. |
+| “P0.1 `PkPdLearnedState` unfinished / two-copy bug unproven” (PR #69 §7.4) | **False.** Merged via PR #71. One class, two instances, shared holder in commonMain. |
+| “DetermineBasalAIMI2 is 2 files from `commonMain`” (`AIMI_PORT_STATE` §1) | The tick **compiles in `androidMain`**. It is not in `commonMain`. |
+| “Plugin is not registered” (`AIMI_PORT_VERIFICATION`) | **False.** `@MetroIntKey(250)` in `androidMain`. |
+| “AIMI commonMain 356 / androidMain 100” (PORT_STATE 6h) | **340 / 109** for the `openAPSAIMI` package today. |
+| “`aimi-engine` is the place the tick lives” | Modules exist. **Evaluate is Hold.** Live tick is still `:plugins:aps`. |
+| “No iOS app” (Aug 25 study) | Retired. Follower app exists. Master on iPhone does not. |
+| Freeze tag `aimi-baseline-2026-08-26` = `1ae418e106` | Do not treat that SHA as today’s reference. Today’s reference tip is `c5db5a0333`. |
+| TFLite-first on **both** SMB and basal | **False.** See §2.6. Basal has **no** live TFLite. |
+| WCycle removed | Staging copies removed. **Live WCycle sources remain.** |
+| assemble / iOS / “330 tests” green **on this tip** | **Unproven.** Last written green: 2026-09-03, older SHA. |
+
+---
+
+## 7. Uncertainties (do not guess)
+
+1. **Build gates were not re-run on `6f66e63565`.** Last written green assemble / iOS klib / 330 host tests: 2026-09-03. P0.1 claimed only `compileAndroidMain` + two test classes.
+2. **Numeric fidelity** of overlapping files vs current `dev_OAPSAIMI` was not re-diffed today.
+3. **`MaxSmbLadder`:** extract vs behaviour change. Study still has ladder tags inside DB2. Compare before porting.
+4. **`HarmoniaDecisionEngine`:** no file of that name on either tip. Tests on reference use that name; implementation is `HarmoniaHarmonizer` / types in `HarmoniaDecision.kt` / logic inside DB2.
+5. **Clinical behaviour:** this study branch and `dev_OAPSAIMI` are **not** the same AIMI. P0.1 closed the shared PK/PD holder. P0.2–P0.8 and the ~424-line tick delta remain.
+6. **`DynIsfCache`:** absent on this tip. Another cloud is implementing P0.2. This docs lot does not start it.
+
+---
+
+## 8. What “done” would mean (unchanged goal)
+
+Android + iOS from **one** `commonMain` engine, no clinical rewrite.
+
+Today:
+
+- Android plugin path: **reachable in a KMP app graph** (last-known assemble green — **not** re-proven on this tip).
+- Shared math: **large, real, not extracted**. Shared learned DIA/peak: **landed**.
+- iOS: **shared spine + follower UI**. No AIMI tick. No pump. No HealthKit. No TFLite.
+- Extracted engine API: **stub**.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **docs only**. Aucun changement clinique / algorithme. Ne touche pas P0.2 `DynIsfCache` (déjà en cours ailleurs, PR #72).

Met à jour les docs vivants pour qu’ils correspondent au tip **aujourd’hui** :

- Branche : `kmp-aimi-migration-study` @ **`6f66e63565`** (merge PR #71)
- Référence : `origin/dev_OAPSAIMI` @ `c5db5a0333`
- Ahead / behind (recompté) : **984** / **2746**
- L’ancien snapshot PR #69 @ `f237f2d3d0` n’est plus HEAD (merge `kmp` + P0.1)

**P0.1 PkPdLearnedState = DONE.** Holder partagé en `commonMain`, Metro `@SingleIn`, deux instances `PkPdIntegration`. Claim tests du lot #71 (14/14 + 3/3). `:app:assembleFullDebug` **non relancé**.

**Gates assemble / iOS / 330 tests :** last-known 2026-09-03, **pas** relancés sur ce tip. Pas de claim green sans preuve.

**ML (REFERENCE #70 §6, confirmé utilisateur) :**
- SMB : TFLite d’abord, puis `AimiNeuralNetwork` + CSV
- Basale : heuristique `BasalLearner` d’abord, puis NN + CSV — **pas** de TFLite basal vivant

P0.2+ restent pending. Un one-liner rappelle que les ports doivent suivre le monde KMP Milos déjà sur study (Metro, sourcesets) — pas un collage depuis `dev_OAPSAIMI`.

Bannières `_docs/kmp/*` pointent vers `docs/kmp-migration/`.

**Review follow-up:** `_docs/kmp/README.md` links now use `../../docs/kmp-migration/…` (the previous `../kmp-migration/…` resolved to a missing `_docs/kmp-migration/` folder).

## EN

Documentation-only refresh of the living snapshot after P0.1 merged.

- New: `docs/kmp-migration/STATUS.md`, `DELTA-remaining.md`, `README.md`
- Banners on stale `_docs/kmp/` files so they no longer claim “read this first”, the old tip `f237f2d3d0`, or unfinished P0.1
- README relative paths from `_docs/kmp/` now go through the repo root into `docs/kmp-migration/`

No algorithm files touched. P0.2 left to the other cloud.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f6b8a5c-1181-4bbf-b5ca-5639ca2e56a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f6b8a5c-1181-4bbf-b5ca-5639ca2e56a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

