### PR TITLE
P0.5 — MaxSmbLadder: extract the maxSMB ceiling and take the shortAvgDelta rise rule

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -66,6 +66,7 @@ import app.aaps.plugins.aps.openAPSAIMI.ml.AimiSmbTrainer
 import app.aaps.plugins.aps.openAPSAIMI.ml.SmbRefinementFeatureSchema
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorJsonlExport
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorVerdict
+import app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadder
 import app.aaps.plugins.aps.openAPSAIMI.smb.SmbIntervalPolicy
 import app.aaps.plugins.aps.openAPSAIMI.advisor.oref.OrefPredictionReasonSuffix
 import app.aaps.plugins.aps.openAPSAIMI.trajectory.TrajectoryType
@@ -1075,30 +1076,6 @@ private const val MEAL_ADVISOR_MIN_CARB_COVERAGE = 0.25
  */
 private const val RISE_FLOOR_REARM_MS = 90L * 60L * 1000L
 
-/**
- * Stable tags naming which branch of the maxSMB ladder picked the ceiling for a tick.
- *
- * Exported as `smb_binding_trace.max_smb_ladder_branch`. The rise floor obeys the ceiling this ladder
- * picks, so the tag is what tells us afterwards whether the ladder saw a rise (a promoted or partial
- * branch) or saw nothing at all (`STANDARD`). The two readings mean very different things.
- *
- * The `_CLAMPED` twins mean the branch fired and the BG below 120 safety clamp then pulled the
- * ceiling back down to the standard preference. Without them the tag would report a promotion that
- * never reached the dose. `STANDARD` has no twin: it already sets the standard preference, so the
- * clamp cannot lower it further.
- */
-private const val LADDER_PLATEAU_CRITICAL = "PLATEAU_CRITICAL_BG250"
-private const val LADDER_PLATEAU_CRITICAL_CLAMPED = "PLATEAU_CRITICAL_BG250_CLAMPED"
-private const val LADDER_CONFIRMED_RISE_HIGH = "CONFIRMED_RISE_HIGH"
-private const val LADDER_CONFIRMED_RISE_HIGH_CLAMPED = "CONFIRMED_RISE_HIGH_CLAMPED"
-private const val LADDER_SENSITIVE_85 = "SENSITIVE_85"
-private const val LADDER_SENSITIVE_85_CLAMPED = "SENSITIVE_85_CLAMPED"
-private const val LADDER_PLATEAU_MODERATE_75 = "PLATEAU_MODERATE_75"
-private const val LADDER_PLATEAU_MODERATE_75_CLAMPED = "PLATEAU_MODERATE_75_CLAMPED"
-private const val LADDER_FALLING_60 = "FALLING_60"
-private const val LADDER_FALLING_60_CLAMPED = "FALLING_60_CLAMPED"
-private const val LADDER_STANDARD = "STANDARD"
-
 private const val TIGHT_SPIRAL_CAP_TDD_REFERENCE_U = 55.0
 
 /** Seuil énergie spiral (U) à TDD = [TIGHT_SPIRAL_CAP_TDD_REFERENCE_U] (échelle adulte repas). */
@@ -2045,6 +2022,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         // empty trace, and a reader could not tell. Null means "the ladder did not run this tick".
         lastMaxSmbLadderBranch = null
         lastSlopeFromMinDeviation = null
+        lastShortAvgDeltaAtLadder = null
         // Effort reduction telemetry is per tick — a basal-only tick must export null, not the last
         // SMB tick's multiplier.
         lastEffortSmbFactorRaw = null
@@ -2654,65 +2632,49 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         // Solution: Use maxSMBHB if EITHER:
         //   1. Active rise detected (slope >= 1.0) - Original logic
         //   2. High plateau (BG >= 250) - NEW, regardless of slope
-        // The rise floor obeys whichever ceiling this ladder picks, so remember the branch and the
-        // slope it read. Both go out in `smb_binding_trace` so the next package can say whether the
-        // ladder we now trust is reading the rise correctly.
+        // The rise floor obeys whichever ceiling this ladder picks, so remember the branch and both
+        // rise signals it read. All three go out in `smb_binding_trace` so the next package can say
+        // whether the ladder we now trust is reading the rise correctly.
         this.lastSlopeFromMinDeviation = ctx.mealData.slopeFromMinDeviation.takeIf { it.isFinite() }
