### PR TITLE
P0.6 — HarmoniaCounterfactual + InsulinOriginMeter: observation pair on the KMP study branch

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -54,6 +54,9 @@ import app.aaps.plugins.aps.openAPSAIMI.carbs.CarbsAdvisor
 import app.aaps.plugins.aps.openAPSAIMI.ISF.CommandedIsf
 import app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeter
 import app.aaps.plugins.aps.openAPSAIMI.ISF.SensitivityRatioEstimator
+import app.aaps.plugins.aps.openAPSAIMI.patient.HarmoniaCounterfactual
+import app.aaps.plugins.aps.openAPSAIMI.patient.HarmoniaSafetyVerdict
+import app.aaps.plugins.aps.openAPSAIMI.quality.InsulinOriginMeter
 import app.aaps.core.interfaces.ui.UiInteraction
 import app.aaps.plugins.aps.openAPSAIMI.context.ContextSnapshot
 import app.aaps.plugins.aps.openAPSAIMI.utils.AimiPath
@@ -382,6 +385,58 @@ internal data class AimiDecisionContext(
         var isf_obs_last_window_drop_mgdl: Double? = null,
         /** Insulin credited to that window, U. */
         var isf_obs_last_window_absorbed_u: Double? = null,
+        /**
+         * Harmonia counterfactual, strictly passive. Nothing in the dosing chain reads these fifteen
+         * fields, and nothing may ever read them: they exist only so that what Harmonia proposed can
+         * be compared, after the fact, with what was really done.
+         *
+         * Harmonia is asked for a plan before the tick knows whether the SMB channel was zeroed for
+         * safety. It is then judged on exactly that verdict, and never told it, nor told that it was
+         * refused. These fields write down the missing message and its price:
+         *
+         *  - `harmonia_cf_*` — what Harmonia would propose if it were told, and whether that differs
+         *    from what it really proposed. [harmonia_cf_changes_proposal] is the whole question.
+         *  - `harmonia_block_*` — the size of the refusal. [harmonia_block_stake_u] is signed:
+         *    negative means the refusal **added** insulin, because it refused an under-dose.
+         *  - `harmonia_verdict_*` — the mirrored safety verdict.
+         *    [harmonia_verdict_known_to_engine] is the witness of inertia: it is written `false`, and
+         *    stays `false` for as long as nothing feeds the verdict back into the decision.
+         *  - `harmonia_prev_*` — what refused the previous tick, and for how many ticks in a row.
+         *  - [harmonia_tree_risk_divergence] — set only when the tree trunk and Harmonia disagree on
+         *    the risk level.
+         *
+         * `var`, and written after this object is built, like the fields above. See
+         * `HarmoniaCounterfactual`.
+         */
+        var harmonia_cf_rule: String? = null,
+        /** Action Harmonia would propose knowing the verdict. */
+        var harmonia_cf_action: String? = null,
+        /** Basal that goes with that action, U/h. */
+        var harmonia_cf_basal_uph: Double? = null,
+        /** `true` only when knowing the verdict would change the proposal. */
+        var harmonia_cf_changes_proposal: Boolean? = null,
+        /** The refused request was above the profile basal by more than one pump step. */
+        var harmonia_block_was_escalation: Boolean? = null,
+        /** Request minus profile basal, U/h, signed. */
+        var harmonia_block_delta_uph: Double? = null,
+        /** Insulin the refusal moved over the applied duration, U, signed. */
+        var harmonia_block_stake_u: Double? = null,
+        /** Applied rate minus requested rate, U/h. */
+        var harmonia_applied_gap_uph: Double? = null,
+        /** Mirrored verdict: a safety rule zeroed the SMB of this tick. */
+        var harmonia_verdict_critical_safety: Boolean? = null,
+        /** Mirrored verdict: the active context suppresses the SMB of this tick. */
+        var harmonia_verdict_context_suppress: Boolean? = null,
+        /** Mirrored verdict: a manual meal mode is declared, which exempts the channel. */
+        var harmonia_verdict_meal_mode: Boolean? = null,
+        /** Witness of inertia. Written `false`: the engine is never told the verdict. */
+        var harmonia_verdict_known_to_engine: Boolean? = null,
+        /** Runtime blocker of the previous tick, `null` when there was none. */
+        var harmonia_prev_blocker: String? = null,
+        /** How many ticks in a row the same blocker has refused Harmonia. */
+        var harmonia_prev_blocked_streak: Int? = null,
+        /** `"tronc=X|harmonia=Y"` when the two risk views differ, `null` when they agree. */
+        var harmonia_tree_risk_divergence: String? = null,
         /** Fast estimator 1: Kalman-filtered raw ISF. */
         val isf_kalman_fast_mgdl: Double? = null,
         /** Fast estimator 2: IsfAdjustmentEngine output. */
@@ -593,6 +648,11 @@ internal data class AimiDecisionContext(
          * it, and the SMB before / after its cap. See `docs/adr/0006-autodrive-consumes-authority.md`.
          */
         var post_hypo_delivery: JsonObject? = null,
+        /**
+         * Running share of the delivered insulin the model actually asked for, against the share the
+         * floors added. Observation only; no dose reads it. See `InsulinOriginMeter`.
+         */
+        var insulin_origin: JsonObject? = null,
     )
 
     data class T3cRuntimeOwnershipExport(
@@ -729,6 +789,21 @@ internal data class AimiDecisionContext(
             base.put("isf_obs_last_window_mgdl", baseline_state.isf_obs_last_window_mgdl ?: AimiJson.NULL)
             base.put("isf_obs_last_window_drop_mgdl", baseline_state.isf_obs_last_window_drop_mgdl ?: AimiJson.NULL)
             base.put("isf_obs_last_window_absorbed_u", baseline_state.isf_obs_last_window_absorbed_u ?: AimiJson.NULL)
+            base.put("harmonia_cf_rule", baseline_state.harmonia_cf_rule ?: AimiJson.NULL)
+            base.put("harmonia_cf_action", baseline_state.harmonia_cf_action ?: AimiJson.NULL)
+            base.put("harmonia_cf_basal_uph", baseline_state.harmonia_cf_basal_uph ?: AimiJson.NULL)
+            base.put("harmonia_cf_changes_proposal", baseline_state.harmonia_cf_changes_proposal ?: AimiJson.NULL)
+            base.put("harmonia_block_was_escalation", baseline_state.harmonia_block_was_escalation ?: AimiJson.NULL)
+            base.put("harmonia_block_delta_uph", baseline_state.harmonia_block_delta_uph ?: AimiJson.NULL)
+            base.put("harmonia_block_stake_u", baseline_state.harmonia_block_stake_u ?: AimiJson.NULL)
+            base.put("harmonia_applied_gap_uph", baseline_state.harmonia_applied_gap_uph ?: AimiJson.NULL)
+            base.put("harmonia_verdict_critical_safety", baseline_state.harmonia_verdict_critical_safety ?: AimiJson.NULL)
+            base.put("harmonia_verdict_context_suppress", baseline_state.harmonia_verdict_context_suppress ?: AimiJson.NULL)
+            base.put("harmonia_verdict_meal_mode", baseline_state.harmonia_verdict_meal_mode ?: AimiJson.NULL)
+            base.put("harmonia_verdict_known_to_engine", baseline_state.harmonia_verdict_known_to_engine ?: AimiJson.NULL)
+            base.put("harmonia_prev_blocker", baseline_state.harmonia_prev_blocker ?: AimiJson.NULL)
+            base.put("harmonia_prev_blocked_streak", baseline_state.harmonia_prev_blocked_streak ?: AimiJson.NULL)
+            base.put("harmonia_tree_risk_divergence", baseline_state.harmonia_tree_risk_divergence ?: AimiJson.NULL)
             base.put("isf_kalman_fast_mgdl", baseline_state.isf_kalman_fast_mgdl ?: AimiJson.NULL)
             base.put("isf_adj_engine_mgdl", baseline_state.isf_adj_engine_mgdl ?: AimiJson.NULL)
             base.put("isf_fused_slow_mgdl", baseline_state.isf_fused_slow_mgdl ?: AimiJson.NULL)
@@ -1002,6 +1077,9 @@ internal data class AimiDecisionContext(
             }
             adjustments.post_hypo_delivery?.let { postHypoDelivery ->
                 adj.put("post_hypo_delivery", postHypoDelivery)
+            }
+            adjustments.insulin_origin?.let { insulinOrigin ->
+                adj.put("insulin_origin", insulinOrigin)
             }
             json.put("adjustments", adj)
 
@@ -1352,6 +1430,17 @@ class DetermineBasalaimiSMB2 @Inject constructor(
      * nothing else can reach it. Any new call site is a bug. See `ObservedSensitivityMeter`.
      */
     private val observedSensitivityMeter = ObservedSensitivityMeter()
+
+    /**
+     * Passive reference instrument. It measures which share of the delivered insulin the model
+     * really asked for, and which share the floors added under it, and writes the answer to
+     * `adjustments.insulin_origin` only.
+     *
+     * **Only the export stage may reach it.** It is a plain private field on purpose: not @Inject,
+     * not @Singleton, so nothing else can. Any other call site is a bug — it would mean a dose
+     * depends on a passive instrument. See `InsulinOriginMeter`.
+     */
+    private val insulinOriginMeter = InsulinOriginMeter()
 
     @Inject lateinit var sensitivityRatioEstimator: SensitivityRatioEstimator
     @Inject lateinit var continuousStateEstimator: app.aaps.plugins.aps.openAPSAIMI.autodrive.estimator.ContinuousStateEstimator
@@ -3697,6 +3786,10 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                         it.enabled && it.applicationMode == EndocrineApplicationMode.APPLIED
                     }
                     ?.effectiveBasalAmp,
+                // Carried for the export and the counterfactual only. The decision engine does not
+                // read these two, and a test locks that down.
+                priorRuntimeBlocker = harmoniaPrevRuntimeBlocker,
+                priorBlockedStreak = harmoniaBlockedStreak,
             )
         }
         val harmoniaDecision = HarmoniaDecisionEngine.evaluate(
@@ -9157,6 +9250,52 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             decisionCtx.baseline_state.isf_obs_last_window_absorbed_u = observed.lastWindow?.absorbedU
         }
 
+        // Observation only — the Harmonia counterfactual. It answers two questions and changes
+        // nothing: "would Harmonia propose something else if it were told the safety verdict", and
+        // "how much insulin does the refusal move". The verdict below is a mirror of the real guard;
+        // it is never handed back to the engine, which is what `harmonia_verdict_known_to_engine`
+        // records. See `HarmoniaCounterfactual`.
+        runCatching {
+            val verdict = HarmoniaSafetyVerdict(
+                criticalSafetyZeroed = criticalSafetyZeroedThisTick,
+                contextSuppressSmb = lastContextSuppressSmb,
+                mealModeActive = manualMealModeActive(),
+                guardsEnabled = basalChannelSafetyGuardsActive(),
+            )
+            val counterfactual = HarmoniaCounterfactual.evaluate(
+                simulation = lastHarmoniaDecision,
+                production = lastHarmoniaProductionDecision,
+                verdict = verdict,
+                profileBasalUph = profile.current_basal,
+                appliedRateUph = finalResult.rate,
+                appliedDurationMin = finalResult.duration ?: 30,
+            )
+            decisionCtx.baseline_state.harmonia_cf_rule = counterfactual.rule.name
+            decisionCtx.baseline_state.harmonia_cf_action = counterfactual.counterfactualAction?.name
+            decisionCtx.baseline_state.harmonia_cf_basal_uph = counterfactual.counterfactualBasalUph
+            decisionCtx.baseline_state.harmonia_cf_changes_proposal = counterfactual.changesProposal
+            decisionCtx.baseline_state.harmonia_block_was_escalation = counterfactual.requestWasEscalation
+            decisionCtx.baseline_state.harmonia_block_delta_uph = counterfactual.requestDeltaVsProfileUph
+            decisionCtx.baseline_state.harmonia_block_stake_u = counterfactual.blockStakeU
+            decisionCtx.baseline_state.harmonia_applied_gap_uph = counterfactual.appliedGapUph
+            decisionCtx.baseline_state.harmonia_verdict_critical_safety = verdict.criticalSafetyZeroed
+            decisionCtx.baseline_state.harmonia_verdict_context_suppress = verdict.contextSuppressSmb
+            decisionCtx.baseline_state.harmonia_verdict_meal_mode = verdict.mealModeActive
+            // Hard-coded false: witness of inertia. It stays false for as long as no decision path
+            // reads the verdict. The day one does, this line has to change with it.
+            decisionCtx.baseline_state.harmonia_verdict_known_to_engine = false
+            decisionCtx.baseline_state.harmonia_prev_blocker = harmoniaPrevRuntimeBlocker
+            decisionCtx.baseline_state.harmonia_prev_blocked_streak = harmoniaBlockedStreak
+            val trunkRisk = lastPhysiologicalTreeSnapshot?.trunk?.riskLevel
+            val harmoniaRisk = lastHarmoniaDecision?.decisionBasis?.trunkRisk
+            decisionCtx.baseline_state.harmonia_tree_risk_divergence =
+                if (trunkRisk != null && harmoniaRisk != null && trunkRisk != harmoniaRisk) {
+                    "tronc=${trunkRisk.name}|harmonia=${harmoniaRisk.name}"
+                } else {
+                    null
+                }
+        }
+
         decisionCtx.adjustments.dynamic_isf = AimiDecisionContext.DynamicIsf(
             final_value_mgdl = snapshotFusedIsf,
             modifiers = mutableListOf<AimiDecisionContext.Modifier>().apply {
@@ -9352,6 +9491,26 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         )
         decisionCtx.adjustments.smb_binding_trace = bindingExportDraft.build(bindingFinalU).toJsonObject()
 
+        // Observation only — running share of the delivered insulin the model really asked for.
+        // Placed here on purpose, **after** `bindingExportDraft` is complete: read any earlier and
+        // the model output and the floor of this tick are not both known yet, so the split would be
+        // wrong on exactly the ticks it is meant to describe. See `InsulinOriginMeter`.
+        runCatching {
+            insulinOriginMeter.observe(
+                InsulinOriginMeter.Sample(
+                    timestampMs = decisionCtx.timestamp,
+                    finalU = bindingFinalU,
+                    modelOutputU = bindingExportDraft.modelOutputU,
+                    mpcOutputU = bindingExportDraft.mpcOutputU,
+                    autodriveFloorU = bindingExportDraft.autodriveFloorU,
+                    bindingStage = bindingExportDraft.stages.lastOrNull()?.name,
+                    originOwner = bindingExportDraft.originOwner,
+                ),
+            )
+            decisionCtx.adjustments.insulin_origin =
+                insulinOriginMeter.read(decisionCtx.timestamp).toJsonObject()
+        }
+
         lastAuditorLoopSnapshot?.let { snapshot ->
             decisionCtx.adjustments.auditor_tick = snapshot.toJsonObject()
         }
@@ -9466,6 +9625,18 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         } catch (e: Exception) {
             consoleError.add("Failed to save HORMONITOR event JSON: ${e.message}")
         }
+
+        // Very last thing the stage does, and it must stay last: the export above has already read
+        // `harmoniaPrevRuntimeBlocker`, so updating here is what makes "previous" mean the previous
+        // tick. Move this up and every line would export its own blocker while claiming it is the
+        // one before. Observation only.
+        val nowBlocker = lastHarmoniaProductionDecision?.runtimeBlocker
+        harmoniaBlockedStreak = when {
+            nowBlocker != null && nowBlocker == harmoniaPrevRuntimeBlocker -> harmoniaBlockedStreak + 1
+            nowBlocker != null                                            -> 1
+            else                                                          -> 0
+        }
+        harmoniaPrevRuntimeBlocker = nowBlocker
     }
 
     private fun aimiDecisionsJsonlFile(): AimiPath = storage.file("AIMI_Decisions.jsonl")
