### PR TITLE
P0.7 — SmbTrainingRowBuffer: delayed origin/outcome CSV columns on the KMP study branch

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -67,6 +67,7 @@ import app.aaps.core.data.model.HR
 import app.aaps.plugins.aps.openAPSAIMI.model.DecisionResult
 import app.aaps.plugins.aps.openAPSAIMI.ml.AimiSmbTrainer
 import app.aaps.plugins.aps.openAPSAIMI.ml.SmbRefinementFeatureSchema
+import app.aaps.plugins.aps.openAPSAIMI.ml.SmbTrainingRowBuffer
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorJsonlExport
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorVerdict
 import app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadder
@@ -9489,7 +9490,26 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             phase = "EXPORT",
             kind = "OBSERVATION",
         )
-        decisionCtx.adjustments.smb_binding_trace = bindingExportDraft.build(bindingFinalU).toJsonObject()
+        val bindingTrace = bindingExportDraft.build(bindingFinalU)
+        decisionCtx.adjustments.smb_binding_trace = bindingTrace.toJsonObject()
+
+        // Observation only — stamps the origin of this tick's dose on the training row queued
+        // earlier in the same tick. Read here, not at CSV time: the row is built inside the SMB
+        // executor, before the owner fallback and the late caps have run, so reading it there would
+        // report "NONE" on ticks that do have an owner.
+        runCatching {
+            smbTrainingRowBuffer.stampOrigin(
+                tickKey = smbTrainingRowTickKey,
+                smbModelU = bindingTrace.modelOutputU,
+                smbFloorU = bindingTrace.autodriveFloorU,
+                bindingStage = bindingTrace.bindingStage,
+                originOwner = bindingTrace.originOwner,
+                // Study SmbBindingTrace has no mpcRequestedU yet (db21308e6c Autodrive fill).
+                // Empty cell = unknown, never a synthetic 0. lastMpcRawSmbU defaults to 0.0
+                // on ticks that never engaged Autodrive and would poison the corpus if read here.
+                smbMpcRequestedU = null,
+            )
+        }
 
         // Observation only — running share of the delivered insulin the model really asked for.
         // Placed here on purpose, **after** `bindingExportDraft` is complete: read any earlier and
@@ -10582,6 +10602,8 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             .getOrNull()
     }
     private var csvPrimaryStorageDeniedLogged = false
+    /** Files whose header was already compared with the wanted one since the app started. */
+    private val csvHeaderCheckedPaths = mutableSetOf<String>()
     private val pkpdIntegration = PkPdIntegration(preferences, pkPdLearnedState, behaviorProfileSource)
     //private val tempFile = File(externalDir, "temp.csv")
     private var bgacc = 0.0