-        this.maxSMB = when {
-            // 🚨 CRITICAL PLATEAU: BG >= 250, regardless of slope
-            // Absolute emergency if BG catastrophic, even with low delta
-            // Protection: Don't apply if rapid fall (delta <= -5)
-            bg >= 250 && combinedDelta > -5.0 -> {
-                this.lastMaxSmbLadderBranch = LADDER_PLATEAU_CRITICAL
-                consoleLog.add("MAXSMB_PLATEAU_CRITICAL BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} -> maxSMBHB=${String.format("%.2f", maxSMBHB)}U (plateau)")
-                maxSMBHB
-            }
+        this.lastShortAvgDeltaAtLadder = glucoseStatus.shortAvgDelta.takeIf { it.isFinite() }
+        // Trap: `this.shortAvgDelta` is only copied from `glucoseStatus` further down this method,
+        // so reading the bare member here would read the PREVIOUS tick. Always pass
+        // `glucoseStatus.shortAvgDelta`.
+        val ladder = MaxSmbLadder.decide(
+            bgMgdl = bg,
+            combinedDelta = combinedDelta.toDouble(),
+            slopeFromMinDeviation = ctx.mealData.slopeFromMinDeviation,
+            shortAvgDeltaMgdl5m = glucoseStatus.shortAvgDelta,
+            honeymoon = honeymoon,
+            maxSmb = this.maxSMB,
+            maxSmbHighBg = this.maxSMBHB,
+        )
+        this.lastMaxSmbLadderBranch = ladder.branch
+        consoleLog.add(
+            when (ladder.branch) {
+                MaxSmbLadder.LADDER_PLATEAU_CRITICAL     ->
+                    "MAXSMB_PLATEAU_CRITICAL BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} -> maxSMBHB=${String.format("%.2f", maxSMBHB)}U (plateau)"
 
-            // 🔴 ACTIVE RISE HIGH: BG >= 140 (meal interception zone)
-            // Full maxSMBHB for confirmed meal/resistance in elevated range
-            // Added combinedDelta check to confirm rise is real
-            (bg >= 140 && !honeymoon && ctx.mealData.slopeFromMinDeviation >= 1.0 && combinedDelta > 0.5) ||
-            (bg >= 180 && honeymoon && ctx.mealData.slopeFromMinDeviation >= 1.4 && combinedDelta > 0.5) -> {
-                this.lastMaxSmbLadderBranch = LADDER_CONFIRMED_RISE_HIGH
-                consoleLog.add("MAXSMB_SLOPE_HIGH BG=${bg.roundToInt()} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} \u0394=${String.format("%.1f", combinedDelta)} -> maxSMBHB=${String.format("%.2f", maxSMBHB)}U (confirmed rise)")
-                maxSMBHB
-            }
+                MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH  ->
+                    "MAXSMB_SLOPE_HIGH BG=${bg.roundToInt()} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} Δ=${String.format("%.1f", combinedDelta)} -> maxSMBHB=${String.format("%.2f", maxSMBHB)}U (confirmed rise)"
 
-            // 🟡 ACTIVE RISE SENSITIVE: BG 120-140 (near target zone)
-            // 85% maxSMBHB for extra caution close to target
-            // Added combinedDelta check to confirm rise is real
-            bg >= 120 && bg < 140 && !honeymoon && ctx.mealData.slopeFromMinDeviation >= 1.0 && combinedDelta > 0.5 -> {
-                this.lastMaxSmbLadderBranch = LADDER_SENSITIVE_85
-                val partial = max(maxSMB, maxSMBHB * 0.85)
-                consoleLog.add("MAXSMB_SLOPE_SENSITIVE BG=${bg.roundToInt()} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} \u0394=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", partial)}U (85% maxSMBHB - confirmed rise)")
-                partial
-            }
+                MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH_BY_DELTA ->
+                    "MAXSMB_DELTA_HIGH BG=${bg.roundToInt()} shortAvgDelta=${String.format("%.2f", glucoseStatus.shortAvgDelta)} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} Δ=${String.format("%.1f", combinedDelta)} -> maxSMBHB=${String.format("%.2f", maxSMBHB)}U (confirmed rise by delta)"
 
-            // 🟠 MODERATE PLATEAU: BG 200-250, stable delta
-            // Compromise: 75% of maxSMBHB for elevated but not critical BG
-            bg >= 200 && bg < 250 && combinedDelta > -3.0 && combinedDelta < 3.0 -> {
-                this.lastMaxSmbLadderBranch = LADDER_PLATEAU_MODERATE_75
-                val partial = max(maxSMB, maxSMBHB * 0.75)
-                consoleLog.add("MAXSMB_PLATEAU_MODERATE BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", partial)}U (75% maxSMBHB)")
-                partial
-            }
+                MaxSmbLadder.LADDER_SENSITIVE_85         ->
+                    "MAXSMB_SLOPE_SENSITIVE BG=${bg.roundToInt()} slope=${String.format("%.2f", ctx.mealData.slopeFromMinDeviation)} Δ=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", ladder.ceilingU)}U (85% maxSMBHB - confirmed rise)"
 
-            // 🔵 FALLING PROTECTION: BG elevated but falling moderately
-            // Partial limit to avoid over-correction while still allowing some action
-            bg > 180 && combinedDelta <= -3.0 && combinedDelta > -8.0 -> {
-                this.lastMaxSmbLadderBranch = LADDER_FALLING_60
-                val partial = max(maxSMB, maxSMBHB * 0.6)
-                consoleLog.add("MAXSMB_FALLING BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", partial)}U (60% maxSMBHB)")
-                partial
-            }
+                MaxSmbLadder.LADDER_PLATEAU_MODERATE_75  ->
+                    "MAXSMB_PLATEAU_MODERATE BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", ladder.ceilingU)}U (75% maxSMBHB)"
 
-            // ⚪ STANDARD: Normal/low BG conditions
-            else -> {
-                this.lastMaxSmbLadderBranch = LADDER_STANDARD
-                consoleLog.add("MAXSMB_STANDARD BG=${bg.roundToInt()} -> ${String.format("%.2f", maxSMB)}U")
-                maxSMB
+                MaxSmbLadder.LADDER_FALLING_60           ->
+                    "MAXSMB_FALLING BG=${bg.roundToInt()} Δ=${String.format("%.1f", combinedDelta)} -> ${String.format("%.2f", ladder.ceilingU)}U (60% maxSMBHB)"
+
+                else                                     ->
+                    "MAXSMB_STANDARD BG=${bg.roundToInt()} -> ${String.format("%.2f", ladder.ceilingU)}U"
             }
-        }
+        )
+        this.maxSMB = ladder.ceilingU
 
         // 🔒 SAFETY CLAMP: Force Standard MaxSMB if < 120
         // User Rule: "lowbg when < 120". No bypass allowed.