@@ -11151,6 +11322,20 @@ class DetermineBasalaimiSMB2 @Inject constructor(
     private var lastMealCertainty: MealCertainty? = null
     private var lastHarmonizerOutcome: HarmoniaHarmonizer.Outcome? = null
     private var lastHarmoniaProductionDecision: HarmoniaProductionDecision? = null
+
+    /**
+     * Runtime blocker that refused Harmonia on the **previous** tick, and how many ticks in a row the
+     * same blocker has refused it.
+     *
+     * Deliberately **not** reset with the other `last*` fields at the start of a tick: a memory that
+     * is cleared every tick is not a memory. Same reason as `lastEffortMemory`, which the reset block
+     * also leaves alone. Both are written at the very end of the export stage, after the export has
+     * already read the previous value, so a tick exports the previous tick and never itself.
+     *
+     * Observation only. Nothing in the dosing chain reads either field.
+     */
+    private var harmoniaPrevRuntimeBlocker: String? = null
+    private var harmoniaBlockedStreak: Int = 0
     private var lastPatientSourceSensor: SourceSensor? = null
     /** Latest IOB surveillance snapshot for JSONL (updated each [finalizeAndCapSMB]). */
     private var lastIobSurveillanceExport: IobSurveillanceExport? = null

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaCounterfactual.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaCounterfactual.kt
@@ -1,0 +1,303 @@
+package app.aaps.plugins.aps.openAPSAIMI.patient
+
+import app.aaps.plugins.aps.openAPSAIMI.aimiFmt2
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Mirror of the basal-first safety verdict, as Harmonia would see it **if it were told**.
+ *
+ * Harmonia is asked for a plan long before the tick knows whether the SMB channel was zeroed for
+ * safety. The verdict is posted later, and the guard reads it later still. Harmonia therefore never
+ * learns the rule it is judged on, and never learns that it was refused.
+ *
+ * This class is that missing message, written down once so it can be measured. It is
+ * **strictly passive**: nothing in the dosing chain reads it, and the field
+ * [wouldBlockBasalFirst] is only a copy of the real rule, never the rule itself.
+ *
+ * The copy must stay identical to
+ * [app.aaps.plugins.aps.openAPSAIMI.basal.BasalChannelSafetyGuards.shouldBlockBasalFirst].
+ * `HarmoniaCounterfactualTest.verdictMirrorsBasalChannelSafetyGuards` compares the two call for
+ * call over the full truth table, so a change on one side and not the other fails the build.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `da9bc789ce` (file SHA `f89412ab72`, unchanged on tip
+ * `c5db5a0333`). Study wiring: commonMain `internal object` (pure, no instance state, one tick
+ * consumer). KMP adaptation only: kotlinx JSON instead of `org.json`, [aimiFmt2] instead of
+ * `String.format(Locale.US)`. Clinical formulas are unchanged.
+ *
+ * @param criticalSafetyZeroed a safety rule zeroed the SMB of this tick.
+ * @param contextSuppressSmb the active context suppresses the SMB of this tick.
+ * @param mealModeActive a manual meal mode is declared, which exempts the channel from the guard.
+ * @param guardsEnabled the guard preference is on. When off, the guard blocks nothing.
+ */
+data class HarmoniaSafetyVerdict(
+    val criticalSafetyZeroed: Boolean,
+    val contextSuppressSmb: Boolean,
+    val mealModeActive: Boolean,
+    val guardsEnabled: Boolean,
+) {
+
+    /** Exact copy of the production rule. Read the class doc before touching it. */
+    val wouldBlockBasalFirst: Boolean =
+        guardsEnabled && !mealModeActive && (criticalSafetyZeroed || contextSuppressSmb)
+
+    companion object {
+
+        /** No verdict was gathered for this tick. Blocks nothing, judges nothing. */
+        val UNKNOWN = HarmoniaSafetyVerdict(
+            criticalSafetyZeroed = false,
+            contextSuppressSmb = false,
+            mealModeActive = false,
+            guardsEnabled = false,
+        )
+    }
+}
+
+/**
+ * Which of the five cases the tick fell into. One case per line, no overlap.
+ */
+enum class HarmoniaCounterfactualRule {
+
+    /** No refusal to explain, or no request to compare. The counterfactual is the identity. */
+    NO_VERDICT,
+
+    /**
+     * The safety guard refused a request that was **below** the profile basal. The guard exists to
+     * stop over-dosing, so refusing an under-dose adds insulin instead of removing it. Knowing the
+     * verdict would not change the proposal: Harmonia was already standing down.
+     */
+    BLOCKED_REDUCTION,
+
+    /** The safety guard refused a request that was, in practice, the profile basal. Nothing at stake. */
+    BLOCKED_NEUTRAL,
+
+    /**
+     * The safety guard refused a request **above** the profile basal. This is the only case where
+     * telling Harmonia would change the proposal: it would stand down to the profile by itself.
+     */
+    WOULD_STAND_DOWN,
+
+    /** Some other blocker refused the tick. It must not be charged to the safety guard. */
+    BLOCKED_NON_SAFETY,
+}
+
+/**
+ * What Harmonia would have proposed if the safety verdict had been part of its environment, and
+ * what the refusal cost in insulin.
+ *
+ * Every field is an observation. Nothing here is applied, and nothing in the dosing chain reads it.
+ *
+ * @param rule which case the tick fell into.
+ * @param actualAction the action Harmonia really proposed.
+ * @param counterfactualAction the action it would propose knowing the verdict.
+ * @param counterfactualBasalUph the basal rate that goes with [counterfactualAction], U/h.
+ * @param changesProposal `true` only when the two proposals differ. This is the measured answer to
+ *   "would telling Harmonia change anything".
+ * @param requestWasEscalation the request was above the profile basal plus one pump step.
+ * @param requestDeltaVsProfileUph request minus profile basal, U/h, signed.
+ * @param blockStakeU insulin the refusal moved over the applied duration, U, signed. Negative means
+ *   the refusal **added** insulin, because it refused an under-dose.
+ * @param appliedGapUph applied rate minus requested rate, U/h. How far the pump ended up from the
+ *   request, whatever the reason.
+ * @param reason one short line, for a human reading the export.
+ */
+data class HarmoniaCounterfactualOutcome(
+    val rule: HarmoniaCounterfactualRule,
+    val actualAction: HarmoniaAction?,
+    val counterfactualAction: HarmoniaAction?,
+    val counterfactualBasalUph: Double?,
+    val changesProposal: Boolean,
+    val requestWasEscalation: Boolean,
+    val requestDeltaVsProfileUph: Double?,
+    val blockStakeU: Double?,
+    val appliedGapUph: Double?,
+    val reason: String,
+) {
+
+    fun toJsonObject(): JsonObject =
+        buildJsonObject {
+            put("rule", rule.name)
+            put("actual_action", actualAction?.name)
+            put("counterfactual_action", counterfactualAction?.name)
+            put("counterfactual_basal_uph", counterfactualBasalUph)
+            put("changes_proposal", changesProposal)
+            put("request_was_escalation", requestWasEscalation)
+            put("request_delta_vs_profile_uph", requestDeltaVsProfileUph)
+            put("block_stake_u", blockStakeU)
+            put("applied_gap_uph", appliedGapUph)
+            put("reason", reason)
+            put("source", "harmonia_counterfactual_v1")
+        }
+}
+
+/**
+ * Answers two questions from data the tick already holds, and answers nothing else:
+ *
+ *  1. would Harmonia propose something else if it were told the safety verdict,
+ *  2. how much insulin does the refusal move.
+ *
+ * ## Strictly passive
+ *
+ * Nothing in the dosing chain may read this. To check that, run:
+ *
+ * ```
+ * grep -rn "HarmoniaCounterfactual\|harmonia_cf_" plugins/aps/src/commonMain plugins/aps/src/androidMain
+ * ```
+ *
+ * It must return exactly three zones and nothing else: this file, the `BaselineState` field
+ * declarations with their `put` lines, and the one feeding block in the export stage of
+ * `DetermineBasalAIMI2`. Any other line is a violation.
+ */
+internal object HarmoniaCounterfactual {
+
+    /**
+     * Half-band around the profile basal, in U/h. One pump step: a difference smaller than this
+     * cannot be delivered, so it is not a real request to change the rate.
+     */
+    const val NEUTRAL_BAND_UPH = 0.05
+
+    /** The runtime blocker string the basal-first safety guard writes. */
+    const val SAFETY_BLOCKER = "smb_zeroed_by_safety"
+
+    /**
+     * @param simulation what Harmonia proposed this tick, `null` when it was not asked.
+     * @param production the production branch record, which carries the runtime blocker.
+     * @param verdict the safety verdict, mirrored. Pass [HarmoniaSafetyVerdict.UNKNOWN] when it
+     *   could not be gathered.
+     * @param profileBasalUph the profile basal of the tick, U/h.
+     * @param appliedRateUph the rate the tick really asks the pump for, U/h.
+     * @param appliedDurationMin the duration that rate is asked for, minutes.
+     */
+    fun evaluate(
+        simulation: HarmoniaDecision?,
+        production: HarmoniaProductionDecision?,
+        verdict: HarmoniaSafetyVerdict,
+        profileBasalUph: Double,
+        appliedRateUph: Double?,
+        appliedDurationMin: Int,
+    ): HarmoniaCounterfactualOutcome {
+        val actualAction = production?.sourceAction ?: simulation?.action
+        val requestedRateUph = production?.requestedRateUph ?: simulation?.targetBasalUph
+        val blocker = production?.runtimeBlocker
+
+        if (requestedRateUph == null || !requestedRateUph.isFinite() || !profileBasalUph.isFinite()) {
+            return identity(
+                rule = HarmoniaCounterfactualRule.NO_VERDICT,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = null,
+                requestWasEscalation = false,
+                blockStakeU = null,
+                appliedGapUph = null,
+                reason = "no comparable request this tick",
+            )
+        }
+
+        val delta = requestedRateUph - profileBasalUph
+        val escalation = delta > NEUTRAL_BAND_UPH
+        val stake = delta * appliedDurationMin / 60.0
+        val gap = appliedRateUph?.takeIf { it.isFinite() }?.let { it - requestedRateUph }
+
+        if (blocker == null) {
+            return identity(
+                rule = HarmoniaCounterfactualRule.NO_VERDICT,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = delta,
+                requestWasEscalation = escalation,
+                blockStakeU = 0.0,
+                appliedGapUph = gap,
+                reason = "no refusal this tick",
+            )
+        }
+
+        if (blocker != SAFETY_BLOCKER) {
+            return identity(
+                rule = HarmoniaCounterfactualRule.BLOCKED_NON_SAFETY,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = delta,
+                requestWasEscalation = escalation,
+                blockStakeU = stake,
+                appliedGapUph = gap,
+                reason = "refused by $blocker, not by the basal safety guard",
+            )
+        }
+
+        if (!verdict.wouldBlockBasalFirst) {
+            return identity(
+                rule = HarmoniaCounterfactualRule.NO_VERDICT,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = delta,
+                requestWasEscalation = escalation,
+                blockStakeU = stake,
+                appliedGapUph = gap,
+                reason = "safety blocker seen, but the mirrored verdict is not active",
+            )
+        }
+
+        return when {
+            delta < -NEUTRAL_BAND_UPH -> identity(
+                rule = HarmoniaCounterfactualRule.BLOCKED_REDUCTION,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = delta,
+                requestWasEscalation = false,
+                blockStakeU = stake,
+                appliedGapUph = gap,
+                reason = "guard refused a request ${aimiFmt2(-delta)} U/h below profile; knowing the verdict changes nothing",
+            )
+
+            delta <= NEUTRAL_BAND_UPH -> identity(
+                rule = HarmoniaCounterfactualRule.BLOCKED_NEUTRAL,
+                actualAction = actualAction,
+                requestedRateUph = requestedRateUph,
+                requestDeltaVsProfileUph = delta,
+                requestWasEscalation = false,
+                // Inside one pump step the difference cannot be delivered, so nothing is at stake.
+                blockStakeU = 0.0,
+                appliedGapUph = gap,
+                reason = "guard refused a request equal to the profile basal within one pump step",
+            )
+
+            else -> HarmoniaCounterfactualOutcome(
+                rule = HarmoniaCounterfactualRule.WOULD_STAND_DOWN,
+                actualAction = actualAction,
+                counterfactualAction = HarmoniaAction.OBSERVE,
+                counterfactualBasalUph = profileBasalUph,
+                changesProposal = true,
+                requestWasEscalation = true,
+                requestDeltaVsProfileUph = delta,
+                blockStakeU = stake,
+                appliedGapUph = gap,
+                reason = "guard refused a request ${aimiFmt2(delta)} U/h above profile; knowing the verdict, Harmonia would stand down",
+            )
+        }
+    }
+
+    /** The counterfactual proposal equals the real one: the outcome only carries the measurement. */
+    private fun identity(
+        rule: HarmoniaCounterfactualRule,
+        actualAction: HarmoniaAction?,
+        requestedRateUph: Double?,
+        requestDeltaVsProfileUph: Double?,
+        requestWasEscalation: Boolean,
+        blockStakeU: Double?,
+        appliedGapUph: Double?,
+        reason: String,
+    ): HarmoniaCounterfactualOutcome =
+        HarmoniaCounterfactualOutcome(
+            rule = rule,
+            actualAction = actualAction,
+            counterfactualAction = actualAction,
+            counterfactualBasalUph = requestedRateUph,
+            changesProposal = false,
+            requestWasEscalation = requestWasEscalation,
+            requestDeltaVsProfileUph = requestDeltaVsProfileUph,
+            blockStakeU = blockStakeU,
+            appliedGapUph = appliedGapUph,
+            reason = reason,
+        )
+}

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecision.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecision.kt
@@ -41,6 +41,18 @@ data class HarmoniaDecisionEnvironment(
      * - `>1.0` = use governor amp (capped).
      */
     val endocrineBasalAmp: Double? = null,
+    /**
+     * Runtime blocker that refused Harmonia on the **previous** tick, `null` when there was none.
+     *
+     * Doors for the export and for `HarmoniaCounterfactual` **only**. The decision never reads them:
+     * `evaluate`, `buildBlockers` and `chooseActionWithReason` all ignore them, and
+     * `HarmoniaDecisionEngineFeedbackIsInertTest` fails the build if that ever stops being true.
+     * They exist so the question "does Harmonia even know it was refused" has a place to be
+     * answered, before anything is wired.
+     */
+    val priorRuntimeBlocker: String? = null,
+    /** How many ticks in a row the same blocker refused Harmonia. Same rule: never read by the decision. */
+    val priorBlockedStreak: Int = 0,
     val seed: Long? = null,
 ) {
     fun toJsonObject(): JsonObject =
@@ -66,6 +78,8 @@ data class HarmoniaDecisionEnvironment(
             effectiveDiaHours?.let { put("effective_dia_h", it) }
             effectivePeakMinutes?.let { put("effective_peak_min", it) }
             put("body_kinetics", bodyKinetics.toJsonObject())
+            put("prior_runtime_blocker", priorRuntimeBlocker)
+            put("prior_blocked_streak", priorBlockedStreak)
             put("seed", seed)
         }
 }

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/InsulinOriginMeter.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/InsulinOriginMeter.kt
@@ -1,0 +1,328 @@
+package app.aaps.plugins.aps.openAPSAIMI.quality
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Measures **where the decided insulin came from**: the model, or the floors that sit under it.
+ *
+ * A tick can end with the same amount of insulin for two very different reasons. Either the model
+ * asked for it, or the model asked for nothing and a floor put it there anyway. The exported
+ * `smb_binding_trace` says this for one tick, but one tick answers nothing: the question is what
+ * share of a week of insulin the model actually decided. This class keeps that running share.
+ *
+ * ## Attribution rule
+ *
+ * For one sample, `raw = max(modelOutputU, autodriveFloorU)`. The floor share of the tick amount is
+ * `finalU * (raw - modelOutputU) / raw`, and the model share is the rest. So:
+ *
+ *  - model 1.0, floor 0.0 → everything is model,
+ *  - model 0.0, floor 1.5 → everything is floor,
+ *  - model 0.6, floor 1.2 → half model, half floor,
+ *  - both zero → nothing is attributed, and the amount lands in `otherOriginU`.
+ *
+ * ## The totals are tick-weighted, they are NOT delivered units
+ *
+ * Read this before using any `_u` number out of this class.
+ *
+ * `finalU` is the amount this tick **decided**, not the amount the pump enacted. This class sits in
+ * the decision path and has no way to know what the pump did. The loop also re-decides far more
+ * often than it delivers: with a one minute sensor the loop runs about every 60 seconds, and the
+ * same micro-bolus is proposed again on every run for as long as it stays valid. Each of those runs
+ * adds the full amount to the totals here.
+ *
+ * That is not a small error. On the night of 2026-09-05, on the 21:22 → 22:35 ramp, the ticks summed
+ * to 53.53 U while IOB only rose by 15.82 U — 53 U in 73 minutes is physically impossible. Over the
+ * whole night the old key `delivered_u` reported 66.03 U for a night of about 18 U.
+ *
+ * So the totals are named for what they are: **tick-weighted** sums. They are useful to compare two
+ * quantities measured the same way, and useless as an insulin amount.
+ *
+ * ## Why the shares survive and the totals do not
+ *
+ * `modelOriginShare` and `floorOriginShare` are ratios of two sums carried over the *same* ticks. A
+ * repeated tick adds its amount to the numerator and to the denominator in the same proportion, so
+ * repeating a decision does not move the ratio. Doubling the loop cadence doubles both totals and
+ * leaves both shares where they were. The shares still carry a weighting bias — a decision that
+ * survives many ticks weighs more than one that survives a single tick — but they are not inflated
+ * by the cadence, which is what makes them the readable part of this export.
+ *
+ * ## Window
+ *
+ * The window is defined in **time**, not in ticks: [windowMs], seven days by default. The previous
+ * version kept a fixed 2016 samples and called that "one week of 5 minute ticks"; at one tick per
+ * minute those same 2016 samples are 33 hours. [maxSamples] is only a memory cap, so a runaway
+ * caller cannot grow the deque without bound. It is not the definition of the window.
+ *
+ * ## Strictly passive
+ *
+ * Nothing in the dosing chain may read this. To check that, run:
+ *
+ * ```
+ * grep -rn "InsulinOriginMeter\|insulinOriginMeter" plugins/aps/src/commonMain plugins/aps/src/androidMain
+ * ```
+ *
+ * It must return exactly two zones: this file, and the import plus the single field and feeding
+ * block in `DetermineBasalAIMI2`. Any other line is a violation.
+ *
+ * ## No persistence
+ *
+ * Samples live in memory only. A process restart empties them. `tickCount` is the witness: when it
+ * is small, the shares have simply not been rebuilt yet.
+ *
+ * ## Not [IobSurveillanceExport]
+ *
+ * Study already has [IobSurveillanceExport]: a one-tick snapshot of plateau / high IOB / predicted
+ * drop. The reference added this meter **beside** that snapshot (`da9bc789ce`, rewritten as a
+ * time-window at `db21308e6c`). This class does not replace it.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `db21308e6c` (file SHA `8f5506d383`, unchanged on tip
+ * `c5db5a0333`). Study wiring: commonMain class + tick `private val` (one consumer, like
+ * [app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeter]). KMP adaptation only: kotlinx
+ * JSON instead of `org.json`, `kotlin.collections.ArrayDeque` instead of `java.util.ArrayDeque`.
+ * Clinical formulas, time window, and attribution rule are unchanged.
+ *
+ * @param windowMs how far back the window reaches, in milliseconds. Seven days by default.
+ * @param maxSamples memory cap on the number of kept samples. Reached only when the loop ticks
+ *   faster than every 30 seconds for a whole window.
+ */
+class InsulinOriginMeter(
+    private val windowMs: Long = DEFAULT_WINDOW_MS,
+    private val maxSamples: Int = DEFAULT_MAX_SAMPLES,
+) {
+
+    companion object {
+
+        /** Seven days. The window this meter is meant to answer on. */
+        const val DEFAULT_WINDOW_MS: Long = 7L * 24L * 60L * 60L * 1000L
+
+        /** Memory cap only: seven days at one sample every 30 seconds. */
+        const val DEFAULT_MAX_SAMPLES: Int = 20_160
+    }
+
+    /**
+     * One tick, as the binding trace saw it.
+     *
+     * @param timestampMs tick time.
+     * @param finalU insulin this tick decided, U. Not what the pump enacted — see the class doc.
+     * @param modelOutputU what the model asked for before the floors, U. `null` when unknown.
+     * @param mpcOutputU what the MPC asked for, U. Carried for the export, not used in the split.
+     * @param autodriveFloorU the floor that was in force, U. `null` when there was none.
+     * @param bindingStage last stage name of the binding trace, for reading back.
+     * @param originOwner which channel owned the amount.
+     */
+    data class Sample(
+        val timestampMs: Long,
+        val finalU: Double,
+        val modelOutputU: Double?,
+        val mpcOutputU: Double?,
+        val autodriveFloorU: Double?,
+        val bindingStage: String?,
+        val originOwner: String,
+    )
+
+    /**
+     * The running answer over the window.
+     *
+     * Every `U` field below is a **tick-weighted** sum, not an amount of insulin. See the class doc.
+     *
+     * @param tickCount how many samples the window holds.
+     * @param tickWeightedU sum of the decided amounts over those ticks, U per tick summed.
+     * @param modelOriginU part of it the model asked for, same weighting.
+     * @param floorOriginU part of it a floor added on top of the model, same weighting.
+     * @param otherOriginU part of it neither could explain, same weighting. Grows when insulin is
+     *   decided while both the model output and the floor are zero or unknown.
+     * @param modelZeroTickWeightedU tick-weighted amount on ticks where the model asked for nothing.
+     * @param modelZeroTickCount how many ticks those were.
+     * @param modelOriginShare `modelOriginU / tickWeightedU`, `null` while nothing was decided. Null,
+     *   never `0.0`: zero would read as "the model decided nothing", which is a different statement.
+     *   This ratio is cadence-proof, unlike the totals above.
+     * @param floorOriginShare `floorOriginU / tickWeightedU`, same rule.
+     * @param windowStartMs time of the oldest kept sample, so a reading can be aged.
+     * @param windowSpanMs newest kept sample minus oldest, so the real reach of the window is
+     *   visible instead of assumed.
+     * @param tickGapMedianMs median gap between two kept samples, so the loop cadence is visible in
+     *   the export. `null` below two samples.
+     */
+    data class Reading(
+        val tickCount: Int,
+        val tickWeightedU: Double,
+        val modelOriginU: Double,
+        val floorOriginU: Double,
+        val otherOriginU: Double,
+        val modelZeroTickWeightedU: Double,
+        val modelZeroTickCount: Int,
+        val modelOriginShare: Double?,
+        val floorOriginShare: Double?,
+        val windowStartMs: Long?,
+        val windowSpanMs: Long?,
+        val tickGapMedianMs: Long?,
+    ) {
+
+        fun toJsonObject(): JsonObject =
+            buildJsonObject {
+                put("tick_count", tickCount)
+                put("tick_weighted_u", tickWeightedU)
+                put("model_origin_u", modelOriginU)
+                put("floor_origin_u", floorOriginU)
+                put("other_origin_u", otherOriginU)
+                put("model_zero_tick_weighted_u", modelZeroTickWeightedU)
+                put("model_zero_tick_count", modelZeroTickCount)
+                put("model_origin_share", modelOriginShare)
+                put("floor_origin_share", floorOriginShare)
+                put("window_start_ms", windowStartMs)
+                put("window_span_ms", windowSpanMs)
+                put("tick_gap_median_ms", tickGapMedianMs)
+                // v2 renamed the totals. `delivered_u` and `model_zero_delivered_u` are gone on
+                // purpose: they claimed to be delivered insulin and were tick-weighted sums.
+                put("source", "insulin_origin_meter_v2")
+            }
+    }
+
+    /** One kept sample, already split, so [read] never has to walk the window for the sums. */
+    private data class Entry(
+        val timestampMs: Long,
+        val tickU: Double,
+        val modelU: Double,
+        val floorU: Double,
+        val otherU: Double,
+        val modelZeroU: Double,
+        val modelZero: Boolean,
+    )
+
+    private val entries = ArrayDeque<Entry>()
+
+    private var tickWeightedSum = 0.0
+    private var modelSum = 0.0
+    private var floorSum = 0.0
+    private var otherSum = 0.0
+    private var modelZeroSum = 0.0
+    private var modelZeroTicks = 0
+
+    /** Below this, the model is treated as having asked for nothing. Half a pump step. */
+    private val modelZeroThresholdU = 0.01
+
+    /** Guard against dividing by a raw amount that is zero in all but name. */
+    private val epsilon = 1e-9
+
+    /** Records one tick. Amortised O(1): one push, and on average one pop per push. */
+    fun observe(s: Sample) {
+        val tickU = s.finalU.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
+        val model = s.modelOutputU?.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
+        val floor = s.autodriveFloorU?.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
+        val raw = maxOf(model, floor)
+
+        val floorPart: Double
+        val modelPart: Double
+        val otherPart: Double
+        if (tickU <= 0.0) {
+            floorPart = 0.0
+            modelPart = 0.0
+            otherPart = 0.0
+        } else if (raw > epsilon) {
+            floorPart = tickU * ((raw - model) / raw)
+            modelPart = tickU - floorPart
+            otherPart = 0.0
+        } else {
+            // Insulin was decided while neither the model nor a floor claimed it. Never silently
+            // credit that to the model: it is exactly the case this meter exists to expose.
+            floorPart = 0.0
+            modelPart = 0.0
+            otherPart = tickU
+        }
+
+        val modelZero = (s.modelOutputU ?: 0.0) <= modelZeroThresholdU
+        val entry = Entry(
+            timestampMs = s.timestampMs,
+            tickU = tickU,
+            modelU = modelPart,
+            floorU = floorPart,
+            otherU = otherPart,
+            modelZeroU = if (modelZero) tickU else 0.0,
+            modelZero = modelZero,
+        )
+        entries.addLast(entry)
+        tickWeightedSum += entry.tickU
+        modelSum += entry.modelU
+        floorSum += entry.floorU
+        otherSum += entry.otherU
+        modelZeroSum += entry.modelZeroU
+        if (entry.modelZero) modelZeroTicks++
+
+        purge(s.timestampMs)
+    }
+
+    /**
+     * Reads the running answer.
+     *
+     * The sums are kept by [observe], so they cost nothing here. The median gap does walk the
+     * window, which is why it is computed on read and not on every sample.
+     *
+     * @param nowMs current time. Used to age the window out even when no new sample arrives, so a
+     *   loop that stopped ticking does not keep reporting a week-old share as current.
+     */
+    fun read(nowMs: Long): Reading {
+        purge(nowMs)
+        val tickWeighted = tickWeightedSum.coerceAtLeast(0.0)
+        val hasAmount = tickWeighted > epsilon
+        val oldest = entries.firstOrNull()?.timestampMs
+        val newest = entries.lastOrNull()?.timestampMs
+        return Reading(
+            tickCount = entries.size,
+            tickWeightedU = tickWeighted,
+            modelOriginU = modelSum,
+            floorOriginU = floorSum,
+            otherOriginU = otherSum,
+            modelZeroTickWeightedU = modelZeroSum,
+            modelZeroTickCount = modelZeroTicks,
+            modelOriginShare = if (hasAmount) modelSum / tickWeighted else null,
+            floorOriginShare = if (hasAmount) floorSum / tickWeighted else null,
+            windowStartMs = oldest,
+            windowSpanMs = if (oldest != null && newest != null) newest - oldest else null,
+            tickGapMedianMs = medianGapMs(),
+        )
+    }
+
+    /**
+     * Drops what is older than [windowMs], then what is over the memory cap.
+     *
+     * The reference time is the later of [referenceMs] and the newest kept sample. A clock that
+     * jumps backwards must not empty a window that was correctly filled.
+     */
+    private fun purge(referenceMs: Long) {
+        val newest = entries.lastOrNull()?.timestampMs ?: return
+        val reference = maxOf(referenceMs, newest)
+        val cutoff = reference - windowMs
+        while (true) {
+            val old = entries.firstOrNull() ?: return
+            if (old.timestampMs >= cutoff && entries.size <= maxSamples) return
+            drop()
+        }
+    }
+
+    private fun drop() {
+        val old = entries.removeFirst()
+        tickWeightedSum -= old.tickU
+        modelSum -= old.modelU
+        floorSum -= old.floorU
+        otherSum -= old.otherU
+        modelZeroSum -= old.modelZeroU
+        if (old.modelZero) modelZeroTicks--
+    }
+
+    /** Median gap between kept samples, or `null` below two samples. O(n log n) on read only. */
+    private fun medianGapMs(): Long? {
+        if (entries.size < 2) return null
+        val gaps = LongArray(entries.size - 1)
+        var index = 0
+        var previous: Long? = null
+        for (entry in entries) {
+            previous?.let { gaps[index++] = entry.timestampMs - it }
+            previous = entry.timestampMs
+        }
+        gaps.sort()
+        val middle = gaps.size / 2
+        return if (gaps.size % 2 == 1) gaps[middle] else (gaps[middle - 1] + gaps[middle]) / 2
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaCounterfactualTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaCounterfactualTest.kt
@@ -1,0 +1,210 @@
+package app.aaps.plugins.aps.openAPSAIMI.patient
+
+import app.aaps.plugins.aps.openAPSAIMI.basal.BasalChannelSafetyGuards
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Specification locks for [HarmoniaCounterfactual].
+ *
+ * Two of these are real locks on a **measured** defect, not just a restatement of the code:
+ *
+ *  - `blockedReductionKeepsTheSameProposal` writes down that 221 of the 629 refusals were refusals
+ *    of a `PROTECTIVE_REDUCTION`. An over-dose guard refusing an under-dose cannot be repaired by
+ *    telling Harmonia about the guard, and the counterfactual must say so instead of pretending a
+ *    gain is available there.
+ *  - `verdictMirrorsBasalChannelSafetyGuards` compares the mirror with the real guard call for call
+ *    over the whole truth table. It is the only thing that stops the two drifting apart.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `da9bc789ce` (file SHA `f89412ab72`, unchanged on tip
+ * `c5db5a0333`). Study source set: [HarmoniaCounterfactual] is commonMain and has no mocks, so the
+ * tests live in `commonTest` (`kotlin.test`) — same layout as [app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCacheTest],
+ * not `androidHostTest`. The name HarmoniaDecisionEngine in the sibling inert lock is the real
+ * `internal object` in [HarmoniaDecision]; it is not [HarmoniaHarmonizer].
+ */
+class HarmoniaCounterfactualTest {
+
+    private val profileBasal = 1.00
+
+    /** Builds a production record with only what the counterfactual reads. */
+    private fun production(
+        requestedRateUph: Double?,
+        runtimeBlocker: String?,
+        sourceAction: HarmoniaAction?,
+        appliedRateUph: Double? = null,
+    ) = HarmoniaProductionDecision(
+        timestampMs = 0L,
+        mode = if (runtimeBlocker == null) HarmoniaProductionMode.READY else HarmoniaProductionMode.BLOCKED,
+        selectedForProduction = runtimeBlocker == null,
+        requestedRateUph = requestedRateUph,
+        boundedRateUph = requestedRateUph,
+        appliedRateUph = appliedRateUph,
+        appliedDurationMin = 30,
+        runtimeBlocker = runtimeBlocker,
+        safetyBlockers = emptyList(),
+        sourceAction = sourceAction,
+        branch = "TEST",
+        reason = "test",
+    )
+
+    private val activeVerdict = HarmoniaSafetyVerdict(
+        criticalSafetyZeroed = true,
+        contextSuppressSmb = false,
+        mealModeActive = false,
+        guardsEnabled = true,
+    )
+
+    /**
+     * The measured defect. Harmonia asked for 0.60 U/h under a 1.00 U/h profile — that is less
+     * insulin, not more — and the over-dose guard refused it.
+     *
+     * Two things must be true. Knowing the verdict changes nothing, because Harmonia was already
+     * standing down. And the stake is **negative**: the refusal put the pump back on the profile
+     * basal, so it added insulin the tick had decided not to give.
+     */
+    @Test
+    fun blockedReductionKeepsTheSameProposal() {
+        val outcome = HarmoniaCounterfactual.evaluate(
+            simulation = null,
+            production = production(
+                requestedRateUph = 0.60,
+                runtimeBlocker = "smb_zeroed_by_safety",
+                sourceAction = HarmoniaAction.PROTECTIVE_REDUCTION,
+                appliedRateUph = profileBasal,
+            ),
+            verdict = activeVerdict,
+            profileBasalUph = profileBasal,
+            appliedRateUph = profileBasal,
+            appliedDurationMin = 30,
+        )
+
+        assertEquals(HarmoniaCounterfactualRule.BLOCKED_REDUCTION, outcome.rule)
+        assertFalse(outcome.changesProposal)
+        assertFalse(outcome.requestWasEscalation)
+        assertEquals(HarmoniaAction.PROTECTIVE_REDUCTION, outcome.counterfactualAction)
+        assertEquals(0.60, outcome.counterfactualBasalUph!!, 1e-9)
+        assertTrue(outcome.blockStakeU!! < 0.0, "refusing an under-dose adds insulin, so the stake is negative")
+        assertEquals(-0.20, outcome.blockStakeU!!, 1e-9)
+        assertEquals(0.40, outcome.appliedGapUph!!, 1e-9)
+    }
+
+    /**
+     * The one case where telling Harmonia would change the proposal: it asked for more than the
+     * profile while a safety rule had already zeroed the SMB. Knowing that, it stands down to the
+     * profile basal by itself, and the stake is positive because the refusal removed insulin.
+     */
+    @Test
+    fun escalationStandsDownWhenVerdictKnown() {
+        val outcome = HarmoniaCounterfactual.evaluate(
+            simulation = null,
+            production = production(
+                requestedRateUph = 1.40,
+                runtimeBlocker = "smb_zeroed_by_safety",
+                sourceAction = HarmoniaAction.BASAL_FIRST,
+                appliedRateUph = profileBasal,
+            ),
+            verdict = activeVerdict,
+            profileBasalUph = profileBasal,
+            appliedRateUph = profileBasal,
+            appliedDurationMin = 30,
+        )
+
+        assertEquals(HarmoniaCounterfactualRule.WOULD_STAND_DOWN, outcome.rule)
+        assertTrue(outcome.changesProposal)
+        assertTrue(outcome.requestWasEscalation)
+        assertEquals(HarmoniaAction.OBSERVE, outcome.counterfactualAction)
+        assertEquals(profileBasal, outcome.counterfactualBasalUph!!, 1e-9)
+        assertTrue(outcome.blockStakeU!! > 0.0)
+        assertEquals(0.20, outcome.blockStakeU!!, 1e-9)
+    }
+
+    /**
+     * A refusal that did not come from the basal safety guard must not be charged to it. Otherwise
+     * the count of "refusals the guard caused" is inflated by every other gate in the tick.
+     */
+    @Test
+    fun nonSafetyBlockerIsNotAttributedToTheGuard() {
+        val outcome = HarmoniaCounterfactual.evaluate(
+            simulation = null,
+            production = production(
+                requestedRateUph = 1.40,
+                runtimeBlocker = "smb_authority_active",
+                sourceAction = HarmoniaAction.BASAL_FIRST,
+                appliedRateUph = profileBasal,
+            ),
+            verdict = activeVerdict,
+            profileBasalUph = profileBasal,
+            appliedRateUph = profileBasal,
+            appliedDurationMin = 30,
+        )
+
+        assertEquals(HarmoniaCounterfactualRule.BLOCKED_NON_SAFETY, outcome.rule)
+        assertFalse(outcome.changesProposal)
+        assertEquals(HarmoniaAction.BASAL_FIRST, outcome.counterfactualAction)
+    }
+
+    /** No blocker at all: nothing to explain, the counterfactual is the identity. */
+    @Test
+    fun noBlockerIsTheIdentity() {
+        val outcome = HarmoniaCounterfactual.evaluate(
+            simulation = null,
+            production = production(
+                requestedRateUph = 1.40,
+                runtimeBlocker = null,
+                sourceAction = HarmoniaAction.BASAL_FIRST,
+                appliedRateUph = 1.40,
+            ),
+            verdict = activeVerdict,
+            profileBasalUph = profileBasal,
+            appliedRateUph = 1.40,
+            appliedDurationMin = 30,
+        )
+
+        assertEquals(HarmoniaCounterfactualRule.NO_VERDICT, outcome.rule)
+        assertFalse(outcome.changesProposal)
+        assertEquals(1.40, outcome.counterfactualBasalUph!!, 1e-9)
+    }
+
+    /**
+     * Anti-drift lock. The mirror in [HarmoniaSafetyVerdict] and the real guard in
+     * [BasalChannelSafetyGuards] must agree on all sixteen input combinations. If someone changes
+     * the guard and forgets the mirror, the counterfactual would start explaining refusals with a
+     * rule the loop no longer uses, and this test fails first.
+     */
+    @Test
+    fun verdictMirrorsBasalChannelSafetyGuards() {
+        val flags = listOf(false, true)
+        var checked = 0
+        for (guardsEnabled in flags) {
+            for (criticalSafetyZeroed in flags) {
+                for (contextSuppressSmb in flags) {
+                    for (mealModeActive in flags) {
+                        val expected = BasalChannelSafetyGuards.shouldBlockBasalFirst(
+                            guardsEnabled = guardsEnabled,
+                            criticalSafetyZeroed = criticalSafetyZeroed,
+                            contextSuppressSmb = contextSuppressSmb,
+                            mealModeActive = mealModeActive,
+                        )
+                        val mirrored = HarmoniaSafetyVerdict(
+                            criticalSafetyZeroed = criticalSafetyZeroed,
+                            contextSuppressSmb = contextSuppressSmb,
+                            mealModeActive = mealModeActive,
+                            guardsEnabled = guardsEnabled,
+                        ).wouldBlockBasalFirst
+                        assertEquals(
+                            expected,
+                            mirrored,
+                            "mirror drifted for guards=$guardsEnabled critical=$criticalSafetyZeroed " +
+                                "context=$contextSuppressSmb meal=$mealModeActive",
+                        )
+                        checked++
+                    }
+                }
+            }
+        }
+        assertEquals(16, checked)
+        assertFalse(HarmoniaSafetyVerdict.UNKNOWN.wouldBlockBasalFirst)
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecisionEngineFeedbackIsInertTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecisionEngineFeedbackIsInertTest.kt
@@ -1,0 +1,134 @@
+package app.aaps.plugins.aps.openAPSAIMI.patient
+
+import app.aaps.plugins.aps.openAPSAIMI.physio.MealAbsorptionPhase
+import app.aaps.plugins.aps.openAPSAIMI.physio.PhysiologicalPhase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The inertia lock.
+ *
+ * [HarmoniaDecisionEnvironment.priorRuntimeBlocker] and
+ * [HarmoniaDecisionEnvironment.priorBlockedStreak] are doors opened for the export and for
+ * `HarmoniaCounterfactual`. They must carry information **out** of the decision, never into it.
+ *
+ * This test is a specification lock, not a bug proof: it was green the moment the two fields were
+ * added, because nothing reads them. Its whole value is later — the day someone wires the feedback
+ * into `buildBlockers` or `chooseActionWithReason`, this test turns red and says so, instead of the
+ * change reaching a pump unannounced.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `da9bc789ce`. The type under test is the real
+ * [HarmoniaDecisionEngine] object in [HarmoniaDecision], not [HarmoniaHarmonizer]. Study source set:
+ * `commonTest` + `kotlin.test`.
+ */
+class HarmoniaDecisionEngineFeedbackIsInertTest {
+
+    /** The refusal seen in the field, and the number of times it was seen. */
+    private val fieldBlocker = "smb_zeroed_by_safety"
+    private val fieldStreak = 629
+
+    /**
+     * Fifty varied environments, each crossed with three different trees. For every one of them the
+     * decision must be identical apart from the `environment` field itself, which of course carries
+     * the two new values.
+     */
+    @Test
+    fun priorBlockerDoesNotChangeAnyOutput() {
+        val trees = listOf(treeStable(), treeResistant(), treeHypoRisk())
+        var compared = 0
+        for (seed in 1L..50L) {
+            val env = HarmoniaDecisionEngine.randomizedEnvironment(seed)
+            val informed = env.copy(
+                priorRuntimeBlocker = fieldBlocker,
+                priorBlockedStreak = fieldStreak,
+            )
+            for (tree in trees) {
+                val blind = HarmoniaDecisionEngine.evaluate(tree = tree, environment = env)
+                val told = HarmoniaDecisionEngine.evaluate(tree = tree, environment = informed)
+
+                assertNotNull(blind, "seed $seed must produce a decision")
+                assertNotNull(told, "seed $seed must produce a decision")
+                // Everything but the environment must match, field by field: action, eligibility,
+                // target basal, target SMB, both factors, caps, blockers, rationale, summary, basis.
+                assertEquals(
+                    blind.copy(environment = env),
+                    told.copy(environment = env),
+                    "the prior blocker changed the decision for seed $seed",
+                )
+                compared++
+            }
+        }
+        assertEquals(150, compared)
+    }
+
+    /** The two fields must really travel, otherwise the test above would compare nothing. */
+    @Test
+    fun priorBlockerIsCarriedButDefaultsToNothing() {
+        val env = HarmoniaDecisionEngine.randomizedEnvironment(1L)
+        assertNull(env.priorRuntimeBlocker)
+        assertEquals(0, env.priorBlockedStreak)
+
+        val told = HarmoniaDecisionEngine.evaluate(
+            tree = treeStable(),
+            environment = env.copy(priorRuntimeBlocker = fieldBlocker, priorBlockedStreak = fieldStreak),
+        )
+        assertEquals(fieldBlocker, told?.environment?.priorRuntimeBlocker)
+        assertEquals(fieldStreak, told?.environment?.priorBlockedStreak)
+    }
+
+    private fun buildTree(state: PatientStateSnapshot) =
+        PhysiologicalTreeBuilder.build(
+            enabled = true,
+            patientState = state,
+            patientModeDecision = PatientModeOrchestrator.evaluate(state),
+        )
+
+    private fun treeStable() = buildTree(baseState())
+
+    private fun treeResistant() = buildTree(
+        baseState().copy(
+            phase = PhysiologicalPhase.DAWN_CORTISOL,
+            endogenousGlucoseDrive = 0.82,
+            transientResistanceProb = 0.70,
+            causalPosterior = CausalStatePosterior(
+                dawnEndogenousProb = 0.84,
+                stressResistanceProb = 0.62,
+                dominant = CausalStateId.DAWN_ENDOGENOUS,
+                dominantConfidence = 0.84,
+                learningQuality = 0.80,
+            ),
+        ),
+    )
+
+    private fun treeHypoRisk() = buildTree(
+        baseState().copy(
+            postHypoReboundProb = 0.65,
+            eventMemory = PatientEventMemory(
+                recentHypoLoad = 0.55,
+                correctionFragilityScore = 0.40,
+            ),
+        ),
+    )
+
+    private fun baseState(): PatientStateSnapshot =
+        PatientStateSnapshot(
+            timestampMs = 1_718_000_000_000L,
+            phase = PhysiologicalPhase.OFF,
+            phaseConfidence = 0.50,
+            mealAbsorptionPhase = MealAbsorptionPhase.NONE,
+            mealAbsorptionBelief = 0.0,
+            mealProb = 0.08,
+            endogenousGlucoseDrive = 0.10,
+            transientResistanceProb = 0.08,
+            sleepDebtScore = 0.0,
+            postHypoReboundProb = 0.0,
+            sensorConfidence = 0.88,
+            causalPosterior = CausalStatePosterior(
+                dominant = CausalStateId.UNKNOWN,
+                dominantConfidence = 0.0,
+                learningQuality = 0.86,
+            ),
+        )
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/InsulinOriginMeterTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/InsulinOriginMeterTest.kt
@@ -1,0 +1,218 @@
+package app.aaps.plugins.aps.openAPSAIMI.quality
+
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Specification locks for [InsulinOriginMeter].
+ *
+ * The first tests write down the two rules the meter must never break: the window stays bounded,
+ * and the parts always add back to the tick-weighted total.
+ *
+ * The later tests are the ones that describe a real defect. The window used to be counted in ticks
+ * (2016, documented as "one week of 5 minute ticks"), while the loop runs about every 60 seconds on
+ * a one minute sensor, so the window was 33 hours and the totals were tick-weighted sums that the
+ * export called delivered insulin. See the class doc of [InsulinOriginMeter].
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (file SHA `8f5506d383`, unchanged on tip
+ * `c5db5a0333` — the v2 time-window rewrite of the `da9bc789ce` meter). Study source set:
+ * `commonTest` + `kotlin.test`. JSON assertions use kotlinx `JsonObject`, not `org.json`.
+ *
+ * [IobSurveillanceExport] is a different type (one-tick plateau/IOB snapshot). The reference added
+ * this meter **beside** that snapshot; this lot does not delete or replace it.
+ */
+class InsulinOriginMeterTest {
+
+    private val t0 = 1_700_000_000_000L
+    private val minute = 60_000L
+
+    private fun sample(
+        index: Int,
+        finalU: Double,
+        modelOutputU: Double?,
+        autodriveFloorU: Double?,
+    ) = InsulinOriginMeter.Sample(
+        timestampMs = t0 + index * 5 * minute,
+        finalU = finalU,
+        modelOutputU = modelOutputU,
+        mpcOutputU = null,
+        autodriveFloorU = autodriveFloorU,
+        bindingStage = "FINAL",
+        originOwner = "TEST",
+    )
+
+    /**
+     * The window is a ring, not a log. At the 5 minute cadence this test feeds, seven days are
+     * exactly 2016 samples, so 5000 ticks must leave 2016 kept and the running sums must describe
+     * exactly those. A leak here would make the shares drift slowly over days, which is precisely
+     * the time scale the meter is meant to answer on.
+     */
+    @Test
+    fun windowIsBoundedAndSharesSumToOne() {
+        val meter = InsulinOriginMeter()
+        for (i in 0 until 5000) {
+            // Varied but always explained: sometimes the model leads, sometimes the floor does.
+            val model = (i % 7) * 0.10
+            val floor = (i % 5) * 0.15
+            val delivered = maxOf(model, floor)
+            meter.observe(sample(i, finalU = delivered, modelOutputU = model, autodriveFloorU = floor))
+        }
+
+        val reading = meter.read(t0 + 5000L * 5 * minute)
+        assertEquals(2016, reading.tickCount)
+        assertTrue(reading.tickWeightedU > 0.0)
+
+        val parts = reading.modelOriginU + reading.floorOriginU + reading.otherOriginU
+        val sum = parts / reading.tickWeightedU
+        assertTrue(sum in 0.999..1.001, "parts must add back to the delivered amount, got $sum")
+
+        assertNotNull(reading.modelOriginShare)
+        assertNotNull(reading.floorOriginShare)
+        assertEquals(1.0, reading.modelOriginShare!! + reading.floorOriginShare!!, 1e-3)
+        assertEquals(t0 + (5000L - 2016L) * 5 * minute, reading.windowStartMs)
+    }
+
+    /**
+     * The case the meter exists for: the model asked for nothing and the floor delivered anyway.
+     * Every unit must be credited to the floor, none to the model, and the tick must be counted as
+     * a model-zero tick. Crediting any of it to the model would hide exactly the failure being
+     * looked for.
+     */
+    @Test
+    fun modelZeroIsCountedWhenTheFloorDelivers() {
+        val meter = InsulinOriginMeter()
+        meter.observe(sample(0, finalU = 1.5, modelOutputU = 0.0, autodriveFloorU = 1.5))
+
+        val reading = meter.read(t0)
+        assertEquals(1, reading.tickCount)
+        assertEquals(1.5, reading.tickWeightedU, 1e-9)
+        assertEquals(0.0, reading.modelOriginU, 1e-9)
+        assertEquals(1.5, reading.floorOriginU, 1e-9)
+        assertEquals(0.0, reading.otherOriginU, 1e-9)
+        assertEquals(1.5, reading.modelZeroTickWeightedU, 1e-9)
+        assertEquals(1, reading.modelZeroTickCount)
+        assertEquals(0.0, reading.modelOriginShare!!, 1e-9)
+        assertEquals(1.0, reading.floorOriginShare!!, 1e-9)
+    }
+
+    /** Nothing delivered yet: the shares must stay `null`, never `0.0`. */
+    @Test
+    fun sharesStayNullBeforeAnyDelivery() {
+        val meter = InsulinOriginMeter()
+        meter.observe(sample(0, finalU = 0.0, modelOutputU = 0.0, autodriveFloorU = 0.0))
+
+        val reading = meter.read(t0)
+        assertEquals(1, reading.tickCount)
+        assertEquals(0.0, reading.tickWeightedU, 1e-9)
+        assertNull(reading.modelOriginShare)
+        assertNull(reading.floorOriginShare)
+    }
+
+    /** Same helper, but the caller places the sample in time itself. */
+    private fun sampleAt(
+        timestampMs: Long,
+        finalU: Double,
+        modelOutputU: Double?,
+        autodriveFloorU: Double?,
+    ) = InsulinOriginMeter.Sample(
+        timestampMs = timestampMs,
+        finalU = finalU,
+        modelOutputU = modelOutputU,
+        mpcOutputU = null,
+        autodriveFloorU = autodriveFloorU,
+        bindingStage = "FINAL",
+        originOwner = "TEST",
+    )
+
+    /**
+     * The window is seven days of clock time, whatever the cadence.
+     *
+     * This is the defect the rewrite fixes. The old window kept 2016 samples and its doc called that
+     * one week; fed at one tick per minute, as the loop really runs on a one minute sensor, those
+     * 2016 samples were 33 hours. Eight days in must leave seven days kept, and the export must say
+     * out loud what the real span and the real cadence were.
+     */
+    @Test
+    fun windowKeepsSevenDaysAtOneTickPerMinute() {
+        val meter = InsulinOriginMeter()
+        val ticks = 8 * 24 * 60
+        for (i in 0 until ticks) {
+            meter.observe(sampleAt(t0 + i * minute, finalU = 0.2, modelOutputU = 0.2, autodriveFloorU = 0.0))
+        }
+
+        val reading = meter.read(t0 + ticks * minute)
+        val sevenDaysOfMinutes = 7 * 24 * 60
+        assertEquals(sevenDaysOfMinutes, reading.tickCount)
+        assertEquals(t0 + (ticks - sevenDaysOfMinutes) * minute, reading.windowStartMs)
+        assertEquals((sevenDaysOfMinutes - 1) * minute, reading.windowSpanMs)
+        assertEquals(minute, reading.tickGapMedianMs)
+    }
+
+    /**
+     * Why the shares are kept and the totals are renamed.
+     *
+     * Two meters see the same decisions. The second one is ticked twice as often, which is exactly
+     * what happens when the sensor moves from five minute samples to one minute samples: the same
+     * micro-bolus is re-proposed on every run. The totals double, so they cannot be read as insulin.
+     * The shares do not move at all, so they can.
+     */
+    @Test
+    fun sharesAreCadenceProofWhileTotalsAreNot() {
+        val decisions = listOf(
+            Triple(0.30, 0.30, 0.00),
+            Triple(0.80, 0.00, 0.80),
+            Triple(0.60, 0.40, 0.60),
+            Triple(0.10, 0.10, 0.05),
+        )
+
+        val slow = InsulinOriginMeter()
+        val fast = InsulinOriginMeter()
+        decisions.forEachIndexed { index, (finalU, modelU, floorU) ->
+            slow.observe(sampleAt(t0 + index * 10 * minute, finalU, modelU, floorU))
+            // Same decision, seen twice because the loop ran twice while it stood.
+            fast.observe(sampleAt(t0 + index * 10 * minute, finalU, modelU, floorU))
+            fast.observe(sampleAt(t0 + index * 10 * minute + 5 * minute, finalU, modelU, floorU))
+        }
+
+        val slowReading = slow.read(t0 + 40 * minute)
+        val fastReading = fast.read(t0 + 40 * minute)
+
+        assertEquals(decisions.size, slowReading.tickCount)
+        assertEquals(2 * decisions.size, fastReading.tickCount)
+        // Totals are tick-weighted: doubling the cadence doubles them for the same therapy.
+        assertEquals(2.0 * slowReading.tickWeightedU, fastReading.tickWeightedU, 1e-9)
+        assertEquals(2.0 * slowReading.modelOriginU, fastReading.modelOriginU, 1e-9)
+        assertEquals(2.0 * slowReading.floorOriginU, fastReading.floorOriginU, 1e-9)
+        // Shares are ratios over the same ticks, so they do not move.
+        assertEquals(slowReading.modelOriginShare!!, fastReading.modelOriginShare!!, 1e-12)
+        assertEquals(slowReading.floorOriginShare!!, fastReading.floorOriginShare!!, 1e-12)
+        assertEquals(10 * minute, slowReading.tickGapMedianMs)
+        assertEquals(5 * minute, fastReading.tickGapMedianMs)
+    }
+
+    /** The renamed keys must be the ones exported, and the source must say why they moved. */
+    @Test
+    fun exportNamesTheTotalsTickWeighted() {
+        val meter = InsulinOriginMeter()
+        meter.observe(sampleAt(t0, finalU = 0.5, modelOutputU = 0.0, autodriveFloorU = 0.5))
+        meter.observe(sampleAt(t0 + minute, finalU = 0.5, modelOutputU = 0.0, autodriveFloorU = 0.5))
+
+        val json = meter.read(t0 + minute).toJsonObject()
+        assertEquals("insulin_origin_meter_v2", json.getValue("source").jsonPrimitive.content)
+        assertTrue("tick_weighted_u" in json)
+        assertTrue("model_zero_tick_weighted_u" in json)
+        assertTrue("window_span_ms" in json)
+        assertTrue("tick_gap_median_ms" in json)
+        assertTrue("delivered_u" !in json, "delivered_u claimed to be enacted insulin, it must be gone")
+        assertTrue("model_zero_delivered_u" !in json, "model_zero_delivered_u must be gone too")
+        assertEquals(1.0, json.getValue("tick_weighted_u").jsonPrimitive.double, 1e-9)
+        assertEquals(minute, json.getValue("tick_gap_median_ms").jsonPrimitive.long)
+        assertEquals(minute, json.getValue("window_span_ms").jsonPrimitive.long)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.6** uniquement — paire HarmoniaCounterfactual + InsulinOriginMeter.

- **Clinique** = référence `origin/dev_OAPSAIMI` :
  - `HarmoniaCounterfactual` @ **`da9bc789ce`** (file SHA `f89412ab72`, inchangé sur le tip `c5db5a0333`)
  - `InsulinOriginMeter` v2 @ **`db21308e6c`** (file SHA `8f5506d383`, inchangé sur le tip `c5db5a0333`) — réécriture fenêtre-temps du mètre introduit dans `da9bc789ce`
- **Câblage** = study tip post-#77 **`b30a62ea76208b239abef032a6c6f9e3e5061bcb`**
- **Tests** = **`commonTest`** + **`kotlin.test`**

Pas de copie aveugle Hilt/javax/`org.json`/`Locale.US`/`java.util.ArrayDeque`. Pas de remplacement aveugle de `DetermineBasalAIMI2`.

### IobSurveillanceExport vs InsulinOriginMeter (vérifié sur les deux pointes)

Ce sont **deux types différents**. Ils coexistent.

| | `IobSurveillanceExport` | `InsulinOriginMeter` |
|---|---|---|
| Rôle | snapshot **d’un tick** (plateau + IOB haut + chute prédite) | compteur **glissant** modèle vs plancher |
| Référence tip | **absent** (DTO imbriqué tick, extrait sur l’étude lot AR) | **présent** (`quality/InsulinOriginMeter.kt`) |
| Étude avant ce lot | **présent** (`quality/IobSurveillanceExport.kt`) | **absent** |

**Décision : garder `IobSurveillanceExport`, ajouter `InsulinOriginMeter` à côté.** La référence n’a pas remplacé le snapshot ; elle a ajouté le mètre. Rien n’est supprimé.

### Noms (vérifiés sur le code)

Les tests parlent de `HarmoniaDecisionEngine`. L’implémentation visée est bien l’`internal object HarmoniaDecisionEngine` dans `HarmoniaDecision.kt` (evaluate / blockers / action). Ce n’est **pas** `HarmoniaHarmonizer` (posture de production). Le verrou d’inertie (`HarmoniaDecisionEngineFeedbackIsInertTest`) appelle `HarmoniaDecisionEngine.evaluate`.

### Copié / adapté

- `HarmoniaCounterfactual` + `HarmoniaSafetyVerdict` / `HarmoniaCounterfactualRule` / `HarmoniaCounterfactualOutcome` → **commonMain** `internal object` (pur, un consommateur tick). kotlinx JSON à la place de `org.json`, `aimiFmt2` à la place de `String.format(Locale.US)`.
- `priorRuntimeBlocker` / `priorBlockedStreak` sur `HarmoniaDecisionEnvironment` (types requis par la paire + test d’inertie).
- `InsulinOriginMeter` v2 → **commonMain** classe + champ privé tick (`private val insulinOriginMeter = InsulinOriginMeter()`), comme `ObservedSensitivityMeter`. `kotlin.collections.ArrayDeque` à la place de `java.util.ArrayDeque`. Pas de Metro `@Inject`.
- Tests : 5 + 2 + 6 verrous en `commonTest`.

Pas de `appliedMatchesRequest` (`db21308e6c`, hors paire). Pas de SmbTrainingRowBuffer / Kalman / Autodrive leftovers / 2ᵉ site `currentMaxSmb`.

### Sites câblés — hunks `da9bc789ce` de la paire seulement (`DetermineBasalAIMI2` androidMain)

1. Imports.
2. Champ privé `insulinOriginMeter` (pas `@Inject`).
3. Champs `var harmonia_cf_*` / `harmonia_block_*` / `harmonia_verdict_*` / `harmonia_prev_*` sur `BaselineState` + `put` via `AimiJson.NULL`.
4. `adjustments.insulin_origin` + `put`.
5. `priorRuntimeBlocker` / `priorBlockedStreak` dans `HarmoniaDecisionEnvironment`.
6. Bloc `HarmoniaCounterfactual.evaluate` dans le stage d’export, **après** `isf_obs_*` et **avant** `dynamic_isf`. Témoin `harmonia_verdict_known_to_engine = false`.
7. `insulinOriginMeter.observe` **après** `bindingExportDraft` complet.
8. Mise à jour `harmoniaPrevRuntimeBlocker` / `harmoniaBlockedStreak` **en tout dernier** du stage (non reset en début de tick).

`OpenAPSAIMIPlugin` **non modifié**. `IobSurveillanceExport` **intact**.

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests '...patient.HarmoniaCounterfactualTest' \
  --tests '...patient.HarmoniaDecisionEngineFeedbackIsInertTest' \
  --tests '...quality.InsulinOriginMeterTest'
  → Counterfactual 5/5, FeedbackIsInert 2/2, InsulinOriginMeter 6/6
    (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests '...ISF.*' --tests '...smb.*' --tests '...patient.*' \
  --tests '...quality.InsulinOriginMeterTest'
  → CommandedIsf 5/5, DynIsfCache 7/7, ObservedSensitivityMeter 18/18,
    MaxSmbLadder 9+9, Counterfactual 5/5, Inert 2/2, OriginMeter 6/6
```

`:app:assembleFullDebug` **non lancé** : pas de nouvel `@Inject` / port Metro (object + champ privé).

### Questions ouvertes

- `appliedMatchesRequest` sur `HarmoniaProductionDecision` (`db21308e6c`) reste hors lot : pas requis par la paire.
- Le 2ᵉ site `currentMaxSmb` n’est pas touché.

## EN

Lot **P0.6** only — HarmoniaCounterfactual + InsulinOriginMeter pair.

- **Clinical** = reference `origin/dev_OAPSAIMI`:
  - `HarmoniaCounterfactual` @ **`da9bc789ce`** (file SHA `f89412ab72`, unchanged on tip `c5db5a0333`)
  - `InsulinOriginMeter` v2 @ **`db21308e6c`** (file SHA `8f5506d383`, unchanged on tip `c5db5a0333`) — time-window rewrite of the meter introduced in `da9bc789ce`
- **Wiring** = study tip after #77 **`b30a62ea76208b239abef032a6c6f9e3e5061bcb`**
- **Tests** = **`commonTest`** + **`kotlin.test`**

Not a blind Hilt/javax/`org.json`/`Locale.US`/`java.util.ArrayDeque` copy. No wholesale replace of `DetermineBasalAIMI2`.

### IobSurveillanceExport vs InsulinOriginMeter (verified on both tips)

These are **two different types**. They coexist.

| | `IobSurveillanceExport` | `InsulinOriginMeter` |
|---|---|---|
| Role | **one-tick** snapshot (plateau + high IOB + predicted drop) | rolling **model vs floor** attribution |
| Reference tip | **absent** (nested tick DTO, extracted on study lot AR) | **present** |
| Study before this lot | **present** | **absent** |

**Decision: keep `IobSurveillanceExport`, add `InsulinOriginMeter` beside it.** The reference did not replace the snapshot; it added the meter. Nothing was deleted.

### Names (verified on code)

Tests mention `HarmoniaDecisionEngine`. The type under test is the real `internal object HarmoniaDecisionEngine` in `HarmoniaDecision.kt`. It is **not** `HarmoniaHarmonizer`. The inertia lock calls `HarmoniaDecisionEngine.evaluate`.

### What was copied / adapted

- `HarmoniaCounterfactual` + related types → **commonMain** `internal object` (pure, one tick consumer). kotlinx JSON instead of `org.json`, `aimiFmt2` instead of `String.format(Locale.US)`.
- `priorRuntimeBlocker` / `priorBlockedStreak` on `HarmoniaDecisionEnvironment` (required by the pair + inertia test).
- `InsulinOriginMeter` v2 → **commonMain** class + tick `private val` (same sibling as `ObservedSensitivityMeter`). `kotlin.collections.ArrayDeque` instead of `java.util.ArrayDeque`. No Metro `@Inject`.
- Tests: 5 + 2 + 6 locks in `commonTest`.

No `appliedMatchesRequest` (`db21308e6c`, not required by the pair). No SmbTrainingRowBuffer / Kalman / Autodrive leftovers / second `currentMaxSmb` site.

### Call sites wired — `da9bc789ce` pair hunks only (`DetermineBasalAIMI2` androidMain)

1. Imports.
2. Private `insulinOriginMeter` field (not `@Inject`).
3. `var harmonia_cf_*` / `harmonia_block_*` / `harmonia_verdict_*` / `harmonia_prev_*` on `BaselineState` + `put` via `AimiJson.NULL`.
4. `adjustments.insulin_origin` + `put`.
5. `priorRuntimeBlocker` / `priorBlockedStreak` in `HarmoniaDecisionEnvironment`.
6. `HarmoniaCounterfactual.evaluate` in the export stage, **after** `isf_obs_*` and **before** `dynamic_isf`. Witness `harmonia_verdict_known_to_engine = false`.
7. `insulinOriginMeter.observe` **after** `bindingExportDraft` is complete.
8. `harmoniaPrevRuntimeBlocker` / `harmoniaBlockedStreak` updated **last** in the stage (not reset at tick start).

`OpenAPSAIMIPlugin` **untouched**. `IobSurveillanceExport` **kept**.

### Evidence

```
./gradlew :plugins:aps:compileAndroidMain
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests '...patient.HarmoniaCounterfactualTest' \
  --tests '...patient.HarmoniaDecisionEngineFeedbackIsInertTest' \
  --tests '...quality.InsulinOriginMeterTest'
  → Counterfactual 5/5, FeedbackIsInert 2/2, InsulinOriginMeter 6/6
    (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL

./gradlew :plugins:aps:jvmTest \
  --tests '...ISF.*' --tests '...smb.*' --tests '...patient.*' \
  --tests '...quality.InsulinOriginMeterTest'
  → CommandedIsf 5/5, DynIsfCache 7/7, ObservedSensitivityMeter 18/18,
    MaxSmbLadder 9+9, Counterfactual 5/5, Inert 2/2, OriginMeter 6/6
```

`:app:assembleFullDebug` **not run**: no new `@Inject` / Metro port (object + private field).

### Open questions

- `appliedMatchesRequest` on `HarmoniaProductionDecision` (`db21308e6c`) stays out of this lot: not required by the pair.
- The second `currentMaxSmb` site is untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e4116b-9ae7-4250-9d38-82714086de2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e4116b-9ae7-4250-9d38-82714086de2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