@@ -11287,6 +11309,26 @@ class DetermineBasalaimiSMB2 @Inject constructor(
     private var lastSmbProposed: Double = 0.0
     /** Diagnostic-only immutable SMB cap chain, replaced at every tick bootstrap. */
     private var lastSmbBindingTraceDraft = SmbBindingTrace.Draft()
+
+    /**
+     * Holds the SMB training rows until their origin stamp and their realised glucose are known.
+     *
+     * Instrumentation only: it changes when a row reaches `oapsaimiML2_records.csv`, never what the
+     * pump is asked to do. See [app.aaps.plugins.aps.openAPSAIMI.ml.SmbTrainingRowBuffer].
+     *
+     * Plain private field on purpose: not @Inject, not @Singleton. One consumer (this tick), same
+     * sibling as [observedSensitivityMeter] / [insulinOriginMeter].
+     */
+    private val smbTrainingRowBuffer = SmbTrainingRowBuffer()
+
+    /**
+     * Tick clock shared by the queued training row and by its origin stamp.
+     *
+     * The row is queued in the middle of the tick and stamped at its end, so both need the same key
+     * to be sure they speak about the same tick. `dateUtil.now()` moves between the two points and
+     * would not match.
+     */
+    private var smbTrainingRowTickKey: Long = 0L
     /** Cross-tick effort-load memory for [EffortActivityBelief]; intentionally NOT reset per tick. */
     private var lastEffortMemory = EffortActivityBelief.Memory()
     private var lastEffortAssessment: EffortActivityBelief.Assessment? = null
@@ -13100,7 +13142,8 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             "dateStr, ${SmbRefinementFeatureSchema.csvFeatureNames.joinToString(", ")}, " +
                 "${SmbRefinementFeatureSchema.familyAuditFeatureNames.joinToString(", ")}, " +
                 "${SmbRefinementFeatureSchema.optionalTrainingAuditFeatureNames.joinToString(", ")}, " +
-                "predictedSMB, smbGiven, dynamicPeak, adjustedDia\n"
+                "predictedSMB, smbGiven, dynamicPeak, adjustedDia, " +
+                "${SmbTrainingRowBuffer.ADDED_COLUMN_NAMES.joinToString(", ")}\n"
         val valuesToRecord = "$dateStr," +
             "$bg,$iob,$cob,$delta,$shortAvgDelta,$longAvgDelta," +
             "$tdd7DaysPerHour,$tdd2DaysPerHour,$tddPerHour,$tdd24HrsPerHour," +
@@ -13112,12 +13155,21 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             "${eventMemory.postHyperExhaustionScore},${eventMemory.correctionFragilityScore},$decisionConflictFlags," +
             "$predictedSMB,$smbToGive," +
             "$peakintermediaire,$latestAdjustedDia"
-        appendCsvSafely(
-            primaryFile = csvfile,
-            fallbackFileName = "oapsaimiML2_records.csv",
-            headerRow = headerRow,
-            valuesRow = valuesToRecord,
-        )
+        // The row is queued, not written. Its origin fields are only complete at the end of the
+        // tick, and its realised glucose only about half an hour later, so it leaves the queue once
+        // its outcome window has closed. This delays when a row appears in the CSV; it does not
+        // change the row itself, the label, or anything the pump is asked to do.
+        val nowMs = smbTrainingRowTickKey.takeIf { it > 0L } ?: dateUtil.now()
+        smbTrainingRowBuffer.fillRealisedOutcomes(nowMs = nowMs, observedBg = bg)
+        smbTrainingRowBuffer.enqueue(timestampMs = nowMs, valuesPrefix = valuesToRecord)
+        smbTrainingRowBuffer.drainWritableRows(nowMs).forEach { readyRow ->
+            appendCsvSafely(
+                primaryFile = csvfile,
+                fallbackFileName = "oapsaimiML2_records.csv",
+                headerRow = headerRow,
+                valuesRow = readyRow,
+            )
+        }
     }
 
     private fun logDataToCsv(predictedSMB: Float, smbToGive: Float) {
@@ -13181,8 +13233,38 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             file.parentFile?.mkdirs()
             file.createNewFile()
             file.appendText(headerRow)
+        } else {
+            upgradeCsvHeaderIfColumnsWereAppended(file, headerRow)
         }
         file.appendText(valuesRow + "\n")