@@ -2722,12 +2684,16 @@ class DetermineBasalaimiSMB2 @Inject constructor(
              // The exported branch tag must show that the clamp won, otherwise the tag reports a
              // promotion that never reached the dose.
              this.lastMaxSmbLadderBranch = when (this.lastMaxSmbLadderBranch) {
-                 LADDER_PLATEAU_CRITICAL    -> LADDER_PLATEAU_CRITICAL_CLAMPED
-                 LADDER_CONFIRMED_RISE_HIGH -> LADDER_CONFIRMED_RISE_HIGH_CLAMPED
-                 LADDER_SENSITIVE_85        -> LADDER_SENSITIVE_85_CLAMPED
-                 LADDER_PLATEAU_MODERATE_75 -> LADDER_PLATEAU_MODERATE_75_CLAMPED
-                 LADDER_FALLING_60          -> LADDER_FALLING_60_CLAMPED
-                 else                       -> LADDER_STANDARD
+                 MaxSmbLadder.LADDER_PLATEAU_CRITICAL    -> MaxSmbLadder.LADDER_PLATEAU_CRITICAL_CLAMPED
+                 MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH -> MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH_CLAMPED
+
+                 MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH_BY_DELTA ->
+                     MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH_BY_DELTA_CLAMPED
+
+                 MaxSmbLadder.LADDER_SENSITIVE_85        -> MaxSmbLadder.LADDER_SENSITIVE_85_CLAMPED
+                 MaxSmbLadder.LADDER_PLATEAU_MODERATE_75 -> MaxSmbLadder.LADDER_PLATEAU_MODERATE_75_CLAMPED
+                 MaxSmbLadder.LADDER_FALLING_60          -> MaxSmbLadder.LADDER_FALLING_60_CLAMPED
+                 else                                    -> MaxSmbLadder.LADDER_STANDARD
              }
              consoleLog.add("🔒 STRICT CLAMP: BG<120 -> Forced Standard MaxSMB (${String.format("%.2f", stdMaxSMB)}U)")
         }
