### PR TITLE
P0.4 — CommandedIsf: read the ISF instrument before the profile floor

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -51,6 +51,7 @@ import app.aaps.plugins.aps.openAPSAIMI.basal.T3cAutodriveBasalBridge
 import app.aaps.plugins.aps.openAPSAIMI.basal.T3cTrajectoryContext
 import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveState
 import app.aaps.plugins.aps.openAPSAIMI.carbs.CarbsAdvisor
+import app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsf
 import app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeter
 import app.aaps.plugins.aps.openAPSAIMI.ISF.SensitivityRatioEstimator
 import app.aaps.core.interfaces.ui.UiInteraction
@@ -396,6 +397,13 @@ internal data class AimiDecisionContext(
         val estimated_ra_mgdl_per_min: Double? = null,
         /** Physiological ISF factor of the tick, bounds [0.85, 1.15]. Applied once since ADR 0007. */
         val physio_isf_factor: Double? = null,
+        /**
+         * Commanded sensitivity before the profile-relative floor, mg/dL per U.
+         *
+         * Next to `command_isf_mgdl` it says how much the floor moved this tick, which no exported
+         * field could say while the shadow witness was reading the already-floored value.
+         */
+        val isf_pre_floor_mgdl: Double? = null,
         /** Shadow: sensitivity an unconditional exit clamp relative to the profile would command. */
         val isf_profile_relative_shadow_mgdl: Double? = null,
         /** Shadow: true when that clamp would have changed the value. */
@@ -728,6 +736,7 @@ internal data class AimiDecisionContext(
             base.put("isf_trajectory_multiplier", baseline_state.isf_trajectory_multiplier ?: AimiJson.NULL)
             base.put("estimated_ra_mgdl_per_min", baseline_state.estimated_ra_mgdl_per_min ?: AimiJson.NULL)
             base.put("physio_isf_factor", baseline_state.physio_isf_factor ?: AimiJson.NULL)
+            base.put("isf_pre_floor_mgdl", baseline_state.isf_pre_floor_mgdl ?: AimiJson.NULL)
             base.put("isf_profile_relative_shadow_mgdl", baseline_state.isf_profile_relative_shadow_mgdl ?: AimiJson.NULL)
             base.put("isf_profile_relative_bound_hit", baseline_state.isf_profile_relative_bound_hit ?: AimiJson.NULL)
             base.put("sensitivity_ratio_r", baseline_state.sensitivity_ratio_r ?: AimiJson.NULL)
@@ -2128,6 +2137,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                 isf_trajectory_multiplier = IsfSourceTelemetry.lastTrajectoryMultiplier,
                 estimated_ra_mgdl_per_min = runCatching { continuousStateEstimator.getLastRa() }.getOrNull(),
                 physio_isf_factor = IsfSourceTelemetry.lastPhysioIsfFactor,
+                isf_pre_floor_mgdl = CommandedIsf.lastPreFloorMgdlPerU,
                 isf_profile_relative_shadow_mgdl = IsfSourceTelemetry.lastProfileRelativeShadowMgdl,
                 isf_profile_relative_bound_hit = IsfSourceTelemetry.lastProfileRelativeBoundHit,
                 sensitivity_ratio_r = runCatching { sensitivityRatioEstimator.ratio }.getOrNull(),

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
@@ -89,6 +89,7 @@ import app.aaps.plugins.aps.R
 import app.aaps.plugins.aps.events.EventOpenAPSUpdateGui
 import app.aaps.plugins.aps.events.EventResetOpenAPSGui
 import app.aaps.plugins.aps.openAPS.TddStatus
+import app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsf
 import app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCache
 import app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfTrajectoryTuning
 import app.aaps.plugins.aps.openAPSAIMI.ISF.DynamicSensitivityPolicy
@@ -1430,25 +1431,19 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
                 // before the multipliers that undo it, which is the defect ADR 0008 keeps recording: the
                 // physiological factor is applied after the `coerceIn(5.0, 300.0)` on this path, which is
                 // how a commanded sensitivity of 4.54 mg/dL/U was reached on 2026-08-14 (5.00 x 0.908).
-                sens = DynamicSensitivityPolicy.floorAgainstProfile(
-                    commandedMgdlPerU = profile.getIsfMgdl("OpenAPSAIMIPlugin") * physioMults.isfFactor,
+                // The shadow witness of that same bound used to be recorded here, on the value the
+                // floor had **already** raised. Its own lower bound is the same 0.5 x profile, so it
+                // could never fire again: `isf_profile_relative_bound_hit` was false on 709 night
+                // ticks out of 709 while the floor was really setting the value on 244 of them. The
+                // order now lives in [CommandedIsf], which measures first and floors after.
+                // See `docs/adr/0008-isf-decision-architecture.md`.
+                sens = CommandedIsf.floorAgainstProfileAndRecordShadow(
+                    // The commanded sensitivity after every multiplier and before the floor. Read
+                    // here, at the same place the old code read it, so the number the loop commands
+                    // is unchanged.
+                    preFloorMgdlPerU = profile.getIsfMgdl("OpenAPSAIMIPlugin") * physioMults.isfFactor,
                     profileIsfMgdlPerU = runCatching { profile.getProfileIsfMgdl() }.getOrNull(),
-                ).also { commanded ->
-                    // Shadow only — nothing reads this. Records what an **unconditional exit clamp**
-                    // relative to the profile would command.
-                    //
-                    // It was first placed inside `calculateVariableIsf`, before the effective-profile
-                    // percentage and the physiological factor. Production then showed the commanded
-                    // sensitivity reaching x0.46 and x2.11 of profile while the shadow reported a
-                    // single hit in 282 ticks — the guard had been put before the multipliers that
-                    // undo it, which is precisely the defect this ADR set keeps documenting. It now
-                    // sits where the value is final.
-                    // See `docs/adr/0008-isf-decision-architecture.md`.
-                    IsfSourceTelemetry.recordProfileRelativeShadow(
-                        blendedMgdl = commanded,
-                        profileIsfMgdl = runCatching { profile.getProfileIsfMgdl() }.getOrNull() ?: 0.0,
-                    )
-                },
+                ),
                 autosens_adjust_targets = false, // not used
                 max_daily_safety_multiplier = preferences.get(DoubleKey.ApsMaxDailyMultiplier) * physioMults.smbFactor, // ?? SMB Cap modulation
                 current_basal_safety_multiplier = preferences.get(DoubleKey.ApsMaxCurrentBasalMultiplier) * physioMults.basalFactor, // ?? Basal Cap modulation

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/CommandedIsf.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/CommandedIsf.kt
@@ -1,0 +1,61 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import app.aaps.plugins.aps.openAPSAIMI.IsfSourceTelemetry
+import kotlin.concurrent.Volatile
+
+/**
+ * The last two steps of the commanded sensitivity, in the order they must happen.
+ *
+ * `OpenAPSAIMIPlugin` used to write these two steps inline, and it wrote them in the wrong order:
+ * the profile-relative floor was applied first, and the shadow witness was then handed the value
+ * that had **already** been floored. The witness's own lower bound is the same 0.5 x profile, so it
+ * could never fire again. Measured on the night of 2026-09-05:
+ * `isf_profile_relative_bound_hit` was `false` on 709 ticks out of 709, while the floor really set
+ * the commanded value (`command_isf_mgdl` exactly 0.5 x 120 = 60.000) on 244 night ticks out of 474.
+ * The instrument reported "nothing to see" on the very mechanism it was added to measure.
+ *
+ * Keeping both steps here makes the order part of the code instead of part of a call site, so a test
+ * can hold it in place.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `db21308e6c` (file SHA `5600100dcb`, unchanged on tip
+ * `c5db5a0333`). Study wiring: commonMain shared `object` (plugin writes, tick reads — two consumers,
+ * so not a private field). KMP adaptation only: [Volatile] from `kotlin.concurrent` instead of the
+ * JVM `@Volatile` the reference uses. Clinical order and formulas are unchanged.
+ */
+internal object CommandedIsf {
+
+    /**
+     * The commanded sensitivity as it stood **before** the profile-relative floor, mg/dL per U.
+     *
+     * Observation only. `null` until a tick has run, and `null` again when the value was not finite.
+     * Exported as `baseline_state.isf_pre_floor_mgdl`.
+     */
+    @Volatile
+    var lastPreFloorMgdlPerU: Double? = null
+        private set
+
+    /**
+     * Records the shadow witness on the pre-floor value, then returns the floored command.
+     *
+     * The witness must see the value before the floor, otherwise it only ever sees its own bound.
+     * The returned value is the one the loop commands, and it is exactly what
+     * [DynamicSensitivityPolicy.floorAgainstProfile] returns for the same two inputs.
+     *
+     * @param preFloorMgdlPerU the commanded sensitivity after every multiplier, before the floor.
+     * @param profileIsfMgdlPerU the static profile sensitivity for this time of day, or null.
+     */
+    fun floorAgainstProfileAndRecordShadow(
+        preFloorMgdlPerU: Double,
+        profileIsfMgdlPerU: Double?,
+    ): Double {
+        lastPreFloorMgdlPerU = preFloorMgdlPerU.takeIf { it.isFinite() }
+        IsfSourceTelemetry.recordProfileRelativeShadow(
+            blendedMgdl = preFloorMgdlPerU,
+            profileIsfMgdl = profileIsfMgdlPerU ?: 0.0,
+        )
+        return DynamicSensitivityPolicy.floorAgainstProfile(
+            commandedMgdlPerU = preFloorMgdlPerU,
+            profileIsfMgdlPerU = profileIsfMgdlPerU,
+        )
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/CommandedIsfOrderTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ISF/CommandedIsfOrderTest.kt
@@ -1,0 +1,120 @@
+package app.aaps.plugins.aps.openAPSAIMI.ISF
+
+import app.aaps.plugins.aps.openAPSAIMI.IsfSourceTelemetry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Holds the order of the last two steps of the commanded sensitivity in place.
+ *
+ * The witness has to read the value **before** the profile-relative floor. Read after it, its own
+ * lower bound has already been applied, so it can never report a hit: on the night of 2026-09-05
+ * `isf_profile_relative_bound_hit` was `false` on 709 ticks out of 709 while the floor really set
+ * the commanded value on 244 night ticks out of 474.
+ *
+ * The first test below fails with the old order and passes with the new one. The last test is the
+ * non-negotiable part: the commanded number itself must not move.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (file SHA `5600100dcb`, unchanged on tip
+ * `c5db5a0333`). Study source set: [CommandedIsf] is commonMain and has no mocks, so the tests live
+ * in `commonTest` (`kotlin.test`) — same layout as [DynIsfCacheTest] / [ObservedSensitivityMeterTest],
+ * not `androidHostTest` (mockito/Robolectric). Assertions are the same locks as the Truth/JUnit
+ * reference corpus.
+ */
+class CommandedIsfOrderTest {
+
+    private val profileIsf = 120.0
+
+    /** A tick where the floor really binds: 0.4 x profile, well under the 0.5 x lower bound. */
+    private val preFloorBelowBound = 48.0
+
+    /** A tick where nothing binds: 1.0 x profile. */
+    private val preFloorInsideBounds = 120.0
+
+    @Test
+    fun `the witness sees the value before the floor, so it can report a hit`() {
+        CommandedIsf.floorAgainstProfileAndRecordShadow(
+            preFloorMgdlPerU = preFloorBelowBound,
+            profileIsfMgdlPerU = profileIsf,
+        )
+
+        assertEquals(true, IsfSourceTelemetry.lastProfileRelativeBoundHit)
+        assertEquals(
+            profileIsf * DynamicSensitivityPolicy.PROFILE_RELATIVE_FLOOR,
+            IsfSourceTelemetry.lastProfileRelativeShadowMgdl!!,
+            absoluteTolerance = 1e-9,
+        )
+    }
+
+    @Test
+    fun `a value inside the bounds is not reported as a hit`() {
+        CommandedIsf.floorAgainstProfileAndRecordShadow(
+            preFloorMgdlPerU = preFloorInsideBounds,
+            profileIsfMgdlPerU = profileIsf,
+        )
+
+        assertEquals(false, IsfSourceTelemetry.lastProfileRelativeBoundHit)
+        assertEquals(
+            preFloorInsideBounds,
+            IsfSourceTelemetry.lastProfileRelativeShadowMgdl!!,
+            absoluteTolerance = 1e-9,
+        )
+    }
+
+    @Test
+    fun `the pre-floor value is kept for the export and is not the commanded one`() {
+        val commanded = CommandedIsf.floorAgainstProfileAndRecordShadow(
+            preFloorMgdlPerU = preFloorBelowBound,
+            profileIsfMgdlPerU = profileIsf,
+        )
+
+        assertEquals(preFloorBelowBound, CommandedIsf.lastPreFloorMgdlPerU!!, absoluteTolerance = 1e-9)
+        assertTrue(commanded > CommandedIsf.lastPreFloorMgdlPerU!!)
+    }
+
+    @Test
+    fun `a non-finite pre-floor value is exported as unknown, never as a number`() {
+        CommandedIsf.floorAgainstProfileAndRecordShadow(
+            preFloorMgdlPerU = Double.NaN,
+            profileIsfMgdlPerU = profileIsf,
+        )
+
+        assertNull(CommandedIsf.lastPreFloorMgdlPerU)
+        assertNull(IsfSourceTelemetry.lastProfileRelativeBoundHit)
+    }
+
+    @Test
+    fun `the commanded sensitivity is exactly what the floor alone returns`() {
+        val cases = listOf(
+            preFloorBelowBound to profileIsf,
+            preFloorInsideBounds to profileIsf,
+            4.54 to 30.0,
+            300.0 to 120.0,
+            0.069 to 120.0,
+        )
+
+        cases.forEach { (preFloor, profile) ->
+            assertEquals(
+                DynamicSensitivityPolicy.floorAgainstProfile(
+                    commandedMgdlPerU = preFloor,
+                    profileIsfMgdlPerU = profile,
+                ),
+                CommandedIsf.floorAgainstProfileAndRecordShadow(
+                    preFloorMgdlPerU = preFloor,
+                    profileIsfMgdlPerU = profile,
+                ),
+            )
+        }
+
+        // A missing profile must fail open on both paths: the input comes back unchanged.
+        assertEquals(
+            4.54,
+            CommandedIsf.floorAgainstProfileAndRecordShadow(
+                preFloorMgdlPerU = 4.54,
+                profileIsfMgdlPerU = null,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.4** uniquement.

- **Clinique** = référence `origin/dev_OAPSAIMI` fichier @ **`db21308e6c00c6b6a2bf0f2485dd351296a2bf50`** (file SHA `5600100dcb`, inchangé sur le tip `c5db5a0333`). Commit d’introduction vérifié : *« read each instrument before the brake it measures »* (ère ObservedSensitivityMeter / instruments ISF).
- **Câblage** = study tip post-#75 **`4ccd0d73ced489bd5ab35a691d5697a347eae582`** : **commonMain** `internal object` partagé (le plugin écrit, le tick lit — deux consommateurs, donc pas un champ privé), **pas Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Preuve = **`:plugins:aps:jvmTest`** → CommandedIsfOrderTest **5/5**.

Pas de copie aveugle Hilt/javax/`@Volatile` JVM. Pas de `org.json` (export via `AimiJson.NULL`).

### Re-vérif study (pointe `4ccd0d73`)

- `CommandedIsf` était **absent**.
- **Une** classe tick AIMI : `androidMain` `DetermineBasalaimiSMB2` (Metro `@Inject` `@SingleIn`). **Une** instance : champ plugin `determineBasalaimiSMB2`.
- **Une** classe plugin AIMI : `androidMain` `OpenAPSAIMIPlugin`.
- Grep `CommandedIsf(` / `isf_pre_floor` : zéro avant ce lot.
- Deux call sites `floorAgainstProfile` dans le plugin : `variableSensitivity` et `sens`. La référence ne câble **que** `sens` via `CommandedIsf` — `variableSensitivity` reste `DynamicSensitivityPolicy.floorAgainstProfile`.
- Pattern frère : `ObservedSensitivityMeter` / `DynIsfCache` = commonMain + champ privé **sauf** deux consommateurs → ici `object` partagé.

### Copié / adapté

- `CommandedIsf` → **commonMain**. `kotlin.concurrent.Volatile` à la place de `@Volatile` JVM. Ordre clinique inchangé : witness **puis** `floorAgainstProfile`. La valeur commandée = exactement `floorAgainstProfile` seul.
- Tests : 5 verrous `db21308e6c` en `commonTest` (`kotlin.test`). Pas Mockito.

### Sites câblés — hunks `db21308e6c` CommandedIsf seulement

**Plugin** (`OpenAPSAIMIPlugin` androidMain)
1. Import.
2. `sens = CommandedIsf.floorAgainstProfileAndRecordShadow(...)` à la place de `floorAgainstProfile(...).also { recordProfileRelativeShadow(commanded) }`.

**Tick** (`DetermineBasalAIMI2` androidMain)
3. Import.
4. Champ `isf_pre_floor_mgdl` sur `BaselineState` + `put` dans `toMedicalJson` via `AimiJson.NULL`.
5. `isf_pre_floor_mgdl = CommandedIsf.lastPreFloorMgdlPerU` au bootstrap du snapshot.

Pas de hunk Autodrive / barrier / Harmonia / `mpcRequestedU` du même commit. Pas de `MaxSmbLadder` / `DynIsfCache` / PkPd / Kalman floor.

### Hors scope

P0.5–P0.8, `MaxSmbLadder`, `DynIsfCache` (déjà P0.2), PkPd, Kalman floor, leftovers du commit `db21308e6c` hors CommandedIsf, iOS `APS=true`.

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsfOrderTest'
  → 5/5 (0 skipped, 0 failures, 0 errors)
  RED before impl: Unresolved reference CommandedIsf

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.*'
  → CommandedIsfOrderTest 5/5, DynIsfCacheTest 7/7, ObservedSensitivityMeterTest 18/18
```

`:app:assembleFullDebug` **non lancé** : pas de nouvel `@Inject` / port Metro (`object` commonMain, comme le pattern frère sauf singleton partagé).

### Questions ouvertes

- Le 2ᵉ call site `variableSensitivity = DynamicSensitivityPolicy.floorAgainstProfile` n’est **pas** passé par `CommandedIsf` sur la référence. Conservé tel quel.
- `IsfSourceTelemetry.reset()` ne remet pas à zéro les champs shadow / `lastPreFloorMgdlPerU` (déjà vrai sur l’étude et la référence).

## EN

Lot **P0.4** only.

- **Clinical** = reference `origin/dev_OAPSAIMI` file @ **`db21308e6c00c6b6a2bf0f2485dd351296a2bf50`** (file SHA `5600100dcb`, unchanged on tip `c5db5a0333`). Introducing commit verified: *“read each instrument before the brake it measures”* (ObservedSensitivityMeter / ISF-instrument era).
- **Wiring** = study tip after #75 **`4ccd0d73ced489bd5ab35a691d5697a347eae582`**: **commonMain** shared `internal object` (plugin writes, tick reads — two consumers, so not a private field), **not Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Evidence = **`:plugins:aps:jvmTest`** → CommandedIsfOrderTest **5/5**.

Not a blind Hilt/javax/JVM-`@Volatile` copy. No `org.json` (export via `AimiJson.NULL`).

### Study re-check (tip `4ccd0d73`)

- `CommandedIsf` was **absent**.
- **One** AIMI tick class: androidMain `DetermineBasalaimiSMB2` (Metro `@Inject` `@SingleIn`). **One** instance: plugin field `determineBasalaimiSMB2`.
- **One** AIMI plugin class: androidMain `OpenAPSAIMIPlugin`.
- Grep `CommandedIsf(` / `isf_pre_floor`: zero before this lot.
- Two `floorAgainstProfile` sites in the plugin: `variableSensitivity` and `sens`. The reference wires **only** `sens` through `CommandedIsf` — `variableSensitivity` stays `DynamicSensitivityPolicy.floorAgainstProfile`.
- Sibling pattern: `ObservedSensitivityMeter` / `DynIsfCache` = commonMain + private field **unless** two consumers need a shared singleton → here a shared `object`.

### What was copied / adapted

- `CommandedIsf` → **commonMain**. `kotlin.concurrent.Volatile` instead of JVM `@Volatile`. Clinical order unchanged: witness **then** `floorAgainstProfile`. Commanded value = exactly `floorAgainstProfile` alone.
- Tests: the 5 `db21308e6c` locks in `commonTest` (`kotlin.test`). No Mockito.

### Call sites wired — `db21308e6c` CommandedIsf hunks only

**Plugin** (`OpenAPSAIMIPlugin` androidMain)
1. Import.
2. `sens = CommandedIsf.floorAgainstProfileAndRecordShadow(...)` instead of `floorAgainstProfile(...).also { recordProfileRelativeShadow(commanded) }`.

**Tick** (`DetermineBasalAIMI2` androidMain)
3. Import.
4. `isf_pre_floor_mgdl` on `BaselineState` + `put` in `toMedicalJson` via `AimiJson.NULL`.
5. `isf_pre_floor_mgdl = CommandedIsf.lastPreFloorMgdlPerU` at snapshot bootstrap.

No Autodrive / barrier / Harmonia / `mpcRequestedU` hunks from the same commit. No `MaxSmbLadder` / `DynIsfCache` / PkPd / Kalman floor.

### Out of scope

P0.5–P0.8, `MaxSmbLadder`, `DynIsfCache` (already P0.2), PkPd, Kalman floor, leftover `db21308e6c` hunks outside CommandedIsf, iOS `APS=true`.

### Evidence

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsfOrderTest'
  → 5/5 (0 skipped, 0 failures, 0 errors)
  RED before impl: Unresolved reference CommandedIsf

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.*'
  → CommandedIsfOrderTest 5/5, DynIsfCacheTest 7/7, ObservedSensitivityMeterTest 18/18
```

`:app:assembleFullDebug` **not run**: no new `@Inject` / Metro port (commonMain `object`, sibling pattern except shared singleton).

### Open questions

- The second call site `variableSensitivity = DynamicSensitivityPolicy.floorAgainstProfile` is **not** routed through `CommandedIsf` on the reference. Left as-is.
- `IsfSourceTelemetry.reset()` does not clear shadow fields / `lastPreFloorMgdlPerU` (already true on study and reference).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55149fd6-3b3a-4c9e-8eee-6a33e8e5838b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55149fd6-3b3a-4c9e-8eee-6a33e8e5838b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