+    }
+
+    /**
+     * Rewrites the first line of an existing CSV when new columns were appended to the header.
+     *
+     * The header is only written when the file is created, so a file that already exists keeps its
+     * old header for ever. New rows would then carry cells that no reader can name, and both
+     * [app.aaps.plugins.aps.openAPSAIMI.ml.AimiSmbTrainer] and the offline analysis look columns up
+     * by name. The rewrite happens only when the stored header is the start of the wanted one, so a
+     * file with another shape is never touched. Old rows keep their shorter row on purpose: a cell
+     * that is not there reads as absent, never as zero.
+     *
+     * The file is read once per path per app start; after that the path is remembered and skipped.
+     * File I/O stays in androidMain on the existing writer — not a second store, not commonMain.
+     */
+    private fun upgradeCsvHeaderIfColumnsWereAppended(file: File, headerRow: String) {
+        if (!csvHeaderCheckedPaths.add(file.absolutePath)) return
+        runCatching {
+            val wanted = headerRow.trimEnd('\n')
+            val lines = file.readLines(Charsets.UTF_8)
+            val stored = lines.firstOrNull()?.trimEnd('\r') ?: return@runCatching
+            if (stored == wanted) return@runCatching
+            if (!wanted.startsWith("$stored,")) return@runCatching
+            file.writeText((listOf(wanted) + lines.drop(1)).joinToString("\n") + "\n", Charsets.UTF_8)
+            aapsLogger.info(LTag.APS, "CSV header extended in place for ${file.name}")
+        }.onFailure { error ->
+            aapsLogger.warn(LTag.APS, "CSV header upgrade skipped for ${file.name}: ${error.message}")
+        }
     }
 
     fun removeLast200Lines(csvFile: File) {
@@ -17119,6 +17201,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         smbSealAllowedRaiseCount = 0
         raNetCombinedDelta = shortAvgDelta
         raNetShortAvgDeltaAdj = shortAvgDelta
+        smbTrainingRowTickKey = ctx.currentTime
         val result = try {
             val inner = runDetermineBasalTickInner(ctx)
             observeRaIfNotAlreadyRun(

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/AimiFmt.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/AimiFmt.kt
@@ -14,6 +14,9 @@ internal fun aimiFmt1(value: Double): String =
 internal fun aimiFmt2(value: Double): String =
     NumberFormat.DECIMAL_2.format(value, NumberFormatPlatform.SEPARATOR_DOT)
 
+internal fun aimiFmt4(value: Double): String =
+    NumberFormat.withDecimals(4).format(value, NumberFormatPlatform.SEPARATOR_DOT)
+
 internal fun aimiFmtSigned1(value: Double): String {
     val body = aimiFmt1(abs(value))
     return if (value >= 0.0) "+$body" else "-$body"

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbTrainingRowBuffer.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbTrainingRowBuffer.kt
@@ -1,0 +1,188 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import app.aaps.core.interfaces.concurrent.AapsLock
+import app.aaps.core.interfaces.concurrent.withLock
+import app.aaps.plugins.aps.openAPSAIMI.aimiFmt1
+import app.aaps.plugins.aps.openAPSAIMI.aimiFmt4
+
+/**
+ * Small in-memory queue that holds SMB training rows until their outcome can be observed.
+ *
+ * Why it exists: the SMB model is trained on the `smbGiven` column, which is the dose that was
+ * really delivered. That column says nothing about **where** the dose came from, and nothing about
+ * what happened next. Measured on 26 days, about four units in ten leave with the model output at
+ * zero, so the model learns to copy the safety net roughly one time in two.
+ *
+ * This class does not change the label, the training filter or the model input vector. It only
+ * carries five origin fields plus one delayed outcome field to the end of each CSV row, so the
+ * question can be answered offline.
+ *
+ * Two things happen with a delay, so a row cannot be written at the moment it is built:
+ *  - the origin fields are only complete at the end of the tick, when the binding trace is built;
+ *  - the realised glucose is only known about half an hour later.
+ *
+ * The row therefore waits here and is written once its outcome window has passed. A row whose
+ * outcome never arrives inside the window is still written, but with an **empty** outcome field:
+ * an empty field must never be read as a value, and a stale reading must never be written as if it
+ * were the outcome. This mirrors `BasalNeuralLearner.fillRealisedOutcomes`, which leaves a sample
+ * unrealised rather than labelling it with an old value.
+ *
+ * Source: `origin/dev_OAPSAIMI` @ `c5db5a0333` (file SHA `c81be0e456`, introduced `7f8aa0109c`,
+ * `smbMpcRequestedU` added `db21308e6c`). Study wiring: commonMain class + tick `private val`
+ * (one consumer, like [app.aaps.plugins.aps.openAPSAIMI.ISF.ObservedSensitivityMeter]). KMP
+ * adaptation only: [AapsLock] instead of `@Synchronized` (`@Synchronized` is JVM-only),
+ * `kotlin.collections.ArrayDeque` instead of `java.util.ArrayDeque`, [aimiFmt4] / [aimiFmt1]
+ * instead of `String.format(Locale.US)`. Clinical formulas, horizons, and column order are
+ * unchanged. No File I/O here — drain returns rendered rows; the tick appends them through the
+ * existing `oapsaimiML2_records.csv` writer.
+ *
+ * ⚠️ ASYNC IMPACT: [AapsLock] around enqueue / stamp / fill / drain. Same monitor contract as
+ * the reference `@Synchronized` methods. No coroutines, no shared Metro singleton.
+ */
+internal class SmbTrainingRowBuffer(
+    private val maxPendingRows: Int = MAX_PENDING_ROWS,
+) {
+
+    /**
+     * One CSV row waiting for its origin stamp and its outcome.
+     *
+     * [valuesPrefix] is the row exactly as the old code wrote it, without the new columns and
+     * without the trailing newline.
+     */
+    internal data class PendingRow(
+        val timestampMs: Long,
+        val valuesPrefix: String,
+        var smbModelU: Double? = null,
+        var smbFloorU: Double? = null,
+        var bindingStage: String? = null,
+        var originOwner: String? = null,
+        /** Solver request before the control barrier, in U. `null` means unknown, never zero. */
+        var smbMpcRequestedU: Double? = null,
+        var originStamped: Boolean = false,
+        var bgRealisedAfter: Double? = null,
+    )
+
+    // Dedicated lock: @Synchronized is JVM-only. Same monitor contract as the reference methods.
+    private val lock = AapsLock()
+
+    private val pending = ArrayDeque<PendingRow>()
+
+    /** Adds the row of the current tick. Oldest rows are dropped if the queue grows past its cap. */
+    fun enqueue(timestampMs: Long, valuesPrefix: String) {
+        lock.withLock {
+            pending.addLast(PendingRow(timestampMs = timestampMs, valuesPrefix = valuesPrefix))
+            while (pending.size > maxPendingRows) pending.removeFirst()
+        }
+    }
+
+    /**
+     * Stamps the five origin fields on the row queued by the tick [tickKey].
+     *
+     * Called at the end of the tick, from the single point every export path goes through. The match
+     * is on the tick key and not on "the newest unstamped row": some ticks reach the export without
+     * having queued a row, and some queue a row and then leave before the export, so the newest
+     * unstamped row can belong to another tick. Writing one tick's origin on another tick's row
+     * would be worse than writing nothing. A tick with no row of its own stamps nothing.
+     */
+    fun stampOrigin(
+        tickKey: Long,
+        smbModelU: Double?,
+        smbFloorU: Double?,
+        bindingStage: String?,
+        originOwner: String?,
+        smbMpcRequestedU: Double?,
+    ) {
+        lock.withLock {
+            val row = pending.lastOrNull { it.timestampMs == tickKey && !it.originStamped } ?: return@withLock
+            row.smbModelU = smbModelU
+            row.smbFloorU = smbFloorU
+            row.bindingStage = bindingStage
+            row.originOwner = originOwner
+            row.smbMpcRequestedU = smbMpcRequestedU
+            row.originStamped = true
+        }
+    }
+
+    /**
+     * Fills [PendingRow.bgRealisedAfter] on rows that have reached the outcome horizon.
+     *
+     * `observedBg` is the glucose measured now, which is the realised outcome of a tick recorded
+     * about [OUTCOME_HORIZON_MS] ago. Rows outside the acceptance window are left alone.
+     */
+    fun fillRealisedOutcomes(nowMs: Long, observedBg: Double) {
+        lock.withLock {
+            if (!observedBg.isFinite() || observedBg <= 0.0) return@withLock
+            pending.forEach { row ->
+                if (row.bgRealisedAfter != null) return@forEach
+                val age = nowMs - row.timestampMs
+                if (age in OUTCOME_HORIZON_MIN_MS..OUTCOME_HORIZON_MAX_MS) {
+                    row.bgRealisedAfter = observedBg
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes and renders every row whose outcome window has closed, oldest first.
+     *
+     * A row leaves with the outcome it got inside the window, or with an empty outcome field if it
+     * got none. Rows still inside their window stay here.
+     */
+    fun drainWritableRows(nowMs: Long): List<String> =
+        lock.withLock {
+            val out = mutableListOf<String>()
+            while (true) {
+                val head = pending.firstOrNull() ?: break
+                if (nowMs - head.timestampMs <= OUTCOME_HORIZON_MAX_MS) break
+                pending.removeFirst()
+                out.add(render(head))
+            }
+            out
+        }
+
+    /** Number of rows still waiting. Used by tests and by diagnostics. */
+    fun pendingCount(): Int = lock.withLock { pending.size }
+
+    /** Renders one row: the original prefix, then the six new fields, empty when unknown. */
+    internal fun render(row: PendingRow): String =
+        row.valuesPrefix +
+            "," + formatUnits(row.smbModelU) +
+            "," + formatUnits(row.smbFloorU) +
+            "," + formatText(row.bindingStage) +
+            "," + formatText(row.originOwner) +
+            "," + formatGlucose(row.bgRealisedAfter) +
+            "," + formatUnits(row.smbMpcRequestedU)
+
+    private fun formatUnits(value: Double?): String =
+        value?.takeIf { it.isFinite() }?.let { aimiFmt4(it) } ?: ""
+
+    private fun formatGlucose(value: Double?): String =
+        value?.takeIf { it.isFinite() }?.let { aimiFmt1(it) } ?: ""
+
+    /** Keeps the CSV grid intact: a separator or a line break inside a name would shift columns. */
+    private fun formatText(value: String?): String =
+        value?.replace(',', ';')?.replace('\n', ' ')?.replace('\r', ' ') ?: ""
+
+    companion object {
+
+        /** Column names added at the end of the `oapsaimiML2_records.csv` header, in write order. */
+        val ADDED_COLUMN_NAMES: List<String> = listOf(
+            "smbModelU",
+            "smbFloorU",
+            "smbBindingStage",
+            "smbOriginOwner",
+            "bgRealisedAfter",
+            // Added last on purpose: a new column at the end leaves every existing column index
+            // untouched, so an older parser reads the same cells it always did.
+            "smbMpcRequestedU",
+        )
+
+        /** Delay after which a tick's outcome is considered observable. Same value as the basal head. */
+        const val OUTCOME_HORIZON_MS = 30L * 60_000
+        const val OUTCOME_HORIZON_MIN_MS = 20L * 60_000
+        const val OUTCOME_HORIZON_MAX_MS = 45L * 60_000
+
+        /** About four hours of five-minute ticks. A safety cap, not a working size. */
+        const val MAX_PENDING_ROWS = 64
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbTrainingRowBufferTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbTrainingRowBufferTest.kt
@@ -1,0 +1,270 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Specification locks for the enriched `oapsaimiML2_records.csv` corpus.
+ *
+ * These are locks on new code, not a red-before / green-after proof. They freeze three promises:
+ *  - adding columns at the end of the header does not change what the existing parser reads;
+ *  - an unknown origin field stays empty and is never read as zero;
+ *  - an outcome that arrives outside the acceptance window is not written into the row.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `7f8aa0109c` + `db21308e6c` (file on tip `c5db5a0333`,
+ * blob SHA `c81be0e456`). Study source set: [SmbTrainingRowBuffer] is commonMain and has no File I/O,
+ * so the tests live in `commonTest` (`kotlin.test`) — same layout as [DynIsfCacheTest] /
+ * [ObservedSensitivityMeterTest], not `androidHostTest`. Assertions are the same locks as the
+ * Truth/JUnit reference corpus.
+ */
+class SmbTrainingRowBufferTest {
+
+    /** The header as it was before the origin and outcome columns were added. */
+    private val legacyHeaders: List<String> = buildList {
+        add("dateStr")
+        addAll(SmbRefinementFeatureSchema.csvFeatureNames)
+        addAll(SmbRefinementFeatureSchema.familyAuditFeatureNames)
+        addAll(SmbRefinementFeatureSchema.optionalTrainingAuditFeatureNames)
+        add("predictedSMB")
+        add("smbGiven")
+        add("dynamicPeak")
+        add("adjustedDia")
+    }
+
+    /** The header written today: the same columns, then the six new ones. */
+    private val enrichedHeaders: List<String> = legacyHeaders + SmbTrainingRowBuffer.ADDED_COLUMN_NAMES
+
+    /** One plausible row for [legacyHeaders]: numbers everywhere, empty conflict flags. */
+    private val legacyCols: List<String> = legacyHeaders.map { name ->
+        when (name) {
+            "dateStr"                             -> "05/09/2026 12:30"
+            "decisionConflictFlags"               -> ""
+            "eventMemoryCorrectionFragilityScore" -> "0.10"
+            "eventMemoryPostHyperExhaustionScore" -> "0.20"
+            "causalLearningQuality"               -> "0.90"
+            "causalProtectiveConfidence"          -> "0.30"
+            "smbGiven"                            -> "0.45"
+            else                                  -> "1.25"
+        }
+    }
+
+    @Test
+    fun `the enriched CSV stays readable by the existing parser`() {
+        val enrichedCols = legacyCols + listOf("0.0000", "0.3000", "AUTODRIVE_FLOOR", "GlobalAIMI", "142.0", "1.5000")
+
+        val legacyFeatures = assertNotNull(SmbRefinementFeatureSchema.parseTrainingFeatures(legacyHeaders, legacyCols))
+        val enrichedFeatures = assertNotNull(SmbRefinementFeatureSchema.parseTrainingFeatures(enrichedHeaders, enrichedCols))
+        assertEquals(legacyFeatures.toList(), enrichedFeatures.toList())
+
+        assertEquals(
+            SmbRefinementFeatureSchema.shouldUseCsvRowForTraining(legacyHeaders, legacyCols, legacyFeatures),
+            SmbRefinementFeatureSchema.shouldUseCsvRowForTraining(enrichedHeaders, enrichedCols, enrichedFeatures),
+        )
+
+        // The label is read by name, so it must still be the same cell in both shapes.
+        assertEquals(
+            legacyCols[legacyHeaders.indexOf("smbGiven")],
+            enrichedCols[enrichedHeaders.indexOf("smbGiven")],
+        )
+    }
+
+    @Test
+    fun `an empty origin column is not read as zero`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 1_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+
+        // No stampOrigin call: the tick never reached the export point.
+        val written = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+        assertEquals(1, written.size)
+
+        val cols = written.first().split(",")
+        assertEquals(enrichedHeaders.size, cols.size)
+        SmbTrainingRowBuffer.ADDED_COLUMN_NAMES.forEach { name ->
+            val value = cols[enrichedHeaders.indexOf(name)]
+            assertEquals("", value)
+            assertNotEquals("0", value)
+            assertNull(value.toDoubleOrNull())
+        }
+    }
+
+    @Test
+    fun `a stamped origin keeps the model output and the floor apart`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 2_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+        buffer.stampOrigin(
+            tickKey = t0,
+            smbModelU = 0.0,
+            smbFloorU = 0.35,
+            bindingStage = "AUTODRIVE_FLOOR",
+            originOwner = "GlobalAIMI",
+            smbMpcRequestedU = null,
+        )
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+
+        assertEquals(0.0, cols[enrichedHeaders.indexOf("smbModelU")].toDouble(), 1e-9)
+        assertEquals(0.35, cols[enrichedHeaders.indexOf("smbFloorU")].toDouble(), 1e-9)
+        assertEquals("AUTODRIVE_FLOOR", cols[enrichedHeaders.indexOf("smbBindingStage")])
+        assertEquals("GlobalAIMI", cols[enrichedHeaders.indexOf("smbOriginOwner")])
+    }
+
+    @Test
+    fun `the pre-barrier request is kept apart from the post-barrier model output`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 8_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+        // The solver asked for 1.5 U and the barrier allowed nothing.
+        buffer.stampOrigin(
+            tickKey = t0,
+            smbModelU = 0.0,
+            smbFloorU = null,
+            bindingStage = null,
+            originOwner = "AutodriveV3",
+            smbMpcRequestedU = 1.5,
+        )
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+
+        assertEquals(1.5, cols[enrichedHeaders.indexOf("smbMpcRequestedU")].toDouble(), 1e-9)
+        assertEquals(0.0, cols[enrichedHeaders.indexOf("smbModelU")].toDouble(), 1e-9)
+    }
+
+    @Test
+    fun `an unknown pre-barrier request stays empty and is never read as zero`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 9_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+        // A tick that did not engage Autodrive: the model output is known, the request is not.
+        buffer.stampOrigin(
+            tickKey = t0,
+            smbModelU = 0.0,
+            smbFloorU = null,
+            bindingStage = null,
+            originOwner = "GlobalAIMI",
+            smbMpcRequestedU = null,
+        )
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+
+        val cell = cols[enrichedHeaders.indexOf("smbMpcRequestedU")]
+        assertEquals("", cell)
+        assertNotEquals("0", cell)
+        assertNull(cell.toDoubleOrNull())
+        // The model output of the same row is a real zero, so the two cannot be confused.
+        assertEquals(0.0, cols[enrichedHeaders.indexOf("smbModelU")].toDouble(), 1e-9)
+    }
+
+    @Test
+    fun `the new column is added last so existing column indexes do not move`() {
+        assertEquals("smbMpcRequestedU", SmbTrainingRowBuffer.ADDED_COLUMN_NAMES.last())
+        assertEquals(legacyHeaders.size, enrichedHeaders.indexOf("smbModelU"))
+        assertEquals(legacyHeaders.size + 4, enrichedHeaders.indexOf("bgRealisedAfter"))
+    }
+
+    @Test
+    fun `an outcome outside the acceptance window is not written`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 3_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+
+        // Too early, then too late: neither reading may be used as the outcome of this row.
+        buffer.fillRealisedOutcomes(nowMs = t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MIN_MS - 1, observedBg = 111.0)
+        buffer.fillRealisedOutcomes(nowMs = t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1, observedBg = 222.0)
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+        assertEquals("", cols[enrichedHeaders.indexOf("bgRealisedAfter")])
+    }
+
+    @Test
+    fun `an outcome inside the acceptance window is written`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 4_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+
+        buffer.fillRealisedOutcomes(nowMs = t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MS, observedBg = 142.0)
+        // A later reading must not overwrite the one already accepted.
+        buffer.fillRealisedOutcomes(nowMs = t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS, observedBg = 199.0)
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+        assertEquals(142.0, cols[enrichedHeaders.indexOf("bgRealisedAfter")].toDouble(), 1e-9)
+    }
+
+    @Test
+    fun `a row still inside its window is not written yet`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 5_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+
+        assertTrue(buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MS).isEmpty())
+        assertEquals(1, buffer.pendingCount())
+    }
+
+    @Test
+    fun `each tick stamps its own row`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 6_000_000L
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+        buffer.stampOrigin(
+            tickKey = t0,
+            smbModelU = 0.10,
+            smbFloorU = null,
+            bindingStage = "SMB_EXECUTOR",
+            originOwner = "A",
+            smbMpcRequestedU = null,
+        )
+        buffer.enqueue(timestampMs = t0 + 300_000, valuesPrefix = legacyCols.joinToString(","))
+        buffer.stampOrigin(
+            tickKey = t0 + 300_000,
+            smbModelU = 0.20,
+            smbFloorU = null,
+            bindingStage = "PKPD_GUARD",
+            originOwner = "B",
+            smbMpcRequestedU = null,
+        )
+
+        val rows = buffer.drainWritableRows(t0 + 300_000 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+        assertEquals(2, rows.size)
+        assertEquals("A", rows[0].split(",")[enrichedHeaders.indexOf("smbOriginOwner")])
+        assertEquals("B", rows[1].split(",")[enrichedHeaders.indexOf("smbOriginOwner")])
+    }
+
+    @Test
+    fun `a tick that queued no row never stamps the row of another tick`() {
+        val buffer = SmbTrainingRowBuffer()
+        val t0 = 7_000_000L
+        // The tick at t0 queues a row but leaves before the export point, so it stays unstamped.
+        buffer.enqueue(timestampMs = t0, valuesPrefix = legacyCols.joinToString(","))
+        // The next tick queues nothing yet reaches the export point.
+        buffer.stampOrigin(
+            tickKey = t0 + 300_000,
+            smbModelU = 9.99,
+            smbFloorU = 9.99,
+            bindingStage = "OTHER",
+            originOwner = "OTHER_TICK",
+            smbMpcRequestedU = 9.99,
+        )
+
+        val cols = buffer.drainWritableRows(t0 + SmbTrainingRowBuffer.OUTCOME_HORIZON_MAX_MS + 1)
+            .single()
+            .split(",")
+
+        assertEquals("", cols[enrichedHeaders.indexOf("smbOriginOwner")])
+        assertEquals("", cols[enrichedHeaders.indexOf("smbModelU")])
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.7** uniquement — `SmbTrainingRowBuffer`.

- **Clinique / corpus** = référence `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
  - Introduit : `7f8aa0109c`
  - Fichier tip : `plugins/aps/src/main/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbTrainingRowBuffer.kt`
  - Blob SHA **`c81be0e456`** (re-vérifié : `c81be0e456f69d116a72fd8039dee949bd652b15`)
  - Six `ADDED_COLUMN_NAMES` dont `smbMpcRequestedU` (`db21308e6c`) — sémantique tip, rien d’inventé
- **Câblage** = study tip post-#78 **`c666ad3b49afd6abaad4ff8875b95547b3c6a6bc`**
- **Tests** = **`commonTest`** + **`kotlin.test`**

Pas de copie aveugle Hilt/javax/`org.json`/`Locale.US`/`java.util.ArrayDeque`. Pas de remplacement aveugle de `DetermineBasalAIMI2`.

### Consommateurs (compté sur les deux pointes)

| | Référence tip | Étude avant ce lot |
|---|---|---|
| `SmbTrainingRowBuffer` | 1 consommateur : champ privé tick | absent |
| `AimiProfileAdvisorActivity` | commentaires seulement | inchangé (hors lot) |
| `BasalNeuralLearner.fillRealisedOutcomes` | homonyme local, pas le buffer | inchangé |

**Décision : champ privé tick** (`private val smbTrainingRowBuffer = SmbTrainingRowBuffer()`), même sibling que `ObservedSensitivityMeter` / `InsulinOriginMeter`. Pas de Metro `@Inject` / singleton.

### Source-set

- Buffer (queue + stamp + drain + render) → **`commonMain`** : pas de `File`, pas d’Environment.
- Écriture CSV `oapsaimiML2_records.csv` → reste **`androidMain`** sur le writer existant (`appendCsvSafely` / `storageHelper.getAimiFile`). Pas de second writer. `upgradeCsvHeaderIfColumnsWereAppended` reste dans le tick (I/O `File` déjà là).
- Tests → **`commonTest`**.

### Adaptations KMP seulement

- `AapsLock` à la place de `@Synchronized` ⚠️ ASYNC IMPACT (même contrat monitor, pas de coroutine)
- `kotlin.collections.ArrayDeque` à la place de `java.util.ArrayDeque`
- `aimiFmt4` / `aimiFmt1` à la place de `String.format(Locale.US, "%.4f"| "%.1f")`

Formules, horizons (20/30/45 min), cap 64, ordre des six colonnes, « vide ≠ zéro » : inchangés. Filtre d’entraînement / vecteur modèle / dose : **non touchés**.

### Sites câblés — hunks buffer seulement (`DetermineBasalAIMI2` androidMain)

1. Import.
2. Champ privé + `smbTrainingRowTickKey`.
3. `smbTrainingRowTickKey = ctx.currentTime` au bootstrap du tick.
4. `stampOrigin` après `bindingExportDraft.build`, **avant** `insulinOriginMeter.observe`.
5. `logDataMLToCsv` : colonnes header + `fillRealisedOutcomes` / `enqueue` / `drainWritableRows` → `appendCsvSafely`.
6. `upgradeCsvHeaderIfColumnsWereAppended` sur le writer existant.

`OpenAPSAIMIPlugin` **non modifié**. Harmonia / InsulinOriginMeter / MaxSmbLadder / CommandedIsf / Kalman / Autodrive leftovers / sync tick P0.8 **non tirés**.

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain \
  :plugins:aps:jvmTest --tests '...ml.SmbTrainingRowBufferTest' \
  :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL in 2m 15s

SmbTrainingRowBufferTest: 11 tests, 0 skipped, 0 failures, 0 errors
  (plugins/aps/build/test-results/jvmTest/TEST-...SmbTrainingRowBufferTest.xml)

./gradlew :plugins:aps:jvmTest \
  --tests '...ml.SmbTrainingRowBufferTest' \
  --tests '...ISF.*' --tests '...smb.*' --tests '...patient.*' \
  --tests '...quality.InsulinOriginMeterTest'
BUILD SUCCESSFUL in 5s
  → CommandedIsf 5/5, DynIsfCache 7/7, ObservedSensitivityMeter 18/18,
    MaxSmbLadder 9+9, Counterfactual 5/5, Inert 2/2, OriginMeter 6/6,
    SmbTrainingRowBuffer 11/11
    TOTAL 72 tests, 0 skipped, 0 failures, 0 errors
```

`:app:assembleFullDebug` **non lancé** : pas de nouvel `@Inject` / port Metro (classe + champ privé).

### Questions ouvertes

- `SmbBindingTrace.mpcRequestedU` n’existe pas sur l’étude (fill Autodrive `db21308e6c`). `stampOrigin` passe `smbMpcRequestedU = null` : cellule vide = inconnu, jamais un 0 synthétique. `autodriveEngine.lastMpcRawSmbU` vaut `0.0` par défaut et empoisonnerait le corpus s’il était lu ici. La colonne existe (ordre tip) ; le remplissage attend le câblage trace/Autodrive.

---

## EN

Lot **P0.7** only — `SmbTrainingRowBuffer`.

- **Clinical / corpus** = reference `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
  - Introduced: `7f8aa0109c`
  - Tip file blob SHA **`c81be0e456`** (re-verified `c81be0e456f69d116a72fd8039dee949bd652b15`)
  - Six `ADDED_COLUMN_NAMES` including `smbMpcRequestedU` (`db21308e6c`) — tip semantics, nothing invented
- **Wiring** = study tip after #78 **`c666ad3b49afd6abaad4ff8875b95547b3c6a6bc`**
- **Tests** = **`commonTest`** + **`kotlin.test`**

Not a blind Hilt/javax/`org.json`/`Locale.US`/`java.util.ArrayDeque` copy. No wholesale replace of `DetermineBasalAIMI2`.

### Consumers (counted on both tips)

One tick consumer on the reference (`private val`). Advisor comments only. Study had none. **Private field on the tick**, same sibling as `ObservedSensitivityMeter` / `InsulinOriginMeter`. No Metro `@Inject`.

### Source-set split

- Buffer → **`commonMain`** (queue + stamp + drain + render; no File I/O).
- CSV append of `oapsaimiML2_records.csv` → stays **`androidMain`** on the existing writer. Header upgrade stays next to that writer. No second store.
- Tests → **`commonTest`**.

### Call sites wired

Import, private field + tick key, tick-bootstrap key, `stampOrigin` after the built binding trace and before `insulinOriginMeter.observe`, `logDataMLToCsv` enqueue/fill/drain into `appendCsvSafely`, in-place header upgrade. Plugin untouched.

### Evidence

```
./gradlew :plugins:aps:compileAndroidMain \
  :plugins:aps:jvmTest --tests '...ml.SmbTrainingRowBufferTest' \
  :plugins:aps:compileKotlinIosArm64
BUILD SUCCESSFUL in 2m 15s
SmbTrainingRowBufferTest: 11/11 (0 skipped, 0 failures, 0 errors)

./gradlew :plugins:aps:jvmTest --tests '...ml.SmbTrainingRowBufferTest' \
  --tests '...ISF.*' --tests '...smb.*' --tests '...patient.*' \
  --tests '...quality.InsulinOriginMeterTest'
BUILD SUCCESSFUL
  CommandedIsf 5/5, DynIsfCache 7/7, ObservedSensitivityMeter 18/18,
  MaxSmbLadder 9+9, Counterfactual 5/5, Inert 2/2, OriginMeter 6/6,
  SmbTrainingRowBuffer 11/11
  TOTAL 72 tests, 0 skipped, 0 failures, 0 errors
```

`:app:assembleFullDebug` **not run**: no new `@Inject` / Metro port.

### Open questions

- Study `SmbBindingTrace` has no `mpcRequestedU` (`db21308e6c` Autodrive fill). Call site stamps `smbMpcRequestedU = null` (empty = unknown, never a fake 0). `lastMpcRawSmbU` defaults to `0.0` and must not be read here. Column is present in tip order; filling waits for the trace/Autodrive wiring.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ab741a6-db6b-488b-a5b1-558d2fc5840c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ab741a6-db6b-488b-a5b1-558d2fc5840c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