@@ -9376,6 +9342,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         val bindingExportDraft = lastSmbBindingTraceDraft.copy(
             maxSmbLadderBranch = lastMaxSmbLadderBranch,
             slopeFromMinDeviation = lastSlopeFromMinDeviation,
+            shortAvgDeltaMgdl5m = lastShortAvgDeltaAtLadder,
         ).appendStage(
             "FINAL",
             bindingFinalU,
@@ -11087,18 +11054,20 @@ class DetermineBasalaimiSMB2 @Inject constructor(
     private var lastRiseFloorContributionMs: Long = 0L
 
     /**
-     * Which branch of the maxSMB ladder fired this tick, and the slope it read.
+     * Which branch of the maxSMB ladder fired this tick, and the two rise signals it read.
      *
      * The rise floor now obeys the ceiling this ladder picks, so we must be able to see whether the
      * ladder is sane. Measured on 2026-08-15: on the two rises that ended below 70 mg/dL the ladder
      * stayed on `STANDARD` while BG climbed 7 to 12 mg/dL per 5 minutes, and the only condition that
      * can have failed there is `slopeFromMinDeviation >= 1.0`. We cannot tell from the exports alone
-     * whether the slope was right or simply blind, so both values are written out.
+     * whether the slope was right or simply blind, so both rise signals are written out.
      *
-     * See [SmbBindingTrace] fields `max_smb_ladder_branch` and `slope_from_min_deviation`.
+     * See [SmbBindingTrace] fields `max_smb_ladder_branch`, `slope_from_min_deviation` and
+     * `short_avg_delta_mgdl_5m`.
      */
     private var lastMaxSmbLadderBranch: String? = null
     private var lastSlopeFromMinDeviation: Double? = null
+    private var lastShortAvgDeltaAtLadder: Double? = null
 
     /**
      * Deltas the end-of-tick safety net feeds the estimator with.

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTrace.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTrace.kt
@@ -49,6 +49,13 @@ internal data class SmbBindingTrace(
      */
     val maxSmbLadderBranch: String?,
     val slopeFromMinDeviation: Double?,
+    /**
+     * The `shortAvgDelta` the ladder read, mg/dL per 5 min.
+     *
+     * The rise branch opens on this value as well as on [slopeFromMinDeviation], so both are written
+     * out. Together they let a support package replay any candidate threshold on recorded ticks.
+     */
+    val shortAvgDeltaMgdl5m: Double?,
     val iobHeadroomU: Double?,
     val rbtBeforeU: Double?,
     val rbtAfterU: Double?,
@@ -85,6 +92,7 @@ internal data class SmbBindingTrace(
             putNullable("max_smb_high_bg_u", maxSmbHighBgU)
             putNullable("max_smb_ladder_branch", maxSmbLadderBranch)
             putNullable("slope_from_min_deviation", slopeFromMinDeviation)
+            putNullable("short_avg_delta_mgdl_5m", shortAvgDeltaMgdl5m)
             putNullable("iob_headroom_u", iobHeadroomU)
             putNullable("rbt_before_u", rbtBeforeU)
             putNullable("rbt_after_u", rbtAfterU)
@@ -136,6 +144,7 @@ internal data class SmbBindingTrace(
         val maxSmbHighBgU: Double? = null,
         val maxSmbLadderBranch: String? = null,
         val slopeFromMinDeviation: Double? = null,
+        val shortAvgDeltaMgdl5m: Double? = null,
         val iobHeadroomU: Double? = null,
         val rbtBeforeU: Double? = null,
         val rbtAfterU: Double? = null,
@@ -180,6 +189,7 @@ internal data class SmbBindingTrace(
                 maxSmbLadderBranch = maxSmbLadderBranch,
                 // NaN or Inf must never reach org.json — export null instead.
                 slopeFromMinDeviation = slopeFromMinDeviation.finiteOrNull(),
+                shortAvgDeltaMgdl5m = shortAvgDeltaMgdl5m.finiteOrNull(),
                 iobHeadroomU = iobHeadroomU.finiteOrNull(),
                 rbtBeforeU = rbtBeforeU.finiteOrNull(),
                 rbtAfterU = rbtAfterU.finiteOrNull(),

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadder.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadder.kt
@@ -1,0 +1,160 @@
+package app.aaps.plugins.aps.openAPSAIMI.smb
+
+import kotlin.math.max
+
+/**
+ * Chooses the maxSMB ceiling of a tick, and names the branch that chose it.
+ *
+ * The ladder answers one question: how much SMB may this tick deliver at most. It reads only the
+ * numbers passed in, so the same inputs always give the same answer and the choice can be tested
+ * without the 18 000-line loop class around it.
+ *
+ * The console lines and the BG below 120 safety clamp stay at the call site. This object only
+ * decides, it does not log and it does not clamp.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `f03fa321a6` (file SHA `057813c03b`, unchanged on tip
+ * `c5db5a0333`). Study already had this ladder **inline** in `DetermineBasalAIMI2` with the
+ * slope-only rise rule. Comparison against the reference: `f03fa321a6` added a second proof
+ * (`shortAvgDelta >= 8.0`) into the confirmed-rise branch. This lot takes **that** rule, then
+ * extracts — it does not keep a second parallel ladder.
+ *
+ * Study wiring: commonMain `internal object` (pure, no instance state, one tick consumer). No Metro
+ * `@Inject`. Sibling `SmbIntervalPolicy` is the same shape; a private field is for stateful meters
+ * such as [app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCache], not for a stateless decide().
+ */
+internal object MaxSmbLadder {
+
+    /**
+     * Stable tags naming which branch of the maxSMB ladder picked the ceiling for a tick.
+     *
+     * Exported as `smb_binding_trace.max_smb_ladder_branch`. The rise floor obeys the ceiling this
+     * ladder picks, so the tag is what tells us afterwards whether the ladder saw a rise (a promoted
+     * or partial branch) or saw nothing at all ([LADDER_STANDARD]). The two readings mean very
+     * different things.
+     *
+     * The `_CLAMPED` twins mean the branch fired and the BG below 120 safety clamp then pulled the
+     * ceiling back down to the standard preference. Without them the tag would report a promotion
+     * that never reached the dose. [LADDER_STANDARD] has no twin: it already sets the standard
+     * preference, so the clamp cannot lower it further.
+     */
+    const val LADDER_PLATEAU_CRITICAL = "PLATEAU_CRITICAL_BG250"
+    const val LADDER_PLATEAU_CRITICAL_CLAMPED = "PLATEAU_CRITICAL_BG250_CLAMPED"
+    const val LADDER_CONFIRMED_RISE_HIGH = "CONFIRMED_RISE_HIGH"
+    const val LADDER_CONFIRMED_RISE_HIGH_CLAMPED = "CONFIRMED_RISE_HIGH_CLAMPED"
+
+    /**
+     * The confirmed rise was opened by [RISE_SHORT_DELTA_THRESHOLD], not by the deviation slope.
+     *
+     * Kept apart from [LADDER_CONFIRMED_RISE_HIGH] so the next support package can count exactly the
+     * ticks this criterion added, and nothing else.
+     */
+    const val LADDER_CONFIRMED_RISE_HIGH_BY_DELTA = "CONFIRMED_RISE_HIGH_BY_DELTA"
+    const val LADDER_CONFIRMED_RISE_HIGH_BY_DELTA_CLAMPED = "CONFIRMED_RISE_HIGH_BY_DELTA_CLAMPED"
+    const val LADDER_SENSITIVE_85 = "SENSITIVE_85"
+    const val LADDER_SENSITIVE_85_CLAMPED = "SENSITIVE_85_CLAMPED"
+    const val LADDER_PLATEAU_MODERATE_75 = "PLATEAU_MODERATE_75"
+    const val LADDER_PLATEAU_MODERATE_75_CLAMPED = "PLATEAU_MODERATE_75_CLAMPED"
+    const val LADDER_FALLING_60 = "FALLING_60"
+    const val LADDER_FALLING_60_CLAMPED = "FALLING_60_CLAMPED"
+    const val LADDER_STANDARD = "STANDARD"
+
+    /**
+     * Second way into the confirmed-rise branch: the plain 15 minute average delta, mg/dL per 5 min.
+     *
+     * `slopeFromMinDeviation` is an oref0 carb absorption estimate, smoothed over 20 to 40 minutes,
+     * and its denominator grows while BG is climbing. It was never built to answer "is BG going up
+     * right now", and on 24 hours of production data it is at or above 1.0 only 10 % of the time,
+     * with a median of 0.02. Asking it that question is what lost 13 minutes on the undeclared meal
+     * of 2026-09-05.
+     *
+     * `shortAvgDelta` is an average of the deltas over the last 15 minutes. It subtracts no BGI and
+     * needs no hour of history, so it answers the question directly. 8.0 mg/dL per 5 min is about
+     * 96 mg/dL per hour: there is no room for doubt about the direction.
+     *
+     * Measured on the same 24 hours of production: this threshold opens 14 extra ticks, all of them
+     * at BG at or above 141, delta at or above 7.4, and no carbs on board. None of them was falling.
+     */
+    const val RISE_SHORT_DELTA_THRESHOLD = 8.0
+
+    /**
+     * The ceiling this ladder picked, and the name of the branch that picked it.
+     *
+     * @property ceilingU maxSMB ceiling for the tick, in units.
+     * @property branch one of the `LADDER_*` tags above.
+     */
+    data class Decision(val ceilingU: Double, val branch: String)
+
+    /**
+     * Picks the maxSMB ceiling for one tick.
+     *
+     * The branches are tried in order and the first match wins:
+     *  1. BG at or above 250 and not falling fast — full high-BG ceiling.
+     *  2. Confirmed rise at high BG, seen by the deviation slope or by the 15 min average
+     *     delta — full high-BG ceiling.
+     *  3. Confirmed rise between 120 and 140 — 85 % of the high-BG ceiling.
+     *  4. Plateau between 200 and 250 with a small delta — 75 % of the high-BG ceiling.
+     *  5. High BG falling moderately — 60 % of the high-BG ceiling.
+     *  6. Anything else — the standard preference.
+     *
+     * @param bgMgdl current glucose, mg/dL.
+     * @param combinedDelta the tick's blended glucose delta, mg/dL per 5 min.
+     * @param slopeFromMinDeviation the oref0 carb absorption estimate.
+     * @param shortAvgDeltaMgdl5m average of the deltas over the last 15 min, mg/dL per 5 min.
+     * @param honeymoon true when the user set the honeymoon preference.
+     * @param maxSmb the standard maxSMB preference, in units.
+     * @param maxSmbHighBg the high-BG maxSMB preference, in units.
+     */
+    fun decide(
+        bgMgdl: Double,
+        combinedDelta: Double,
+        slopeFromMinDeviation: Double,
+        shortAvgDeltaMgdl5m: Double,
+        honeymoon: Boolean,
+        maxSmb: Double,
+        maxSmbHighBg: Double,
+    ): Decision = when {
+
+        // CRITICAL PLATEAU: BG >= 250, regardless of slope.
+        // Absolute emergency if BG catastrophic, even with low delta.
+        // Protection: do not apply if rapid fall (delta <= -5).
+        bgMgdl >= 250 && combinedDelta > -5.0 ->
+            Decision(maxSmbHighBg, LADDER_PLATEAU_CRITICAL)
+
+        // ACTIVE RISE HIGH: BG >= 140 (meal interception zone).
+        // Full high-BG ceiling for a confirmed meal or resistance in the elevated range.
+        // The combinedDelta check confirms the rise is real.
+        // Two ways in, on purpose: the deviation slope, and the plain 15 min average delta. See
+        // [RISE_SHORT_DELTA_THRESHOLD] for why the slope alone is not enough.
+        (bgMgdl >= 140 && !honeymoon &&
+            (slopeFromMinDeviation >= 1.0 || shortAvgDeltaMgdl5m >= RISE_SHORT_DELTA_THRESHOLD) &&
+            combinedDelta > 0.5) ||
+            (bgMgdl >= 180 && honeymoon && slopeFromMinDeviation >= 1.4 && combinedDelta > 0.5) -> {
+            // Attribution must be exact: only the ticks the new criterion opened may carry the new
+            // tag, or the next support package cannot measure what the change did.
+            val openedByDeltaOnly = !honeymoon && slopeFromMinDeviation < 1.0
+            val branch =
+                if (openedByDeltaOnly) LADDER_CONFIRMED_RISE_HIGH_BY_DELTA
+                else LADDER_CONFIRMED_RISE_HIGH
+            Decision(maxSmbHighBg, branch)
+        }
+
+        // ACTIVE RISE SENSITIVE: BG 120-140 (near target zone).
+        // 85 % of the high-BG ceiling for extra caution close to target.
+        bgMgdl >= 120 && bgMgdl < 140 && !honeymoon && slopeFromMinDeviation >= 1.0 && combinedDelta > 0.5 ->
+            Decision(max(maxSmb, maxSmbHighBg * 0.85), LADDER_SENSITIVE_85)
+
+        // MODERATE PLATEAU: BG 200-250, stable delta.
+        // Compromise: 75 % of the high-BG ceiling for elevated but not critical BG.
+        bgMgdl >= 200 && bgMgdl < 250 && combinedDelta > -3.0 && combinedDelta < 3.0 ->
+            Decision(max(maxSmb, maxSmbHighBg * 0.75), LADDER_PLATEAU_MODERATE_75)
+
+        // FALLING PROTECTION: BG elevated but falling moderately.
+        // Partial limit to avoid over-correction while still allowing some action.
+        bgMgdl > 180 && combinedDelta <= -3.0 && combinedDelta > -8.0 ->
+            Decision(max(maxSmb, maxSmbHighBg * 0.6), LADDER_FALLING_60)
+
+        // STANDARD: normal or low BG conditions.
+        else ->
+            Decision(maxSmb, LADDER_STANDARD)
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadderCharacterizationTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadderCharacterizationTest.kt
@@ -1,0 +1,133 @@
+package app.aaps.plugins.aps.openAPSAIMI.smb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Freezes the maxSMB ladder as it behaved before it was moved out of `DetermineBasalAIMI2`.
+ *
+ * One fixture per branch. These tests are the proof that lifting the ladder into [MaxSmbLadder]
+ * changed nothing: they were written against the old inline `when` and must stay green through the
+ * move. They must also stay green after the shortAvgDelta rise fix, because that fix only opens a
+ * branch that was closed here, it never closes one that was open.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `f03fa321a6` (file SHA `057813c03b`, unchanged on tip
+ * `c5db5a0333`). Study source set: [MaxSmbLadder] is commonMain and has no mocks, so the tests live
+ * in `commonTest` (`kotlin.test`) — same layout as [app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsfOrderTest],
+ * not `androidHostTest` (mockito/Robolectric). Assertions are the same locks as the Truth/JUnit
+ * reference corpus.
+ */
+class MaxSmbLadderCharacterizationTest {
+
+    private val maxSmb = 1.60
+    private val maxSmbHighBg = 2.70
+
+    private fun decide(
+        bg: Double,
+        combinedDelta: Double,
+        slope: Double,
+        shortAvgDelta: Double = 0.0,
+        honeymoon: Boolean = false,
+    ) = MaxSmbLadder.decide(
+        bgMgdl = bg,
+        combinedDelta = combinedDelta,
+        slopeFromMinDeviation = slope,
+        shortAvgDeltaMgdl5m = shortAvgDelta,
+        honeymoon = honeymoon,
+        maxSmb = maxSmb,
+        maxSmbHighBg = maxSmbHighBg,
+    )
+
+    @Test
+    fun `BG 250 and above takes the critical plateau branch whatever the slope`() {
+        val decision = decide(bg = 250.0, combinedDelta = 0.2, slope = 0.02)
+
+        assertEquals(MaxSmbLadder.LADDER_PLATEAU_CRITICAL, decision.branch)
+        assertEquals(maxSmbHighBg, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 280 falling fast drops out of the critical plateau branch`() {
+        // combinedDelta <= -5 is the guard that keeps the emergency ceiling off a fast fall.
+        val decision = decide(bg = 280.0, combinedDelta = -6.0, slope = 0.02)
+
+        assertEquals(MaxSmbLadder.LADDER_FALLING_60, decision.branch)
+        assertEquals(maxSmbHighBg * 0.6, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 160 with a slope above one takes the confirmed rise branch`() {
+        val decision = decide(bg = 160.0, combinedDelta = 2.0, slope = 1.2)
+
+        assertEquals(MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH, decision.branch)
+        assertEquals(maxSmbHighBg, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 130 with a slope above one takes the sensitive 85 branch`() {
+        val decision = decide(bg = 130.0, combinedDelta = 2.0, slope = 1.1)
+
+        assertEquals(MaxSmbLadder.LADDER_SENSITIVE_85, decision.branch)
+        assertEquals(maxSmbHighBg * 0.85, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 220 on a flat plateau takes the moderate plateau branch`() {
+        val decision = decide(bg = 220.0, combinedDelta = 0.5, slope = 0.02)
+
+        assertEquals(MaxSmbLadder.LADDER_PLATEAU_MODERATE_75, decision.branch)
+        assertEquals(maxSmbHighBg * 0.75, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 190 falling moderately takes the falling 60 branch`() {
+        val decision = decide(bg = 190.0, combinedDelta = -4.0, slope = 0.02)
+
+        assertEquals(MaxSmbLadder.LADDER_FALLING_60, decision.branch)
+        assertEquals(maxSmbHighBg * 0.6, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `BG 100 takes the standard branch`() {
+        val decision = decide(bg = 100.0, combinedDelta = 1.0, slope = 1.5)
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `the honeymoon rise needs BG 180 and a slope of 1 point 4`() {
+        // Just under both honeymoon thresholds, so the ladder must stay on standard.
+        assertEquals(
+            MaxSmbLadder.LADDER_STANDARD,
+            decide(bg = 179.0, combinedDelta = 2.0, slope = 1.5, honeymoon = true).branch,
+        )
+        assertEquals(
+            MaxSmbLadder.LADDER_STANDARD,
+            decide(bg = 185.0, combinedDelta = 2.0, slope = 1.3, honeymoon = true).branch,
+        )
+        // Both thresholds met, so the ladder promotes.
+        assertEquals(
+            MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH,
+            decide(bg = 185.0, combinedDelta = 2.0, slope = 1.4, honeymoon = true).branch,
+        )
+    }
+
+    @Test
+    fun `the partial branches never fall below the standard preference`() {
+        // A user whose standard preference is higher than 85 percent of the high BG one still gets
+        // the standard preference, because the ladder takes the larger of the two.
+        val decision = MaxSmbLadder.decide(
+            bgMgdl = 220.0,
+            combinedDelta = 0.5,
+            slopeFromMinDeviation = 0.02,
+            shortAvgDeltaMgdl5m = 0.0,
+            honeymoon = false,
+            maxSmb = 3.0,
+            maxSmbHighBg = 2.0,
+        )
+
+        assertEquals(MaxSmbLadder.LADDER_PLATEAU_MODERATE_75, decision.branch)
+        assertEquals(3.0, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadderRiseByDeltaTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/smb/MaxSmbLadderRiseByDeltaTest.kt
@@ -1,0 +1,140 @@
+package app.aaps.plugins.aps.openAPSAIMI.smb
+
+import kotlin.math.max
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The confirmed-rise branch must also open on `shortAvgDelta`, not on `slopeFromMinDeviation` alone.
+ *
+ * Measured on the undeclared meal of 2026-09-05: BG crossed 140 at 13:54 but the SMB ceiling stayed
+ * at 0.60 U until 14:07, because `slopeFromMinDeviation` sat between 0.67 and 0.85 the whole time
+ * while `shortAvgDelta` ran from 7.5 to 12.5 mg/dL per 5 min. Thirteen lost minutes, then 13.78 U in
+ * 76 minutes with 67 % of it above 180 mg/dL.
+ *
+ * These tests pin the new opening AND every guard the fix must not weaken.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `f03fa321a6` (file SHA `057813c03b`, unchanged on tip
+ * `c5db5a0333`). Study source set: [MaxSmbLadder] is commonMain and has no mocks, so the tests live
+ * in `commonTest` (`kotlin.test`) — same layout as [MaxSmbLadderCharacterizationTest], not
+ * `androidHostTest`. Assertions are the same locks as the Truth/JUnit reference corpus.
+ */
+class MaxSmbLadderRiseByDeltaTest {
+
+    private val maxSmb = 0.60
+    private val maxSmbHighBg = 2.70
+
+    private fun decide(
+        bg: Double,
+        combinedDelta: Double,
+        slope: Double,
+        shortAvgDelta: Double,
+        honeymoon: Boolean = false,
+    ) = MaxSmbLadder.decide(
+        bgMgdl = bg,
+        combinedDelta = combinedDelta,
+        slopeFromMinDeviation = slope,
+        shortAvgDeltaMgdl5m = shortAvgDelta,
+        honeymoon = honeymoon,
+        maxSmb = maxSmb,
+        maxSmbHighBg = maxSmbHighBg,
+    )
+
+    @Test
+    fun `le tick 13h54 du 5 septembre promeut sur shortAvgDelta quand la pente de deviation est aveugle`() {
+        val decision = decide(bg = 141.0, combinedDelta = 2.0, slope = 0.85, shortAvgDelta = 9.0)
+
+        assertEquals(maxSmbHighBg, decision.ceilingU, absoluteTolerance = 1e-9)
+        assertEquals(MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH_BY_DELTA, decision.branch)
+    }
+
+    @Test
+    fun `une montee sous le seuil reste standard`() {
+        val decision = decide(bg = 141.0, combinedDelta = 2.0, slope = 0.85, shortAvgDelta = 7.9)
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `le plancher BG 140 n est pas affaibli`() {
+        val decision = decide(bg = 139.9, combinedDelta = 2.0, slope = 0.2, shortAvgDelta = 12.0)
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `la garde combinedDelta n est pas affaiblie`() {
+        val decision = decide(bg = 160.0, combinedDelta = 0.4, slope = 0.2, shortAvgDelta = 12.0)
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `une descente avec un shortAvgDelta residuel eleve ne prend pas la branche montee`() {
+        // shortAvgDelta averages 15 minutes, so it stays high for a while after a rise turns over.
+        // The combinedDelta guard is what keeps the ladder off the rise branch on that turn.
+        val decision = decide(bg = 210.0, combinedDelta = -2.0, slope = 0.2, shortAvgDelta = 9.0)
+
+        assertEquals(MaxSmbLadder.LADDER_PLATEAU_MODERATE_75, decision.branch)
+        assertEquals(max(maxSmb, maxSmbHighBg * 0.75), decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `le honeymoon est inchange`() {
+        val decision = decide(
+            bg = 190.0, combinedDelta = 2.0, slope = 0.9, shortAvgDelta = 12.0, honeymoon = true,
+        )
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `la bande 120 140 est inchangee`() {
+        val decision = decide(bg = 130.0, combinedDelta = 2.0, slope = 0.5, shortAvgDelta = 12.0)
+
+        assertEquals(MaxSmbLadder.LADDER_STANDARD, decision.branch)
+        assertEquals(maxSmb, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `le chemin pente historique garde son propre tag`() {
+        // Attribution matters: only ticks the new criterion opened may carry the new tag, or the
+        // next support package cannot measure the fix.
+        val decision = decide(bg = 160.0, combinedDelta = 2.0, slope = 1.03, shortAvgDelta = 2.0)
+
+        assertEquals(MaxSmbLadder.LADDER_CONFIRMED_RISE_HIGH, decision.branch)
+        assertEquals(maxSmbHighBg, decision.ceilingU, absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `le plafond promu ne depasse jamais la preference utilisateur`() {
+        val bgs = listOf(90.0, 119.0, 125.0, 139.9, 141.0, 185.0, 210.0, 260.0)
+        val deltas = listOf(-9.0, -4.0, -1.0, 0.4, 2.0, 6.0)
+        val slopes = listOf(0.0, 0.85, 1.03, 1.5)
+        val shortAvgDeltas = listOf(-5.0, 0.0, 7.9, 8.0, 12.0)
+        val prefs = listOf(0.6 to 2.7, 3.0 to 2.0, 1.6 to 1.6)
+
+        for (bg in bgs) for (d in deltas) for (s in slopes) for (sad in shortAvgDeltas) {
+            for ((std, high) in prefs) {
+                val decision = MaxSmbLadder.decide(
+                    bgMgdl = bg,
+                    combinedDelta = d,
+                    slopeFromMinDeviation = s,
+                    shortAvgDeltaMgdl5m = sad,
+                    honeymoon = false,
+                    maxSmb = std,
+                    maxSmbHighBg = high,
+                )
+                assertTrue(
+                    decision.ceilingU <= max(std, high),
+                    "ceiling ${decision.ceilingU} exceeded max($std, $high) at bg=$bg d=$d s=$s sad=$sad",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.5** uniquement.

- **Clinique** = référence `origin/dev_OAPSAIMI` fichier @ **`f03fa321a6844dd0d72bdbb6434106b0799485f7`** (file SHA `057813c03b`, inchangé sur le tip `c5db5a033379390bceb7851ff92004b72ef055bf`). Commit d’introduction vérifié : *« let a confirmed rise open the SMB ceiling, not only the slope »*.
- **Câblage** = study tip post-#76 **`2ffbfa32d91dbb4f771f8ccf56b78705e5cf1b52`** : **commonMain** `internal object` pur (pas d’état, un consommateur tick), **pas Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Preuve = **`:plugins:aps:jvmTest`** → MaxSmbLadderCharacterizationTest **9/9** + MaxSmbLadderRiseByDeltaTest **9/9**.

Pas de copie aveugle Hilt/javax. Pas de `org.json` (export via kotlinx / `putNullable`). Pas de remplacement aveugle de `DetermineBasalAIMI2`.

### Comparaison study vs référence (pointe `2ffbfa32`)

L’étude avait **déjà** l’échelle **inline** dans `DetermineBasalAIMI2` :
- constantes `LADDER_*` ~L1090–1100 (guide PORTING ~L1034–1042, décalé)
- branches ~L2661–2733 (guide ~L2600–2664, décalé)
- champ `lastMaxSmbLadderBranch` ~L11100 (guide ~L10992, décalé)

**Résultat de la comparaison : mise à jour de règle + extraction.** Les seuils / branches plateau / 85 % / 75 % / 60 % / honeymoon / clamp BG&lt;120 sont identiques. `f03fa321a6` a **changé** la branche montée confirmée : `slope >= 1.0` **ou** `shortAvgDelta >= 8.0` (`RISE_SHORT_DELTA_THRESHOLD`), tag dédié `CONFIRMED_RISE_HIGH_BY_DELTA`. L’inline study n’avait que la pente. Ce lot prend **cette** règle, puis extrait — **pas** une deuxième échelle parallèle.

### Copié / adapté

- `MaxSmbLadder` → **commonMain**. Formules et ordre des branches = référence. Seule adaptation KMP : source set + `kotlin.test`.
- Tests : 9 caractérisations + 9 rise-by-delta (`f03fa321a6`) en `commonTest`.
- Pattern frère : objet sans état comme `SmbIntervalPolicy`. Un champ privé servirait un meter stateful (`DynIsfCache` / `ObservedSensitivityMeter`), pas un `decide()`.

### Sites câblés — hunks `f03fa321a6` MaxSmbLadder seulement

**Tick** (`DetermineBasalAIMI2` androidMain)
1. Import `MaxSmbLadder`.
2. Suppression des constantes `LADDER_*` fichier.
3. `MaxSmbLadder.decide(...)` à la place du `when` inline. Lecture de **`glucoseStatus.shortAvgDelta`** (le membre `this.shortAvgDelta` n’est copié que ~95 lignes plus bas — piège nommé dans `f03fa321a6`).
4. Clamp BG&lt;120 inchangé, plus le jumeau `_CLAMPED` de `CONFIRMED_RISE_HIGH_BY_DELTA`.
5. `lastShortAvgDeltaAtLadder` : reset tick / export.

**Trace** (`SmbBindingTrace` commonMain)
6. Champ `shortAvgDeltaMgdl5m` + clé `short_avg_delta_mgdl_5m` (AimiJson / kotlinx, pas `org.json`).

Pas de hunk Autodrive / barrier / `mpcRequestedU` / Harmonia / InsulinOriginMeter / SmbTrainingRowBuffer / Kalman / P0.6–P0.8.

### Hors scope

P0.6–P0.8, leftovers Autodrive du même commit, 2ᵉ site `currentMaxSmb` (laissé tel quel sur la référence pour garder le tag mesurable), iOS `APS=true`.

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadderCharacterizationTest' \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadderRiseByDeltaTest'
  → Characterization 9/9, RiseByDelta 9/9 (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.*' \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.*'
  → CommandedIsfOrderTest 5/5, DynIsfCacheTest 7/7,
    ObservedSensitivityMeterTest 18/18,
    MaxSmbLadderCharacterizationTest 9/9, MaxSmbLadderRiseByDeltaTest 9/9
```

`:app:assembleFullDebug` **non lancé** : pas de nouvel `@Inject` / port Metro (`object` commonMain).

### Questions ouvertes

- Le 2ᵉ site `currentMaxSmb` (même pente, seuil 120) n’est **pas** passé par `MaxSmbLadder` sur la référence. Conservé tel quel pour que le tag `CONFIRMED_RISE_HIGH_BY_DELTA` reste mesurable.

## EN

Lot **P0.5** only.

- **Clinical** = reference `origin/dev_OAPSAIMI` file @ **`f03fa321a6844dd0d72bdbb6434106b0799485f7`** (file SHA `057813c03b`, unchanged on tip `c5db5a033379390bceb7851ff92004b72ef055bf`). Introducing commit verified: *“let a confirmed rise open the SMB ceiling, not only the slope”*.
- **Wiring** = study tip after #76 **`2ffbfa32d91dbb4f771f8ccf56b78705e5cf1b52`**: **commonMain** pure `internal object` (no instance state, one tick consumer), **not Metro** `@Inject` / `@SingleIn`.
- **Tests** = **`commonTest`** + **`kotlin.test`**. Evidence = **`:plugins:aps:jvmTest`** → MaxSmbLadderCharacterizationTest **9/9** + MaxSmbLadderRiseByDeltaTest **9/9**.

Not a blind Hilt/javax copy. No `org.json` (export via kotlinx / `putNullable`). No wholesale replace of `DetermineBasalAIMI2`.

### Study vs reference comparison (tip `2ffbfa32`)

Study already had the ladder **inline** in `DetermineBasalAIMI2`:
- `LADDER_*` constants ~L1090–1100 (PORTING guide ~L1034–1042, shifted)
- branches ~L2661–2733 (guide ~L2600–2664, shifted)
- field `lastMaxSmbLadderBranch` ~L11100 (guide ~L10992, shifted)

**Comparison result: rule update + extract.** Plateau / 85 % / 75 % / 60 % / honeymoon / BG&lt;120 clamp numbers match. `f03fa321a6` **changed** the confirmed-rise branch: `slope >= 1.0` **or** `shortAvgDelta >= 8.0` (`RISE_SHORT_DELTA_THRESHOLD`), dedicated tag `CONFIRMED_RISE_HIGH_BY_DELTA`. Study inline was slope-only. This lot takes **that** rule, then extracts — **not** a second parallel ladder.

### What was copied / adapted

- `MaxSmbLadder` → **commonMain**. Clinical formulas and branch order = reference. KMP adaptation only: source set + `kotlin.test`.
- Tests: the 9 characterisation + 9 rise-by-delta locks from `f03fa321a6` in `commonTest`.
- Sibling pattern: stateless object like `SmbIntervalPolicy`. A private field is for a stateful meter (`DynIsfCache` / `ObservedSensitivityMeter`), not for a `decide()`.

### Call sites wired — `f03fa321a6` MaxSmbLadder hunks only

**Tick** (`DetermineBasalAIMI2` androidMain)
1. Import `MaxSmbLadder`.
2. Drop file-level `LADDER_*` constants.
3. `MaxSmbLadder.decide(...)` instead of the inline `when`. Reads **`glucoseStatus.shortAvgDelta`** (`this.shortAvgDelta` is only copied ~95 lines later — the trap named in `f03fa321a6`).
4. BG&lt;120 clamp unchanged, plus the `_CLAMPED` twin for `CONFIRMED_RISE_HIGH_BY_DELTA`.
5. `lastShortAvgDeltaAtLadder`: per-tick reset / export.

**Trace** (`SmbBindingTrace` commonMain)
6. Field `shortAvgDeltaMgdl5m` + key `short_avg_delta_mgdl_5m` (AimiJson / kotlinx, not `org.json`).

No Autodrive / barrier / `mpcRequestedU` / Harmonia / InsulinOriginMeter / SmbTrainingRowBuffer / Kalman / P0.6–P0.8 hunks.

### Out of scope

P0.6–P0.8, leftover Autodrive hunks from the same commit, the second `currentMaxSmb` site (left as-is on the reference so the tag stays measurable), iOS `APS=true`.

### Evidence

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadderCharacterizationTest' \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadderRiseByDeltaTest'
  → Characterization 9/9, RiseByDelta 9/9 (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.ISF.*' \
  --tests 'app.aaps.plugins.aps.openAPSAIMI.smb.*'
  → CommandedIsfOrderTest 5/5, DynIsfCacheTest 7/7,
    ObservedSensitivityMeterTest 18/18,
    MaxSmbLadderCharacterizationTest 9/9, MaxSmbLadderRiseByDeltaTest 9/9
```

`:app:assembleFullDebug` **not run**: no new `@Inject` / Metro port (commonMain `object`).

### Open questions

- The second `currentMaxSmb` site (same slope, 120 threshold) is **not** routed through `MaxSmbLadder` on the reference. Left as-is so the `CONFIRMED_RISE_HIGH_BY_DELTA` tag stays measurable.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb4f5d9b-c247-4354-b589-081a6a7fa130?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb4f5d9b-c247-4354-b589-081a6a7fa130&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

