### PR TITLE
P0.3 — ObservedSensitivityMeter: passive outcome ISF instrument on the KMP study branch

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -51,6 +51,7 @@ import app.aaps.plugins.aps.openAPSAIMI.basal.T3cAutodriveBasalBridge
 import app.aaps.plugins.aps.openAPSAIMI.basal.T3cTrajectoryContext
 import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveState
 import app.aaps.plugins.aps.openAPSAIMI.carbs.CarbsAdvisor
+import app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeter
 import app.aaps.plugins.aps.openAPSAIMI.ISF.SensitivityRatioEstimator
 import app.aaps.core.interfaces.ui.UiInteraction
 import app.aaps.plugins.aps.openAPSAIMI.context.ContextSnapshot
@@ -341,6 +342,44 @@ internal data class AimiDecisionContext(
         val isf_cache_key: Long? = null,
         /** Glucose the cached value was computed for (the key's within-bucket remainder). */
         val isf_cache_glucose_mgdl: Long? = null,
+        /**
+         * Sensitivity the **outcomes** imply, in mg/dL per U, measured as `-dBG / insulin absorbed`
+         * over clean falls. See `ObservedSensitivityMeter`.
+         *
+         * A fall is counted only when it lasts 30 to 120 minutes, drops at least 25 mg/dL, has no
+         * carbs on board and no meal in the 30 minutes before it, shows a mean rate of glucose
+         * appearance below 0.30 mg/dL/min, and cost at least 0.8 U. The insulin credited is the fall
+         * in IOB, plus the basal above the profile rate, plus the SMBs decided inside the window.
+         *
+         * The median is `null` below three windows, never `0.0`: zero would read as a real
+         * sensitivity of zero. [isf_obs_window_count] says how far the instrument is from being able
+         * to answer.
+         *
+         * These fields are **strictly passive**. Nothing in the dosing chain reads them. They exist
+         * for one purpose: to be compared with [command_isf_mgdl], so that the question "does the ISF
+         * chain estimate the right quantity" can finally be answered from exported data.
+         *
+         * `var`, and written after this object is built, like the fields below.
+         */
+        var isf_obs_median_mgdl: Double? = null,
+        /** Same measure, night windows only (local hour 0 to 8). */
+        var isf_obs_night_median_mgdl: Double? = null,
+        /** Same measure, day windows only. */
+        var isf_obs_day_median_mgdl: Double? = null,
+        /** How many windows the look-back holds. Reported even when the median is `null`. */
+        var isf_obs_window_count: Int? = null,
+        /** How many of them are night windows. */
+        var isf_obs_night_count: Int? = null,
+        /** How many of them are day windows. */
+        var isf_obs_day_count: Int? = null,
+        /** End time of the most recent window, so a reading can be aged. */
+        var isf_obs_last_window_end_ms: Long? = null,
+        /** Sensitivity of that most recent window alone. */
+        var isf_obs_last_window_mgdl: Double? = null,
+        /** Fall of that window, mg/dL. */
+        var isf_obs_last_window_drop_mgdl: Double? = null,
+        /** Insulin credited to that window, U. */
+        var isf_obs_last_window_absorbed_u: Double? = null,
         /** Fast estimator 1: Kalman-filtered raw ISF. */
         val isf_kalman_fast_mgdl: Double? = null,
         /** Fast estimator 2: IsfAdjustmentEngine output. */
@@ -671,6 +710,16 @@ internal data class AimiDecisionContext(
             base.put("isf_age_ms", baseline_state.isf_age_ms ?: AimiJson.NULL)
             base.put("isf_cache_key", baseline_state.isf_cache_key ?: AimiJson.NULL)
             base.put("isf_cache_glucose_mgdl", baseline_state.isf_cache_glucose_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_median_mgdl", baseline_state.isf_obs_median_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_night_median_mgdl", baseline_state.isf_obs_night_median_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_day_median_mgdl", baseline_state.isf_obs_day_median_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_window_count", baseline_state.isf_obs_window_count ?: AimiJson.NULL)
+            base.put("isf_obs_night_count", baseline_state.isf_obs_night_count ?: AimiJson.NULL)
+            base.put("isf_obs_day_count", baseline_state.isf_obs_day_count ?: AimiJson.NULL)
+            base.put("isf_obs_last_window_end_ms", baseline_state.isf_obs_last_window_end_ms ?: AimiJson.NULL)
+            base.put("isf_obs_last_window_mgdl", baseline_state.isf_obs_last_window_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_last_window_drop_mgdl", baseline_state.isf_obs_last_window_drop_mgdl ?: AimiJson.NULL)
+            base.put("isf_obs_last_window_absorbed_u", baseline_state.isf_obs_last_window_absorbed_u ?: AimiJson.NULL)
             base.put("isf_kalman_fast_mgdl", baseline_state.isf_kalman_fast_mgdl ?: AimiJson.NULL)
             base.put("isf_adj_engine_mgdl", baseline_state.isf_adj_engine_mgdl ?: AimiJson.NULL)
             base.put("isf_fused_slow_mgdl", baseline_state.isf_fused_slow_mgdl ?: AimiJson.NULL)
@@ -1311,6 +1360,13 @@ class DetermineBasalaimiSMB2 @Inject constructor(
     @Inject lateinit var contextInfluenceEngine: app.aaps.plugins.aps.openAPSAIMI.context.ContextInfluenceEngine  // 🎯 Context Influence
     @Inject lateinit var physioAdapter: app.aaps.plugins.aps.openAPSAIMI.physio.AIMIInsulinDecisionAdapterMTR  // 🏥 Physiological Modulation
     @Inject lateinit var straightLineTubeAdvisor: StraightLineTubeAdvisor  // 📐 MPC-lite hypo tube + SMB-cap smoothing
+    /**
+     * Passive reference instrument. It measures the sensitivity the outcomes imply and writes it to
+     * `baseline_state` only. It is a plain private field on purpose: not @Inject, not @Singleton, so
+     * nothing else can reach it. Any new call site is a bug. See `ObservedSensitivityMeter`.
+     */
+    private val observedSensitivityMeter = ObservedSensitivityMeter()
+
     @Inject lateinit var sensitivityRatioEstimator: SensitivityRatioEstimator
     @Inject lateinit var continuousStateEstimator: app.aaps.plugins.aps.openAPSAIMI.autodrive.estimator.ContinuousStateEstimator
     @Inject lateinit var tpoOrchestrator: AimiTpo
@@ -9081,6 +9137,48 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                     lastBolusMs = ctx.iobDataArray.firstOrNull()?.lastBolusTime ?: 0L,
                 ),
             )
+        }
+
+        // Reference measurement, strictly passive. It rebuilds the sensitivity the outcomes imply,
+        // -dBG / absorbed insulin over clean falls, outside the ISF chain. No dosing decision reads
+        // it: it only reaches baseline_state, next to command_isf_mgdl, so the two can be compared.
+        runCatching {
+            val tickCalendar = Calendar.getInstance()
+            tickCalendar.timeInMillis = decisionCtx.timestamp
+            val runningTempForMeter = ctx.currentTemp
+            observedSensitivityMeter.observe(
+                ObservedSensitivityMeter.Sample(
+                    timestampMs = decisionCtx.timestamp,
+                    localHourOfDay = tickCalendar.get(Calendar.HOUR_OF_DAY),
+                    bgMgdl = decisionCtx.baseline_state.current_bg_mgdl,
+                    // Net of the profile basal: it goes negative when the loop cuts the basal for a
+                    // long time, which is why the basal integral below is needed.
+                    iobU = decisionCtx.baseline_state.iob_u,
+                    cobG = decisionCtx.baseline_state.cob_g,
+                    smbU = finalResult.units ?: 0.0,
+                    // The basal that ran is the temp in progress, not the rate this tick asks for.
+                    deliveredBasalUph =
+                        if (runningTempForMeter.duration > 0) runningTempForMeter.rate else profile.current_basal,
+                    profileBasalUph = profile.current_basal,
+                    // Previous tick's value. A one-tick lag does not matter for a threshold filter
+                    // over a 30 to 120 minute window. Do not swap this for the "used" field: it is
+                    // only set on the engaged Autodrive branch, so it would be null most of the time
+                    // and the fail-closed rule would reject every window.
+                    raMgdlPerMin = decisionCtx.baseline_state.estimated_ra_mgdl_per_min,
+                    lastBolusMs = ctx.iobDataArray.firstOrNull()?.lastBolusTime ?: 0L,
+                ),
+            )
+            val observed = observedSensitivityMeter.read(decisionCtx.timestamp)
+            decisionCtx.baseline_state.isf_obs_median_mgdl = observed.medianMgdlPerU
+            decisionCtx.baseline_state.isf_obs_night_median_mgdl = observed.nightMedianMgdlPerU
+            decisionCtx.baseline_state.isf_obs_day_median_mgdl = observed.dayMedianMgdlPerU
+            decisionCtx.baseline_state.isf_obs_window_count = observed.windowCount
+            decisionCtx.baseline_state.isf_obs_night_count = observed.nightCount
+            decisionCtx.baseline_state.isf_obs_day_count = observed.dayCount
+            decisionCtx.baseline_state.isf_obs_last_window_end_ms = observed.lastWindow?.endMs
+            decisionCtx.baseline_state.isf_obs_last_window_mgdl = observed.lastWindow?.isfMgdlPerU
+            decisionCtx.baseline_state.isf_obs_last_window_drop_mgdl = observed.lastWindow?.dropMgdl
+            decisionCtx.baseline_state.isf_obs_last_window_absorbed_u = observed.lastWindow?.absorbedU
         }
 
         decisionCtx.adjustments.dynamic_isf = AimiDecisionContext.DynamicIsf(

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/ObservedSensitivityMeter.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/ObservedSensitivityMeter.kt
@@ -1,0 +1,412 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import app.aaps.core.interfaces.concurrent.AapsLock
+import app.aaps.core.interfaces.concurrent.withLock
+
+/**
+ * Measures the insulin sensitivity that the **outcomes** imply, as `-dBG / insulin absorbed` over
+ * clean falls. It is an instrument, not a controller.
+ *
+ * ## What the number is worth, and what it is not worth
+ *
+ * Endogenous glucose production is **not** modelled. The liver keeps releasing glucose while the
+ * glucose falls, so part of the insulin that was absorbed paid for that release instead of moving
+ * the measured glucose down. The measured number is therefore a **lower bound** on the true
+ * sensitivity — but only under one condition: the profile basal must not be too high. The window
+ * credits the insulin above the profile basal, so if the profile basal itself is too high, the
+ * excess insulin it carries is never counted as a cost while its effect is still counted as a fall.
+ * The number then reads **too high**, not too low. Read it next to `command_isf_mgdl`, and read the
+ * two together, never one alone.
+ *
+ * There is no carbohydrate model, no meal model and no exercise model here. Windows with carbs on
+ * board, or with a meal in the run-up, or with a measurable rate of glucose appearance, are simply
+ * refused. The class prefers to answer nothing rather than to answer with a guess.
+ *
+ * ## Strictly passive
+ *
+ * Nothing in the dosing chain may read this. To check that, run:
+ *
+ * ```
+ * grep -rn "ObservedSensitivityMeter\|isf_obs_" plugins/aps/src/commonMain plugins/aps/src/androidMain
+ * ```
+ *
+ * It must return exactly four zones and nothing else:
+ *  1. this class,
+ *  2. the import and the field declaration in `DetermineBasalAIMI2`,
+ *  3. the one feeding block in `runAimiSnapshotMedicalJsonAndHormonitorExportStage`,
+ *  4. the `BaselineState` field declarations and their `put` lines in `toMedicalJson`.
+ *
+ * Any other line is a violation: it would mean a dose depends on a passive instrument.
+ *
+ * ## Where the filters come from
+ *
+ * The thresholds are the ones the offline corpus study used, and they are written down in
+ * [DynamicSensitivityPolicy]: at least 30 minutes, at least a 25 mg/dL fall, no carbs on board,
+ * a mean rate of appearance below 0.30 mg/dL/min, and at least 0.8 U absorbed. Here they are
+ * applied continuously, tick after tick, inside the app, so the same rule that produced the offline
+ * table also runs live.
+ *
+ * The appearance-rate filter is **fail-closed**: a window in which the rate of appearance was never
+ * known is refused, not accepted. An unverifiable filter is not a passed filter.
+ *
+ * ## No persistence
+ *
+ * Windows live in memory only. A process restart empties them, and this is a deliberate choice: the
+ * measure is cheap to rebuild and a stale file would be worse than an empty one. `isf_obs_window_count`
+ * is the witness — when it is small or zero, the medians simply have not been rebuilt yet.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `eb84e078f5` (unchanged on tip `c5db5a0333`). Study wiring matches
+ * [DynIsfCache]: commonMain, no Metro `@Inject` (one tick-owned instance, constructed as a field on
+ * `DetermineBasalaimiSMB2`). KMP adaptation only: [AapsLock] instead of `@Synchronized`
+ * (`@Synchronized` is JVM-only). Clinical formulas and filters are unchanged.
+ *
+ * @param windowRetentionMs how long a closed window is kept.
+ * @param maxWindows hard cap on the number of kept windows.
+ */
+class ObservedSensitivityMeter(
+    private val windowRetentionMs: Long = 7L * 24 * 3_600_000L,
+    private val maxWindows: Int = 256,
+) {
+
+    /**
+     * One tick of state, as the loop saw it.
+     *
+     * @param timestampMs time of the tick.
+     * @param localHourOfDay local hour, 0..23, used only to pick a [Stratum].
+     * @param bgMgdl glucose of the tick.
+     * @param iobU insulin on board at the tick, **before** the SMB this tick decides.
+     * @param cobG carbs on board at the tick.
+     * @param smbU SMB decided at this tick. It acts over the interval that follows the tick.
+     * @param deliveredBasalUph basal that was actually running over the interval that ended here.
+     * @param profileBasalUph profile basal rate for this time of day.
+     * @param raMgdlPerMin estimated rate of glucose appearance, or `null` when it is not known.
+     * @param lastBolusMs time of the last bolus of any origin.
+     */
+    data class Sample(
+        val timestampMs: Long,
+        val localHourOfDay: Int,
+        val bgMgdl: Double,
+        val iobU: Double,
+        val cobG: Double,
+        val smbU: Double,
+        val deliveredBasalUph: Double,
+        val profileBasalUph: Double,
+        val raMgdlPerMin: Double?,
+        val lastBolusMs: Long,
+    )
+
+    /** Time of day a window belongs to, chosen from the hour at the middle of the window. */
+    enum class Stratum { NIGHT, DAY }
+
+    /**
+     * One closed measurement window.
+     *
+     * @param startMs time of the first sample of the window.
+     * @param endMs time of the last sample of the window.
+     * @param minutes length of the window in minutes.
+     * @param startBgMgdl glucose at the start.
+     * @param dropMgdl fall in glucose over the window, always positive.
+     * @param absorbedU insulin credited to the window: the fall in IOB, plus the basal above profile,
+     *   plus the SMBs decided inside it.
+     * @param isfMgdlPerU the measured sensitivity, `dropMgdl / absorbedU`.
+     * @param stratum night or day, from the middle of the window.
+     */
+    data class Window(
+        val startMs: Long,
+        val endMs: Long,
+        val minutes: Double,
+        val startBgMgdl: Double,
+        val dropMgdl: Double,
+        val absorbedU: Double,
+        val isfMgdlPerU: Double,
+        val stratum: Stratum,
+    )
+
+    /**
+     * What the instrument reports for a look-back period.
+     *
+     * A median is `null` when there are fewer than [MIN_WINDOWS_FOR_MEDIAN] windows. It is never
+     * `0.0`: zero would be read as a real sensitivity of zero.
+     *
+     * @param medianMgdlPerU median over all strata.
+     * @param windowCount how many windows the period holds.
+     * @param nightMedianMgdlPerU median of the night windows.
+     * @param nightCount how many night windows, reported even when the median is `null`.
+     * @param dayMedianMgdlPerU median of the day windows.
+     * @param dayCount how many day windows, reported even when the median is `null`.
+     * @param lastWindow the most recently closed window in the period.
+     */
+    data class Reading(
+        val medianMgdlPerU: Double?,
+        val windowCount: Int,
+        val nightMedianMgdlPerU: Double?,
+        val nightCount: Int,
+        val dayMedianMgdlPerU: Double?,
+        val dayCount: Int,
+        val lastWindow: Window?,
+    ) {
+
+        companion object {
+
+            /** The reading of an instrument that has measured nothing. */
+            val EMPTY = Reading(
+                medianMgdlPerU = null,
+                windowCount = 0,
+                nightMedianMgdlPerU = null,
+                nightCount = 0,
+                dayMedianMgdlPerU = null,
+                dayCount = 0,
+                lastWindow = null,
+            )
+        }
+    }
+
+    // Dedicated lock: @Synchronized is JVM-only. Same monitor contract as the reference methods.
+    private val lock = AapsLock()
+
+    private val samples = ArrayList<Sample>()
+    private val windows = ArrayList<Window>()
+    private var lastWindowEndMs: Long = Long.MIN_VALUE
+
+    /**
+     * Feeds one tick and closes a window when one is complete.
+     *
+     * @return the window that just closed, or `null`. The return value exists for the tests; no
+     *   caller in the dosing chain may use it.
+     */
+    fun observe(sample: Sample): Window? = lock.withLock {
+        if (!sample.bgMgdl.isFinite() || sample.bgMgdl <= 0.0) return@withLock null
+        if (!sample.iobU.isFinite() || !sample.cobG.isFinite()) return@withLock null
+        if (!sample.smbU.isFinite() || !sample.deliveredBasalUph.isFinite() || !sample.profileBasalUph.isFinite()) return@withLock null
+        if (sample.raMgdlPerMin != null && !sample.raMgdlPerMin.isFinite()) return@withLock null
+        if (sample.timestampMs <= 0L) return@withLock null
+
+        val previous = samples.lastOrNull()
+        if (previous != null) {
+            // A replay, a duplicate or a clock that stepped back. Accepting it would break the
+            // ordering every accumulator below relies on.
+            if (sample.timestampMs <= previous.timestampMs) return@withLock null
+            // A hole means the basal integral over the hole is unknown, so every window that would
+            // span it is wrong. Start again from here.
+            if (sample.timestampMs - previous.timestampMs > MAX_GAP_MS) samples.clear()
+        }
+
+        samples.add(sample)
+        val oldestKept = sample.timestampMs - BUFFER_MS
+        while (samples.isNotEmpty() && samples[0].timestampMs < oldestKept) samples.removeAt(0)
+        while (samples.size > MAX_SAMPLES) samples.removeAt(0)
+
+        val window = closeWindow() ?: return@withLock null
+        windows.add(window)
+        lastWindowEndMs = window.endMs
+        val oldestWindowKept = window.endMs - windowRetentionMs
+        while (windows.isNotEmpty() && windows[0].endMs < oldestWindowKept) windows.removeAt(0)
+        while (windows.size > maxWindows) windows.removeAt(0)
+        window
+    }
+
+    /**
+     * Reads the instrument over `(nowMs - lookbackMs, nowMs]`.
+     *
+     * Returns [Reading.EMPTY] when the period holds no window.
+     */
+    fun read(nowMs: Long, lookbackMs: Long = DEFAULT_LOOKBACK_MS): Reading = lock.withLock {
+        val from = nowMs - lookbackMs
+        val all = ArrayList<Double>()
+        val night = ArrayList<Double>()
+        val day = ArrayList<Double>()
+        var last: Window? = null
+        for (window in windows) {
+            if (window.endMs <= from || window.endMs > nowMs) continue
+            all.add(window.isfMgdlPerU)
+            if (window.stratum == Stratum.NIGHT) night.add(window.isfMgdlPerU) else day.add(window.isfMgdlPerU)
+            if (last == null || window.endMs >= last.endMs) last = window
+        }
+        if (all.isEmpty()) return@withLock Reading.EMPTY
+        Reading(
+            medianMgdlPerU = medianOrNull(all),
+            windowCount = all.size,
+            nightMedianMgdlPerU = medianOrNull(night),
+            nightCount = night.size,
+            dayMedianMgdlPerU = medianOrNull(day),
+            dayCount = day.size,
+            lastWindow = last,
+        )
+    }
+
+    /** Drops every sample and every window. */
+    fun reset() {
+        lock.withLock {
+            samples.clear()
+            windows.clear()
+            lastWindowEndMs = Long.MIN_VALUE
+        }
+    }
+
+    /**
+     * Walks backwards from the newest sample and returns the **shortest** window that passes every
+     * filter, or `null`.
+     *
+     * The shortest one is kept on purpose: a longer window would average the local slope with older
+     * behaviour and report a sensitivity that no moment actually showed.
+     *
+     * The accumulators grow as the walk goes back, so no sub-list is ever allocated.
+     */
+    private fun closeWindow(): Window? {
+        if (samples.size < 2) return null
+        val end = samples[samples.size - 1]
+
+        var absorbedFromBasal = 0.0
+        var smbSum = 0.0
+        var raSum = 0.0
+        var raCount = 0
+
+        for (i in samples.size - 2 downTo 0) {
+            val a = samples[i]
+            val b = samples[i + 1]
+            // Half-open interval (a, b]. The basal that ran over it is the one recorded at b, and
+            // the SMB that was added over it is the one decided at a — that SMB is not yet inside
+            // a.iobU, which is why it is credited separately.
+            absorbedFromBasal += (b.timestampMs - a.timestampMs) / 3_600_000.0 * (b.deliveredBasalUph - b.profileBasalUph)
+            smbSum += a.smbU
+            val ra = a.raMgdlPerMin
+            if (ra != null) {
+                raSum += ra
+                raCount++
+            }
+
+            // Windows must not overlap: two windows sharing samples would count the same insulin
+            // twice and report the same fall twice.
+            if (a.timestampMs < lastWindowEndMs) return null
+            if (a.cobG > 0.0 || b.cobG > 0.0) return null
+
+            val span = (end.timestampMs - a.timestampMs) / 60_000.0
+            if (span > MAX_WINDOW_MINUTES) return null
+            if (span < MIN_WINDOW_MINUTES) continue
+            if (hasCarbsInRunUp(i)) continue
+
+            val drop = a.bgMgdl - end.bgMgdl
+            if (drop < MIN_DROP_MGDL) continue
+            // Fail-closed: with no known appearance rate the meal filter cannot be checked, so the
+            // window is refused rather than trusted.
+            if (raCount == 0) continue
+            if (raSum / raCount >= MAX_RA_MGDL_PER_MIN) continue
+
+            val absorbed = (a.iobU - end.iobU) + absorbedFromBasal + smbSum
+            if (absorbed < MIN_ABSORBED_U) continue
+
+            val isf = drop / absorbed
+            if (!isf.isFinite() || isf < MIN_PLAUSIBLE_ISF || isf > MAX_PLAUSIBLE_ISF) continue
+
+            return Window(
+                startMs = a.timestampMs,
+                endMs = end.timestampMs,
+                minutes = span,
+                startBgMgdl = a.bgMgdl,
+                dropMgdl = drop,
+                absorbedU = absorbed,
+                isfMgdlPerU = isf,
+                stratum = stratumOf(a.timestampMs, end.timestampMs),
+            )
+        }
+        return null
+    }
+
+    /**
+     * True when a sample in `[start - RUN_UP_MINUTES, start)` had carbs on board.
+     *
+     * `startIndex` is the index of the sample that would open the window.
+     */
+    private fun hasCarbsInRunUp(startIndex: Int): Boolean {
+        val startMs = samples[startIndex].timestampMs
+        val from = startMs - RUN_UP_MINUTES * 60_000L
+        for (j in startIndex - 1 downTo 0) {
+            val s = samples[j]
+            if (s.timestampMs < from) break
+            if (s.cobG > 0.0) return true
+        }
+        return false
+    }
+
+    /**
+     * Picks the stratum from the sample nearest the middle of the window.
+     *
+     * A window that straddles the night boundary is classified by its middle, not by its start, so
+     * a 07:40 to 08:40 window counts as day.
+     */
+    private fun stratumOf(startMs: Long, endMs: Long): Stratum {
+        val middleMs = startMs + (endMs - startMs) / 2
+        var best: Sample? = null
+        var bestDistance = Long.MAX_VALUE
+        for (s in samples) {
+            if (s.timestampMs < startMs || s.timestampMs > endMs) continue
+            val distance = if (s.timestampMs > middleMs) s.timestampMs - middleMs else middleMs - s.timestampMs
+            if (distance < bestDistance) {
+                bestDistance = distance
+                best = s
+            }
+        }
+        val hour = best?.localHourOfDay ?: return Stratum.DAY
+        return if (hour >= NIGHT_START_HOUR && hour < NIGHT_END_HOUR) Stratum.NIGHT else Stratum.DAY
+    }
+
+    /**
+     * Classic median, `null` below [MIN_WINDOWS_FOR_MEDIAN] values.
+     *
+     * With an even count it is the mean of the two middle values, like `numpy.median`.
+     */
+    private fun medianOrNull(values: List<Double>): Double? {
+        if (values.size < MIN_WINDOWS_FOR_MEDIAN) return null
+        val sorted = values.sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 1) sorted[middle] else (sorted[middle - 1] + sorted[middle]) / 2.0
+    }
+
+    companion object {
+
+        /** Shortest window that may be measured, in minutes. */
+        const val MIN_WINDOW_MINUTES: Double = 30.0
+
+        /** Longest window that may be measured, in minutes. */
+        const val MAX_WINDOW_MINUTES: Double = 120.0
+
+        /** Smallest fall in glucose a window must show, in mg/dL. */
+        const val MIN_DROP_MGDL: Double = 25.0
+
+        /** Highest mean rate of glucose appearance a window may show, in mg/dL/min. */
+        const val MAX_RA_MGDL_PER_MIN: Double = 0.30
+
+        /** Smallest amount of insulin a window must have absorbed, in U. */
+        const val MIN_ABSORBED_U: Double = 0.8
+
+        /** How far before the window start a meal still disqualifies it, in minutes. */
+        private const val RUN_UP_MINUTES: Long = 30L
+
+        /** Longest hole between two ticks that still keeps the buffer usable. */
+        private const val MAX_GAP_MS: Long = 12L * 60_000L
+
+        /** How much recent history the sample buffer keeps. */
+        private const val BUFFER_MS: Long = 150L * 60_000L
+
+        /** Hard cap on the sample buffer. */
+        private const val MAX_SAMPLES: Int = 256
+
+        /** First hour of the night stratum, inclusive. */
+        private const val NIGHT_START_HOUR: Int = 0
+
+        /** First hour that is no longer night, exclusive. */
+        private const val NIGHT_END_HOUR: Int = 8
+
+        /** Below this many windows a median is reported as `null`, never as a number. */
+        private const val MIN_WINDOWS_FOR_MEDIAN: Int = 3
+
+        /** Default look-back of [read]. */
+        private const val DEFAULT_LOOKBACK_MS: Long = 24L * 3_600_000L
+
+        /** Lowest sensitivity that can be a measurement rather than noise, in mg/dL/U. */
+        private const val MIN_PLAUSIBLE_ISF: Double = 2.0
+
+        /** Highest sensitivity that can be a measurement rather than noise, in mg/dL/U. */
+        private const val MAX_PLAUSIBLE_ISF: Double = 400.0
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/ObservedSensitivityMeterTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/ObservedSensitivityMeterTest.kt
@@ -1,0 +1,456 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Specification locks for [ObservedSensitivityMeter].
+ *
+ * These are **not** a red-before / green-after proof of a bug: the class is new, so every test here
+ * simply writes down the rule the class must keep. The one test that documents a real mistake is
+ * `a zero temp basal window credits less insulin than the raw iob drop`: without the basal integral
+ * the meter would answer 20.0 instead of 31.6 on the same descent.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `eb84e078f5`. Study source set: [ObservedSensitivityMeter]
+ * is commonMain and has no mocks, so the tests live in `commonTest` (`kotlin.test`) — same layout as
+ * [DynIsfCacheTest], not `androidHostTest` (mockito/Robolectric).
+ *
+ * ## Why the closed window is 30 minutes and not the whole descent
+ *
+ * The meter keeps the **shortest** window that passes every filter, and it is fed one tick at a
+ * time, so a window closes at the first tick where one is valid. On a straight-line descent that is
+ * 30 minutes after the start. Every descent below is a straight line, so the sensitivity is the same
+ * for any sub-window of it: the ratio the meter reports is exactly the ratio computed by hand over
+ * the whole fall, while the fall and the insulin of the closed window are 6/11 of the whole-descent
+ * figures.
+ */
+class ObservedSensitivityMeterTest {
+
+    private val minute = 60 * 1000L
+    private val hour = 60 * minute
+
+    /** A fixed epoch. The hour of day is always passed in, so the real calendar does not matter. */
+    private val t0 = 1_700_000_000_000L
+
+    private val profileBasal = 1.0
+
+    /**
+     * Feeds one tick.
+     *
+     * Only what a test needs to say is passed; everything else stays on a neutral default: no carbs,
+     * no SMB, temp basal equal to the profile basal, and a small known rate of appearance so the
+     * fail-closed filter is satisfied.
+     */
+    private fun tick(
+        meter: ObservedSensitivityMeter,
+        timestampMs: Long,
+        bgMgdl: Double,
+        iobU: Double,
+        hourOfDay: Int = 12,
+        cobG: Double = 0.0,
+        smbU: Double = 0.0,
+        deliveredBasalUph: Double = profileBasal,
+        raMgdlPerMin: Double? = 0.05,
+    ): ObservedSensitivityMeter.Window? = meter.observe(
+        ObservedSensitivityMeter.Sample(
+            timestampMs = timestampMs,
+            localHourOfDay = hourOfDay,
+            bgMgdl = bgMgdl,
+            iobU = iobU,
+            cobG = cobG,
+            smbU = smbU,
+            deliveredBasalUph = deliveredBasalUph,
+            profileBasalUph = profileBasal,
+            raMgdlPerMin = raMgdlPerMin,
+            lastBolusMs = 0L,
+        ),
+    )
+
+    /**
+     * Feeds a straight-line descent of [ticks] samples, 5 minutes apart, and returns the windows it
+     * closed.
+     */
+    private fun descent(
+        meter: ObservedSensitivityMeter,
+        startMs: Long = t0,
+        ticks: Int = 12,
+        bgFrom: Double = 200.0,
+        bgTo: Double = 150.0,
+        iobFrom: Double = 3.0,
+        iobTo: Double = 0.5,
+        hourOfDay: Int = 12,
+        cobG: Double = 0.0,
+        deliveredBasalUph: Double = profileBasal,
+        raMgdlPerMin: Double? = 0.05,
+    ): List<ObservedSensitivityMeter.Window> {
+        val closed = ArrayList<ObservedSensitivityMeter.Window>()
+        val last = ticks - 1
+        for (i in 0 until ticks) {
+            val fraction = i.toDouble() / last
+            tick(
+                meter = meter,
+                timestampMs = startMs + i * 5 * minute,
+                bgMgdl = bgFrom + (bgTo - bgFrom) * fraction,
+                iobU = iobFrom + (iobTo - iobFrom) * fraction,
+                hourOfDay = hourOfDay,
+                cobG = cobG,
+                deliveredBasalUph = deliveredBasalUph,
+                raMgdlPerMin = raMgdlPerMin,
+            )?.let { closed.add(it) }
+        }
+        return closed
+    }
+
+    /**
+     * T1 — the reference measurement.
+     *
+     * Glucose 200 to 150 while insulin on board goes 3.00 to 0.50 with the temp basal on the profile
+     * rate: 50 mg/dL for 2.50 U absorbed, so 20.0 mg/dL per U. The closed window is the first valid
+     * one, 30 minutes long, and it carries 6/11 of both figures — the ratio is unchanged.
+     */
+    @Test
+    fun `a clean descent yields the hand computed sensitivity`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter)
+
+        assertEquals(1, windows.size)
+        val window = windows[0]
+        assertEquals(20.0, window.isfMgdlPerU, 1e-9)
+        assertEquals(30.0, window.minutes, 1e-9)
+        assertEquals(50.0 * 6 / 11, window.dropMgdl, 1e-9)
+        assertEquals(2.5 * 6 / 11, window.absorbedU, 1e-9)
+    }
+
+    /**
+     * T2 — the basal integral, its sign and its size.
+     *
+     * The same descent, but the pump ran a zero temp basal against a profile basal of 1.0 U/h. Over
+     * the 30 minutes of the closed window that is 0.5 U **less** than the profile, so the fall in IOB
+     * over-states what was really absorbed and the integral must be subtracted, not added.
+     *
+     * Absorbed becomes 1.3636 - 0.5 = 0.8636 U and the sensitivity 31.6 mg/dL per U. Over the whole
+     * 55-minute descent the same arithmetic gives an integral of -0.917 U, 1.583 U absorbed and the
+     * same 31.6.
+     *
+     * Without the integral the meter would answer 20.0; with the sign flipped, 14.6.
+     */
+    @Test
+    fun `a zero temp basal window credits less insulin than the raw iob drop`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, deliveredBasalUph = 0.0)
+
+        assertEquals(1, windows.size)
+        val window = windows[0]
+        assertEquals(600.0 / 19.0, window.isfMgdlPerU, 1e-9)
+        assertEquals(2.5 * 6 / 11 - 0.5, window.absorbedU, 1e-9)
+    }
+
+    /**
+     * T3 — the half-open interval.
+     *
+     * An SMB of 0.5 U is decided in the middle of the window. It is not inside the IOB of the tick
+     * that decided it, it is inside the IOB of every later tick. So it must be credited once: added
+     * as an SMB, and cancelled by the higher IOB at the end of the window.
+     *
+     * Forgetting it gives 31.6, counting it twice gives 14.6.
+     */
+    @Test
+    fun `an smb inside the window is added to the absorbed insulin`() {
+        val meter = ObservedSensitivityMeter()
+        val smbAtTick = 3
+        var closed: ObservedSensitivityMeter.Window? = null
+
+        for (i in 0 until 12) {
+            val fraction = i / 11.0
+            val rawIob = 3.0 - 2.5 * fraction
+            tick(
+                meter = meter,
+                timestampMs = t0 + i * 5 * minute,
+                bgMgdl = 200.0 - 50.0 * fraction,
+                // The SMB decided at tick 3 shows up in the IOB from tick 4 on.
+                iobU = if (i > smbAtTick) rawIob + 0.5 else rawIob,
+                smbU = if (i == smbAtTick) 0.5 else 0.0,
+            )?.let { closed = it }
+        }
+
+        assertNotNull(closed)
+        assertEquals(20.0, closed!!.isfMgdlPerU, 1e-9)
+        assertEquals(2.5 * 6 / 11, closed!!.absorbedU, 1e-9)
+    }
+
+    /** T4 — 20 minutes of fall is a slope, not a measurement. */
+    @Test
+    fun `a window shorter than thirty minutes is rejected`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, ticks = 5)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /** T5 — a 20 mg/dL fall is below the noise the corpus study accepted. */
+    @Test
+    fun `a fall below twenty five mgdl is rejected`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, bgTo = 180.0)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /** T6 — digestion hides part of the fall, so the sensitivity would read low. */
+    @Test
+    fun `carbs on board reject the window`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, cobG = 10.0)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /**
+     * T7 — a meal that ended just before the window still absorbs inside it.
+     *
+     * Six ticks with carbs, then a clean 30-minute fall. The control run, identical but with no carbs
+     * at all, does close a window, so the rejection is really the run-up rule and not the shape of
+     * the data.
+     */
+    @Test
+    fun `carbs in the run up reject the window`() {
+        val withRunUpCarbs = ObservedSensitivityMeter()
+        val control = ObservedSensitivityMeter()
+        val closed = ArrayList<ObservedSensitivityMeter.Window>()
+        val controlClosed = ArrayList<ObservedSensitivityMeter.Window>()
+
+        for (i in 0 until 13) {
+            val fraction = i / 12.0
+            val bg = 260.0 - 120.0 * fraction
+            val iob = 6.0 - 5.5 * fraction
+            val at = t0 + i * 5 * minute
+            tick(withRunUpCarbs, at, bg, iob, cobG = if (i < 6) 20.0 else 0.0)?.let { closed.add(it) }
+            tick(control, at, bg, iob)?.let { controlClosed.add(it) }
+        }
+
+        assertTrue(closed.isEmpty())
+        assertTrue(controlClosed.isNotEmpty())
+    }
+
+    /** T8 — a fall that cost almost no insulin measures the liver, not the insulin. */
+    @Test
+    fun `less than zero point eight units absorbed rejects the window`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, iobFrom = 3.0, iobTo = 2.9)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /** T9 — glucose still appearing means something other than insulin is driving the curve. */
+    @Test
+    fun `an appearance rate above the threshold rejects the window`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, raMgdlPerMin = 0.5)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /**
+     * T10 — fail-closed.
+     *
+     * With no known rate of appearance the meal filter cannot be checked. An unchecked filter is not
+     * a passed filter, so the window is refused. Everything else about this descent is perfect.
+     */
+    @Test
+    fun `a window with no known appearance rate is rejected`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(meter, raMgdlPerMin = null)
+
+        assertTrue(windows.isEmpty())
+    }
+
+    /**
+     * T11 — no sample may be counted twice.
+     *
+     * Three hours of steady fall. Two overlapping windows would count the same insulin and the same
+     * fall twice, and the median would then be built from copies of one event.
+     */
+    @Test
+    fun `windows never overlap`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(
+            meter,
+            ticks = 37,
+            bgFrom = 320.0,
+            bgTo = 140.0,
+            iobFrom = 6.0,
+            iobTo = 0.5,
+        )
+
+        assertTrue(windows.size >= 2)
+        for (i in 0 until windows.size - 1) {
+            assertTrue(windows[i + 1].startMs >= windows[i].endMs)
+        }
+    }
+
+    /** T12 — the two strata are told apart, and both are counted. */
+    @Test
+    fun `a night window and a day window land in different strata`() {
+        val meter = ObservedSensitivityMeter()
+
+        val night = descent(meter, startMs = t0 + 2 * hour, ticks = 7, hourOfDay = 2)
+        val day = descent(meter, startMs = t0 + 14 * hour, ticks = 7, hourOfDay = 14)
+
+        assertEquals(1, night.size)
+        assertEquals(1, day.size)
+        assertEquals(ObservedSensitivityMeter.Stratum.NIGHT, night[0].stratum)
+        assertEquals(ObservedSensitivityMeter.Stratum.DAY, day[0].stratum)
+
+        val reading = meter.read(nowMs = t0 + 15 * hour)
+        assertEquals(2, reading.windowCount)
+        assertEquals(1, reading.nightCount)
+        assertEquals(1, reading.dayCount)
+    }
+
+    /**
+     * T13 — the middle decides, not the start.
+     *
+     * The window runs from 07:50 to 08:20, so it starts in the night and ends in the day. Its middle
+     * is 08:05, so it is a day window. Classifying by the start would put it in the night.
+     */
+    @Test
+    fun `a window straddling eight in the morning is classified by its midpoint`() {
+        val meter = ObservedSensitivityMeter()
+        val start = t0 + 7 * hour + 50 * minute
+        var closed: ObservedSensitivityMeter.Window? = null
+
+        for (i in 0 until 7) {
+            val fraction = i / 6.0
+            val at = start + i * 5 * minute
+            // 07:50 and 07:55 are hour 7; 08:00 onwards is hour 8.
+            val hourOfDay = if (i < 2) 7 else 8
+            tick(
+                meter = meter,
+                timestampMs = at,
+                bgMgdl = 200.0 - 50.0 * fraction,
+                iobU = 3.0 - 2.5 * fraction,
+                hourOfDay = hourOfDay,
+            )?.let { closed = it }
+        }
+
+        assertNotNull(closed)
+        assertEquals(30.0, closed!!.minutes, 1e-9)
+        assertEquals(ObservedSensitivityMeter.Stratum.DAY, closed!!.stratum)
+    }
+
+    /** T14 — nothing measured must read as nothing, never as a sensitivity of zero. */
+    @Test
+    fun `no window yields a null median and a zero count`() {
+        val meter = ObservedSensitivityMeter()
+
+        val reading = meter.read(nowMs = t0)
+
+        assertNull(reading.medianMgdlPerU)
+        assertNull(reading.nightMedianMgdlPerU)
+        assertNull(reading.dayMedianMgdlPerU)
+        assertEquals(0, reading.windowCount)
+        assertEquals(0, reading.nightCount)
+        assertEquals(0, reading.dayCount)
+        assertNull(reading.lastWindow)
+    }
+
+    /**
+     * T15 — a median of two windows is not a median.
+     *
+     * The count is still reported, so a reader can see how far the instrument is from being able to
+     * answer.
+     */
+    @Test
+    fun `fewer than three windows yields a null median but a real count`() {
+        val meter = ObservedSensitivityMeter()
+
+        val windows = descent(
+            meter,
+            ticks = 13,
+            bgFrom = 320.0,
+            bgTo = 260.0,
+            iobFrom = 6.0,
+            iobTo = 4.0,
+        )
+        val reading = meter.read(nowMs = t0 + 2 * hour)
+
+        assertEquals(2, windows.size)
+        assertEquals(2, reading.windowCount)
+        assertEquals(2, reading.dayCount)
+        assertNull(reading.medianMgdlPerU)
+        assertNull(reading.dayMedianMgdlPerU)
+    }
+
+    /**
+     * T16 — a hole makes the basal integral unknowable.
+     *
+     * The same seven ticks close a window when they are evenly spaced. Move the last one 20 minutes
+     * out and the buffer is dropped, because nobody knows what the pump did during the hole.
+     */
+    @Test
+    fun `a gap longer than twelve minutes prevents a window across it`() {
+        val withGap = ObservedSensitivityMeter()
+        val control = ObservedSensitivityMeter()
+        var gapClosed: ObservedSensitivityMeter.Window? = null
+        var controlClosed: ObservedSensitivityMeter.Window? = null
+
+        for (i in 0 until 7) {
+            val fraction = i / 6.0
+            val bg = 200.0 - 50.0 * fraction
+            val iob = 3.0 - 2.5 * fraction
+            val evenly = t0 + i * 5 * minute
+            val delayed = if (i == 6) t0 + 45 * minute else evenly
+            tick(withGap, delayed, bg, iob)?.let { gapClosed = it }
+            tick(control, evenly, bg, iob)?.let { controlClosed = it }
+        }
+
+        assertNull(gapClosed)
+        assertNotNull(controlClosed)
+    }
+
+    /** T17 — a replay or a clock that steps back must not enter the buffer. */
+    @Test
+    fun `an out of order sample is ignored`() {
+        val meter = ObservedSensitivityMeter()
+
+        for (i in 0 until 6) {
+            val fraction = i / 6.0
+            tick(meter, t0 + i * 5 * minute, 200.0 - 50.0 * fraction, 3.0 - 2.5 * fraction)
+        }
+        // A sample from the past, with values that would wreck any window it entered.
+        val replayed = tick(meter, t0 + 15 * minute, 500.0, 30.0)
+        val closed = tick(meter, t0 + 30 * minute, 150.0, 0.5)
+
+        assertNull(replayed)
+        assertNotNull(closed)
+        assertEquals(20.0, closed!!.isfMgdlPerU, 1e-9)
+        assertEquals(30.0, closed!!.minutes, 1e-9)
+    }
+
+    /** T18 — a window that fell out of the retention window is gone, not merely hidden. */
+    @Test
+    fun `windows older than the retention are dropped`() {
+        val meter = ObservedSensitivityMeter(windowRetentionMs = hour)
+
+        val first = descent(meter, startMs = t0, ticks = 7)
+        val second = descent(meter, startMs = t0 + 5 * hour, ticks = 7)
+        val reading = meter.read(nowMs = t0 + 6 * hour, lookbackMs = 7 * 24 * hour)
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertEquals(1, reading.windowCount)
+        assertEquals(second[0].endMs, reading.lastWindow?.endMs)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.3** uniquement.

- **Clinique** = reference `origin/dev_OAPSAIMI` fichier @ **`eb84e078f52be9b16ff5fcbffab7080958bb9ee1`** (inchangé sur le tip `c5db5a0333`).
- **Câblage** = study tip post-#72 **`a613bb3c27263cda00bc4a7c98c6064065709d96`** : **commonMain** + champ privé du tick (`private val observedSensitivityMeter = ObservedSensitivityMeter()`), **pas Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Preuve = **`:plugins:aps:jvmTest`** → ObservedSensitivityMeterTest **18/18**.

Pas de copie aveugle Hilt/javax/`@Synchronized`. Pas de `org.json` (export via `AimiJson.NULL`).

### Re-vérif study (pointe `a613bb3c27`)

- `ObservedSensitivityMeter` était **absent**.
- **Une** classe tick AIMI : `androidMain` `DetermineBasalaimiSMB2` (Metro `@Inject` `@SingleIn`). **Une** instance : champ plugin `determineBasalaimiSMB2`.
- **Une** classe plugin AIMI : `androidMain` `OpenAPSAIMIPlugin`. **Pas** de call site plugin dans `eb84e078f5`.
- Grep `ObservedSensitivityMeter(` / `isf_obs_` : zéro avant ce lot.
- Pattern frère : `DynIsfCache` = commonMain, champ `private val`, pas Metro. Ici le propriétaire est le **tick**, pas le plugin — comme la référence.

### Copié / adapté

- `ObservedSensitivityMeter` → **commonMain**. `AapsLock` à la place de `@Synchronized`. Formules, filtres (30–120 min, −25 mg/dL, COB, Ra fail-closed 0.30, ≥0.8 U, strata 00–08), médiane `null` sous 3 fenêtres : inchangés.
- Tests : 18 verrous `eb84e078f5` en `commonTest` (`kotlin.test`). Pas Mockito.

### Sites câblés (`DetermineBasalAIMI2` androidMain) — hunks `eb84e078f5` seulement

1. Import.
2. Champ privé (pas `@Inject`).
3. Champs `var isf_obs_*` sur `BaselineState` + `put` dans `toMedicalJson` via `AimiJson.NULL`.
4. Bloc `observe`/`read` dans `runAimiSnapshotMedicalJsonAndHormonitorExportStage`, **après** `SensitivityRatioEstimator` et **avant** `dynamic_isf`.

`OpenAPSAIMIPlugin` **non modifié**. Pas de `CommandedIsf` / `MaxSmbLadder` / `DynIsfCache` / PkPd / Kalman floor / `isf_calc_path`.

Quatre zones prod uniquement (`commonMain` + `androidMain`) : classe, import+champ, bloc d’alimentation, champs+`put`. Rien d’autre ne lit l’instrument.

### Hors scope

P0.4–P0.8, `CommandedIsf`, `MaxSmbLadder`, Kalman floor, leftovers `dd9979ca4d`, iOS `APS=true`.

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeterTest'
  → 18/18 (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL
```

`:app:assembleFullDebug` **non lancé** : pas de nouvel `@Inject` / port Metro (champ privé, comme `DynIsfCache`).

### Questions ouvertes

- `isf_calc_path` / `isf_cache_size` restent absents sur l’étude (télémetrie P0.2 ref, hors lot).
- Le grep de passivité de la référence pointait `src/main` ; ici : `plugins/aps/src/commonMain` + `androidMain`.

## EN

Lot **P0.3** only.

- **Clinical** = reference `origin/dev_OAPSAIMI` file @ **`eb84e078f52be9b16ff5fcbffab7080958bb9ee1`** (unchanged on tip `c5db5a0333`).
- **Wiring** = study tip after #72 **`a613bb3c27263cda00bc4a7c98c6064065709d96`**: **commonMain** + tick field (`private val observedSensitivityMeter = ObservedSensitivityMeter()`), **not Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Evidence = **`:plugins:aps:jvmTest`** → ObservedSensitivityMeterTest **18/18**.

Not a blind Hilt/javax/`@Synchronized` copy. No `org.json` (export via `AimiJson.NULL`).

### Study re-check (tip `a613bb3c27`)

- `ObservedSensitivityMeter` was **absent**.
- **One** AIMI tick class: androidMain `DetermineBasalaimiSMB2` (Metro `@Inject` `@SingleIn`). **One** instance: plugin field `determineBasalaimiSMB2`.
- **One** AIMI plugin class: androidMain `OpenAPSAIMIPlugin`. **No** plugin call site in `eb84e078f5`.
- Grep `ObservedSensitivityMeter(` / `isf_obs_`: zero before this lot.
- Sibling pattern: `DynIsfCache` = commonMain, `private val` field, not Metro. Owner here is the **tick**, not the plugin — same as the reference.

### What was copied / adapted

- `ObservedSensitivityMeter` → **commonMain**. `AapsLock` instead of `@Synchronized`. Formulas and filters unchanged (30–120 min, −25 mg/dL, COB, Ra fail-closed 0.30, ≥0.8 U, night 00–08, median `null` below 3 windows).
- Tests: the 18 `eb84e078f5` locks in `commonTest` (`kotlin.test`). No Mockito.

### Call sites wired (`DetermineBasalAIMI2` androidMain) — `eb84e078f5` hunks only

1. Import.
2. Private field (not `@Inject`).
3. `var isf_obs_*` on `BaselineState` + `put` in `toMedicalJson` via `AimiJson.NULL`.
4. `observe`/`read` block in `runAimiSnapshotMedicalJsonAndHormonitorExportStage`, **after** `SensitivityRatioEstimator` and **before** `dynamic_isf`.

`OpenAPSAIMIPlugin` **untouched**. No `CommandedIsf` / `MaxSmbLadder` / `DynIsfCache` / PkPd / Kalman floor / `isf_calc_path`.

Production grep (`commonMain` + `androidMain`) shows four zones only: class, import+field, feed block, fields+`put`. Nothing in the dosing chain reads the instrument.

### Out of scope

P0.4–P0.8, `CommandedIsf`, `MaxSmbLadder`, Kalman floor, `dd9979ca4d` leftovers, iOS `APS=true`.

### Evidence

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeterTest'
  → 18/18 (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL
```

`:app:assembleFullDebug` **not run**: no new `@Inject` / Metro port (private field, same as `DynIsfCache`).

### Open questions

- `isf_calc_path` / `isf_cache_size` remain absent on study (P0.2 ref telemetry, out of this lot).
- Reference passivity grep targeted `src/main`; here: `plugins/aps/src/commonMain` + `androidMain`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81ab490a-63c1-4866-a9a5-bfebdf09bd41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81ab490a-63c1-4866-a9a5-bfebdf09bd41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

