### PR TITLE
P0.8 — clinical tick/plugin hunk sync on the KMP study branch

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -387,6 +387,16 @@ internal data class AimiDecisionContext(
         /** Insulin credited to that window, U. */
         var isf_obs_last_window_absorbed_u: Double? = null,
         /**
+         * Shadow late fat damping window: the late part of an absorption episode while a large
+         * insulin stack is already working. Strictly passive — nothing in the dosing chain reads it.
+         * It exists to be compared with [late_fat_rise_flag] before any wiring is decided.
+         */
+        var late_fat_damping_window: Boolean? = null,
+        /** The old `isLateFatProteinRise` predicate for the same tick, to measure the divergence. */
+        var late_fat_rise_flag: Boolean? = null,
+        /** Minutes since the absorption episode started, `null` when there is no episode. */
+        var late_fat_onset_age_min: Int? = null,
+        /**
          * Harmonia counterfactual, strictly passive. Nothing in the dosing chain reads these fifteen
          * fields, and nothing may ever read them: they exist only so that what Harmonia proposed can
          * be compared, after the fact, with what was really done.
@@ -790,6 +800,9 @@ internal data class AimiDecisionContext(
             base.put("isf_obs_last_window_mgdl", baseline_state.isf_obs_last_window_mgdl ?: AimiJson.NULL)
             base.put("isf_obs_last_window_drop_mgdl", baseline_state.isf_obs_last_window_drop_mgdl ?: AimiJson.NULL)
             base.put("isf_obs_last_window_absorbed_u", baseline_state.isf_obs_last_window_absorbed_u ?: AimiJson.NULL)
+            base.put("late_fat_damping_window", baseline_state.late_fat_damping_window ?: AimiJson.NULL)
+            base.put("late_fat_rise_flag", baseline_state.late_fat_rise_flag ?: AimiJson.NULL)
+            base.put("late_fat_onset_age_min", baseline_state.late_fat_onset_age_min ?: AimiJson.NULL)
             base.put("harmonia_cf_rule", baseline_state.harmonia_cf_rule ?: AimiJson.NULL)
             base.put("harmonia_cf_action", baseline_state.harmonia_cf_action ?: AimiJson.NULL)
             base.put("harmonia_cf_basal_uph", baseline_state.harmonia_cf_basal_uph ?: AimiJson.NULL)
@@ -1930,6 +1943,12 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         }
     }
     private var lateFatRiseFlag: Boolean = false
+
+    /**
+     * Last value the `isLateFatProteinRise` predicate produced this tick, kept only so the export
+     * can compare it with the shadow damping window. Never read by the dosing chain.
+     */
+    private var lateFatRiseFlagForExport: Boolean = false
     // — Hystérèse anti-pompage —
     private val HYPO_RELEASE_MARGIN   = 5.0      // mg/dL au-dessus du seuil
     private val HYPO_RELEASE_HOLD_MIN = 5        // minutes à rester > seuil+margin
@@ -5562,6 +5581,12 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                 originOwner = "AutodriveV3",
                 modelOutputU = v3SmbModel,
                 mpcOutputU = v3SmbModel,
+                // Read here and not earlier: `lastMpcRawSmbU` is written inside `tick()`, exactly
+                // like the barrier fields read by `markHtrRaFloorForExport` a few lines above. Read
+                // before the call it would still hold the previous tick's request. Ticks that do
+                // not engage Autodrive never reach this line, so the field stays null there —
+                // "not known", which is what the barrier-zero case needs to be told apart from.
+                mpcRequestedU = autodriveEngine.lastMpcRawSmbU.takeIf { it.isFinite() },
                 tier = v3FloorTier,
                 smallPrebolusPrefU = smallPrebolusPref,
                 largePrebolusPrefU = largePrebolusPref,
@@ -9251,6 +9276,16 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             decisionCtx.baseline_state.isf_obs_last_window_absorbed_u = observed.lastWindow?.absorbedU
         }
 
+        // Shadow only — measurement of the late fat damping window against the old rise predicate.
+        // Nothing downstream reads these three fields; they exist to size the divergence on a real
+        // support package before any wiring is decided.
+        runCatching {
+            decisionCtx.baseline_state.late_fat_damping_window = isLateFatDampingWindow(decisionCtx.timestamp)
+            decisionCtx.baseline_state.late_fat_rise_flag = lateFatRiseFlagForExport
+            decisionCtx.baseline_state.late_fat_onset_age_min =
+                MealAbsorptionMemory.onsetAgeMin(decisionCtx.timestamp)?.roundToInt()
+        }
+
         // Observation only — the Harmonia counterfactual. It answers two questions and changes
         // nothing: "would Harmonia propose something else if it were told the safety verdict", and
         // "how much insulin does the refusal move". The verdict below is a mirror of the real guard;
@@ -9504,10 +9539,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                 smbFloorU = bindingTrace.autodriveFloorU,
                 bindingStage = bindingTrace.bindingStage,
                 originOwner = bindingTrace.originOwner,
-                // Study SmbBindingTrace has no mpcRequestedU yet (db21308e6c Autodrive fill).
-                // Empty cell = unknown, never a synthetic 0. lastMpcRawSmbU defaults to 0.0
-                // on ticks that never engaged Autodrive and would poison the corpus if read here.
-                smbMpcRequestedU = null,
+                smbMpcRequestedU = bindingTrace.mpcRequestedU,
             )
         }
 
@@ -10031,6 +10063,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             lastBolusTimeMs = lastBolusTimeMs,
             mealFlags = mealFlags
         )
+        lateFatRiseFlagForExport = lateFatRiseFlag
         val tdd24hStateForPkpd = determineBasalInvocationCaches.getTdd24hTotalAmountState(tddCalculator)
         logInvocationCacheState("TDD24H_PKPD", tdd24hStateForPkpd)
         var tdd24Hrs = tdd24hStateForPkpd.valueOrNull()?.toFloat() ?: 0.0f
@@ -15371,6 +15404,29 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         return noMeal && hoursSinceBolus in 2.0..7.0 && rising && highish && lowIOB && cob <= 1.0
     }
 
+    /**
+     * Damping-only sibling of `isLateFatProteinRise`. SHADOW for now: computed and exported, not
+     * wired into any dose. It is deliberately NOT fed to the meal absorption phase engine nor to any
+     * belief layer, because that predicate also drives an SMB floor whose IOB requirement is the
+     * opposite of this one.
+     *
+     * It looks for the late part of an absorption episode while a large insulin stack is already
+     * working, which is where extra SMB overshoots.
+     */
+    private fun isLateFatDampingWindow(nowMs: Long = dateUtil.now()): Boolean {
+        val ageMin = MealAbsorptionMemory.onsetAgeMin(nowMs) ?: return false
+        if (ageMin !in 120.0..420.0) return false
+        if (cob > 1.0f) return false
+        if (mealTime || bfastTime || lunchTime || dinnerTime || highCarbTime) return false
+        val rising = delta >= 1.0f && (shortAvgDelta >= 0.5f || longAvgDelta >= 0.3f)
+        val highish = bg > 130.0 || predictedBg > 140.0f
+        // The stack floor is a STOCK, homogeneous with IOB. maxSMB is a per bolus cap and was the
+        // wrong scale: during the incident IOB was 6 to 10 U against a maxSMB of 0.05 to 1.5.
+        // There is no 24h TDD field on this class, only the hourly rate, so rebuild the stock.
+        val tdd24hU = tdd24HrsPerHour.toDouble() * 24.0
+        val stackFloorU = maxOf(2.0 * basalaimi.toDouble(), 0.15 * tdd24hU, 1.0)
+        return rising && highish && iob >= stackFloorU
+    }
 
     private fun neuralnetwork5(
         delta: Float,

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecision.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaDecision.kt
@@ -1,6 +1,7 @@
 package app.aaps.plugins.aps.openAPSAIMI.patient
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -9,6 +10,7 @@ import kotlinx.serialization.json.put
 import app.aaps.plugins.aps.openAPSAIMI.aimiFmt2
 
 import app.aaps.plugins.aps.openAPSAIMI.physio.MealAbsorptionPhase
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
@@ -175,6 +177,17 @@ data class HarmoniaProductionDecision(
     val selectedForProduction: Boolean,
     val requestedRateUph: Double?,
     val boundedRateUph: Double?,
+    /**
+     * The rate the pump was finally told to run, whoever decided it.
+     *
+     * This is **not** proof that Harmonia was followed. It is the final loop rate of the tick, which
+     * any later stage can have rewritten. On the night of 2026-09-05 the 18 ticks marked
+     * [HarmoniaProductionMode.APPLIED] all differ from [boundedRateUph] by more than 0.05 U/h; at
+     * 02:58 Harmonia asked for 0.85 U/h and the pump left at 3.14 U/h.
+     *
+     * Read `applied_matches_request` (from [appliedMatchesRequest]) to know whether this number is
+     * Harmonia's own.
+     */
     val appliedRateUph: Double?,
     val appliedDurationMin: Int?,
     val runtimeBlocker: String?,
@@ -184,6 +197,22 @@ data class HarmoniaProductionDecision(
     val reason: String,
     val version: Int = 1,
 ) {
+
+    /**
+     * True when the pump really ran the rate Harmonia asked for on this tick.
+     *
+     * Observation only: nothing in the loop reads it. It is `true` when [appliedRateUph] and
+     * [boundedRateUph] are both known and less than [APPLIED_MATCH_TOLERANCE_UPH] apart, `false`
+     * when they are both known and further apart, and `null` when either one is missing, because
+     * "we cannot tell" must never be exported as "no".
+     */
+    val appliedMatchesRequest: Boolean?
+        get() {
+            val applied = appliedRateUph?.takeIf { it.isFinite() } ?: return null
+            val bounded = boundedRateUph?.takeIf { it.isFinite() } ?: return null
+            return abs(applied - bounded) < APPLIED_MATCH_TOLERANCE_UPH
+        }
+
     fun toJsonObject(): JsonObject =
         buildJsonObject {
             put("timestamp", timestampMs)
@@ -193,6 +222,10 @@ data class HarmoniaProductionDecision(
             put("requested_rate_uph", requestedRateUph)
             put("bounded_rate_uph", boundedRateUph)
             put("applied_rate_uph", appliedRateUph)
+            when (val match = appliedMatchesRequest) {
+                null -> put("applied_matches_request", JsonNull)
+                else -> put("applied_matches_request", match)
+            }
             put("applied_duration_min", appliedDurationMin)
             put("runtime_blocker", runtimeBlocker)
             put("safety_blockers", JsonArray(safetyBlockers.map { JsonPrimitive(it) }))
@@ -204,12 +237,26 @@ data class HarmoniaProductionDecision(
             put("applies_to_pump", mode == HarmoniaProductionMode.APPLIED)
             put("source", "harmonia_production_branch_v1")
         }
+
+    companion object {
+
+        /** How close the pump rate must stay to the asked rate to count as the same command, U/h. */
+        const val APPLIED_MATCH_TOLERANCE_UPH: Double = 0.05
+    }
 }
 
 enum class HarmoniaProductionMode {
     SKIPPED,
     BLOCKED,
     READY,
+
+    /**
+     * Harmonia handed a rate over and the tick ended with a positive pump rate.
+     *
+     * It does **not** say the pump ran Harmonia's number. A later stage can replace the rate and the
+     * mode still reads `APPLIED`, so this value alone overstates how often Harmonia is followed. Use
+     * `applied_matches_request` for that.
+     */
     APPLIED,
 }
 

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/physio/MealAbsorptionMemory.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/physio/MealAbsorptionMemory.kt
@@ -15,6 +15,17 @@ object MealAbsorptionMemory {
     @Volatile
     var lastActiveAtMs: Long = 0L
 
+    /**
+     * Time the current absorption episode started, not the time it was last seen.
+     *
+     * [lastActiveAtMs] is refreshed on every active tick, so it always says "a few minutes ago" and
+     * can never tell how old the episode is. This field is written once, when the phase turns
+     * active while it was not, and then stays put until [reset]. Use [onsetAgeMin] to ask how far
+     * into the episode the loop is.
+     */
+    @Volatile
+    var onsetAtMs: Long = 0L
+
     @Volatile
     var waveCount: Int = 0
 
@@ -29,6 +40,9 @@ object MealAbsorptionMemory {
 
     fun isActive(nowMs: Long): Boolean =
         lastPhase.isActive && lastActiveAtMs > 0L && (nowMs - lastActiveAtMs) < MEMORY_WINDOW_MS
+
+    /** Minutes since the episode started, or `null` when there is no episode. */
+    fun onsetAgeMin(nowMs: Long): Double? = onsetAtMs.takeIf { it > 0L }?.let { (nowMs - it) / 60_000.0 }
 
     fun update(output: MealAbsorptionPhaseEngine.Output, nowMs: Long) {
         val prev = lastPhase
@@ -45,6 +59,9 @@ object MealAbsorptionMemory {
             } else if (!prev.isActive && output.phase == MealAbsorptionPhase.FIRST_WAVE) {
                 waveCount = 1
             }
+            // Onset is stamped once per episode: when the phase turns active while it was not, or
+            // when the stamp is missing. Later active ticks must not move it.
+            if (!prev.isActive || onsetAtMs == 0L) onsetAtMs = nowMs
             lastPhase = output.phase
             lastActiveAtMs = nowMs
         } else if (!isActive(nowMs)) {
@@ -58,6 +75,7 @@ object MealAbsorptionMemory {
     fun reset() {
         lastPhase = MealAbsorptionPhase.NONE
         lastActiveAtMs = 0L
+        onsetAtMs = 0L
         waveCount = 0
         lastDeltaMgdlPer5 = null
         lastGapMgdl = null

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/SmbDamping.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/SmbDamping.kt
@@ -80,7 +80,8 @@ class SmbDamping(
             // the delayed rise fades over ~4h. `elapsedSinceMealMin` is now passed in explicitly by the
             // caller — the previous reflection into `ModeState.timeSinceMealMin` always threw (no such field)
             // so `elapsed` was pinned at 0 and the whole ladder collapsed to a constant 0.85.
-            val base = policy.lateFattyMealDamping
+            // The preference range allows 0.0, which would zero the SMB for up to four hours. Floor it.
+            val base = policy.lateFattyMealDamping.coerceIn(0.5, 1.0)
             val progress = (elapsedSinceMealMin / 240.0).coerceIn(0.0, 1.0)
             lateMult = base + (0.95 - base).coerceAtLeast(0.0) * progress
             out *= lateMult

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTrace.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTrace.kt
@@ -35,6 +35,18 @@ internal data class SmbBindingTrace(
     val finalOwner: String,
     val modelOutputU: Double?,
     val mpcOutputU: Double?,
+    /**
+     * What the Autodrive solver asked for **before** the control barrier saw it, in U, or `null` when unknown.
+     *
+     * [modelOutputU] is read after the barrier, so a `0.000` there means either "the solver wanted
+     * nothing" or "the solver wanted a dose and the barrier removed it". Those two readings need
+     * opposite fixes. From 21:55 to 22:15 on 2026-09-05 the solver asked for 1.725, 1.350, 1.125,
+     * 1.575 and 1.575 U, the barrier permitted 0.000, and the trace exported a bare zero.
+     *
+     * `null` means "not known on this tick" and must never be read as zero. It stays `null` when the
+     * tick did not engage Autodrive, because then no solver ran.
+     */
+    val mpcRequestedU: Double?,
     val tier: String,
     val smallPrebolusPrefU: Double?,
     val largePrebolusPrefU: Double?,
@@ -84,6 +96,7 @@ internal data class SmbBindingTrace(
             put("stage_structure", "ORDERED_EVENTS_NOT_STRICTLY_CONTIGUOUS")
             putNullable("model_output_u", modelOutputU)
             putNullable("mpc_output_u", mpcOutputU)
+            putNullable("mpc_requested_u", mpcRequestedU)
             put("tier", tier)
             putNullable("small_prebolus_pref_u", smallPrebolusPrefU)
             putNullable("large_prebolus_pref_u", largePrebolusPrefU)
@@ -136,6 +149,8 @@ internal data class SmbBindingTrace(
         val finalOwner: String = "NONE",
         val modelOutputU: Double? = null,
         val mpcOutputU: Double? = null,
+        /** See [SmbBindingTrace.mpcRequestedU]. `null` until an engaged Autodrive tick fills it. */
+        val mpcRequestedU: Double? = null,
         val tier: String = "OFF",
         val smallPrebolusPrefU: Double? = null,
         val largePrebolusPrefU: Double? = null,
@@ -180,6 +195,7 @@ internal data class SmbBindingTrace(
                 finalOwner = finalOwner,
                 modelOutputU = modelOutputU.finiteOrNull(),
                 mpcOutputU = mpcOutputU.finiteOrNull(),
+                mpcRequestedU = mpcRequestedU.finiteOrNull(),
                 tier = tier,
                 smallPrebolusPrefU = smallPrebolusPrefU.finiteOrNull(),
                 largePrebolusPrefU = largePrebolusPrefU.finiteOrNull(),

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaAppliedMatchesRequestTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaAppliedMatchesRequestTest.kt
@@ -1,0 +1,93 @@
+package app.aaps.plugins.aps.openAPSAIMI.patient
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.content
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `mode = APPLIED` only says the tick ended with a positive pump rate. It never said the pump ran
+ * Harmonia's number: on the night of 2026-09-05 all 18 APPLIED ticks were more than 0.05 U/h away
+ * from the asked rate, so the real follow rate was 0 %, not 2.7 %.
+ *
+ * `applied_matches_request` is the field that answers that question. It reads observation only:
+ * [HarmoniaProductionDecision.mode] and the runtime state around it are untouched.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (unchanged on tip `c5db5a0333`).
+ * Study source set: [HarmoniaProductionDecision] is commonMain and uses kotlinx JSON, so the tests
+ * live in `commonTest` (`kotlin.test`). Not `org.json`.
+ */
+class HarmoniaAppliedMatchesRequestTest {
+
+    private fun decision(
+        mode: HarmoniaProductionMode,
+        boundedRateUph: Double?,
+        appliedRateUph: Double?,
+    ) = HarmoniaProductionDecision(
+        timestampMs = 1_757_120_280_000L,
+        mode = mode,
+        selectedForProduction = mode == HarmoniaProductionMode.APPLIED,
+        requestedRateUph = boundedRateUph,
+        boundedRateUph = boundedRateUph,
+        appliedRateUph = appliedRateUph,
+        appliedDurationMin = 30,
+        runtimeBlocker = null,
+        safetyBlockers = emptyList(),
+        sourceAction = HarmoniaAction.BASAL_FIRST,
+        branch = "basal_first",
+        reason = "harmonia_basal_first_applied",
+    )
+
+    @Test
+    fun `the 0258 tick is reported as not followed`() {
+        val d = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = 0.85, appliedRateUph = 3.14)
+
+        assertEquals(false, d.appliedMatchesRequest)
+        assertFalse(d.toJsonObject().getValue("applied_matches_request").jsonPrimitive.boolean)
+        // The mode is deliberately left alone: it still says APPLIED.
+        assertEquals("APPLIED", d.toJsonObject().getValue("mode").jsonPrimitive.content)
+        assertTrue(d.toJsonObject().getValue("applies_to_pump").jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun `a pump rate equal to the asked rate is reported as followed`() {
+        val d = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = 0.85, appliedRateUph = 0.85)
+
+        assertEquals(true, d.appliedMatchesRequest)
+        assertTrue(d.toJsonObject().getValue("applied_matches_request").jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun `a gap just inside the tolerance still counts as followed`() {
+        val inside = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = 0.85, appliedRateUph = 0.89)
+        val outside = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = 0.85, appliedRateUph = 0.95)
+
+        assertEquals(true, inside.appliedMatchesRequest)
+        assertEquals(false, outside.appliedMatchesRequest)
+        assertEquals(0.05, HarmoniaProductionDecision.APPLIED_MATCH_TOLERANCE_UPH, 1e-9)
+    }
+
+    @Test
+    fun `a missing rate is unknown and never a no`() {
+        val noApplied = decision(HarmoniaProductionMode.READY, boundedRateUph = 0.85, appliedRateUph = null)
+        val noBounded = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = null, appliedRateUph = 0.85)
+        val neither = decision(HarmoniaProductionMode.SKIPPED, boundedRateUph = null, appliedRateUph = null)
+
+        assertNull(noApplied.appliedMatchesRequest)
+        assertNull(noBounded.appliedMatchesRequest)
+        assertNull(neither.appliedMatchesRequest)
+        assertEquals(JsonNull, noApplied.toJsonObject()["applied_matches_request"])
+    }
+
+    @Test
+    fun `a non-finite rate is unknown`() {
+        val d = decision(HarmoniaProductionMode.APPLIED, boundedRateUph = Double.NaN, appliedRateUph = 0.85)
+
+        assertNull(d.appliedMatchesRequest)
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaAppliedMatchesRequestTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/patient/HarmoniaAppliedMatchesRequestTest.kt
@@ -2,7 +2,6 @@ package app.aaps.plugins.aps.openAPSAIMI.patient
 
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.content
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/physio/MealAbsorptionMemoryTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/physio/MealAbsorptionMemoryTest.kt
@@ -1,0 +1,71 @@
+package app.aaps.plugins.aps.openAPSAIMI.physio
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Checks the episode onset stamp of [MealAbsorptionMemory]: it must mark the start of the episode,
+ * not the last time the episode was seen.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `81e370bfbf` (unchanged on tip `c5db5a0333`).
+ * Study source set: [MealAbsorptionMemory] is commonMain, so the tests live in `commonTest`
+ * (`kotlin.test`) — same layout as [app.aaps.plugins.aps.openAPSAIMI.ISF.DynIsfCacheTest].
+ */
+class MealAbsorptionMemoryTest {
+
+    private val t0 = 1_700_000_000_000L
+
+    @BeforeTest
+    fun setUp() = MealAbsorptionMemory.reset()
+
+    @AfterTest
+    fun tearDown() = MealAbsorptionMemory.reset()
+
+    private fun output(phase: MealAbsorptionPhase) = MealAbsorptionPhaseEngine.Output(
+        phase = phase,
+        belief = 0.5,
+        reason = "test",
+        deltaMgdlPer5 = 1.0,
+        gapMgdl = 10.0,
+        bestTerminalMgdl = 150.0,
+        memoryActive = phase.isActive,
+        waveCount = 1,
+        mealDeliveryPriority = false,
+        chronoPrior = 0.0,
+        kineticScore = 0.0,
+        trajectoryScore = 0.0,
+        physioScore = 0.0
+    )
+
+    @Test
+    fun `onset is set once when the episode starts and does not move on later active ticks`() {
+        MealAbsorptionMemory.update(output(MealAbsorptionPhase.FIRST_WAVE), t0)
+        assertEquals(t0, MealAbsorptionMemory.onsetAtMs)
+
+        val later = t0 + 30 * 60_000L
+        MealAbsorptionMemory.update(output(MealAbsorptionPhase.SECOND_WAVE), later)
+        assertEquals(t0, MealAbsorptionMemory.onsetAtMs)
+        // Last activity does move, the onset does not. That is the whole point of the new field.
+        assertEquals(later, MealAbsorptionMemory.lastActiveAtMs)
+        assertEquals(30.0, MealAbsorptionMemory.onsetAgeMin(later)!!, 1e-9)
+    }
+
+    @Test
+    fun `reset clears the onset`() {
+        MealAbsorptionMemory.update(output(MealAbsorptionPhase.FIRST_WAVE), t0)
+        assertNotNull(MealAbsorptionMemory.onsetAgeMin(t0))
+
+        MealAbsorptionMemory.reset()
+        assertEquals(0L, MealAbsorptionMemory.onsetAtMs)
+        assertNull(MealAbsorptionMemory.onsetAgeMin(t0))
+    }
+
+    @Test
+    fun `onsetAgeMin is null when there is no episode`() {
+        assertNull(MealAbsorptionMemory.onsetAgeMin(t0))
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/SmbDampingTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/pkpd/SmbDampingTest.kt
@@ -1,0 +1,47 @@
+package app.aaps.plugins.aps.openAPSAIMI.pkpd
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Locks the late-fat damping floor from `origin/dev_OAPSAIMI` @ `81e370bfbf` (unchanged on tip
+ * `c5db5a0333`). The preference range of `OApsAIMISmbLateFatDamping` starts at 0.0. Taken as is,
+ * that would zero every SMB for up to four hours, so the multiplier is floored at 0.5.
+ *
+ * Study source set: [SmbDamping] is commonMain, so the test lives in `commonTest` (`kotlin.test`).
+ */
+class SmbDampingTest {
+
+    private fun createActivity(
+        stage: InsulinActivityStage = InsulinActivityStage.RISING,
+        relativeActivity: Double = 0.5,
+        postWindowFraction: Double = 0.0,
+        anticipationWeight: Double = 0.0
+    ) = InsulinActivityState(
+        window = InsulinActivityWindow(0.0, 0.0, 0.0, 0.0),
+        relativeActivity = relativeActivity,
+        normalizedPosition = 0.0,
+        postWindowFraction = postWindowFraction,
+        anticipationWeight = anticipationWeight,
+        minutesUntilOnset = 0.0,
+        stage = stage
+    )
+
+    @Test
+    fun `late fat damping never zeroes the smb even at the lowest preference`() {
+        val zeroPolicy = SmbDamping(
+            TailAwareSmbPolicy(
+                tailIobHigh = 0.25,
+                smbDampingAtTail = 0.5,
+                postExerciseDamping = 0.6,
+                lateFattyMealDamping = 0.0
+            )
+        )
+        val audit = zeroPolicy.dampWithAudit(
+            1.0, 0.0, exercise = false, suspectedLateFatMeal = true,
+            bypassDamping = false, activity = createActivity(), elapsedSinceMealMin = 0.0
+        )
+        assertTrue(audit.lateFatMult >= 0.5, "lateFatMult was ${audit.lateFatMult}")
+        assertTrue(audit.out >= 0.5, "out was ${audit.out}")
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
@@ -40,7 +40,7 @@ class SmbBindingTraceMpcRequestTest {
     }
 
     @Test
-    fun `a tick without autodrive leaves the request unknown, not zero`() {
+    fun `a tick without autodrive leaves the request unknown not zero`() {
         val json = draft()
             .copy(originOwner = "GlobalAIMI", modelOutputU = 0.0)
             .build(finalU = 0.0)

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
@@ -1,0 +1,73 @@
+package app.aaps.plugins.aps.openAPSAIMI.quality
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Locks the one reading the binding trace could not make before: "the solver asked for nothing"
+ * against "the barrier removed what the solver asked for".
+ *
+ * `model_output_u` is taken after the barrier, so it is 0 in both cases. `mpc_requested_u` is taken
+ * before it, and stays absent — never 0 — on ticks where no solver ran.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (unchanged on tip `c5db5a0333`).
+ * Study source set: [SmbBindingTrace] is commonMain and uses kotlinx JSON, so the tests live in
+ * `commonTest` (`kotlin.test`). Not `org.json`.
+ */
+class SmbBindingTraceMpcRequestTest {
+
+    private fun draft(): SmbBindingTrace.Draft = SmbBindingTrace.Draft(timestampMs = 1_757_100_000_000L)
+
+    @Test
+    fun `a request wiped by the barrier is still readable`() {
+        val json = draft()
+            .copy(
+                originOwner = "AutodriveV3",
+                modelOutputU = 0.0,
+                mpcOutputU = 0.0,
+                mpcRequestedU = 1.5,
+            )
+            .build(finalU = 0.0)
+            .toJsonObject()
+
+        assertEquals(1.5, json.getValue("mpc_requested_u").jsonPrimitive.double, 1e-9)
+        assertEquals(0.0, json.getValue("model_output_u").jsonPrimitive.double, 1e-9)
+        assertEquals(0.0, json.getValue("final_u").jsonPrimitive.double, 1e-9)
+    }
+
+    @Test
+    fun `a tick without autodrive leaves the request unknown, not zero`() {
+        val json = draft()
+            .copy(originOwner = "GlobalAIMI", modelOutputU = 0.0)
+            .build(finalU = 0.0)
+            .toJsonObject()
+
+        assertEquals(JsonNull, json["mpc_requested_u"])
+        assertTrue(json["mpc_requested_u"] !is kotlinx.serialization.json.JsonPrimitive)
+    }
+
+    @Test
+    fun `a non-finite request is exported as unknown`() {
+        val trace = draft()
+            .copy(originOwner = "AutodriveV3", mpcRequestedU = Double.NaN)
+            .build(finalU = 0.0)
+
+        assertNull(trace.mpcRequestedU)
+        assertEquals(JsonNull, trace.toJsonObject()["mpc_requested_u"])
+    }
+
+    @Test
+    fun `a real zero request stays a zero and is not turned into unknown`() {
+        val trace = draft()
+            .copy(originOwner = "AutodriveV3", mpcRequestedU = 0.0)
+            .build(finalU = 0.0)
+
+        assertEquals(0.0, trace.mpcRequestedU!!, 1e-9)
+        assertEquals(0.0, trace.toJsonObject().getValue("mpc_requested_u").jsonPrimitive.double, 1e-9)
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/quality/SmbBindingTraceMpcRequestTest.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 /**
  * Locks the one reading the binding trace could not make before: "the solver asked for nothing"
@@ -48,7 +47,6 @@ class SmbBindingTraceMpcRequestTest {
             .toJsonObject()
 
         assertEquals(JsonNull, json["mpc_requested_u"])
-        assertTrue(json["mpc_requested_u"] !is kotlinx.serialization.json.JsonPrimitive)
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.8** uniquement — greffe hunk-par-hunk du delta clinique restant dans le tick (et seams déjà présentes), **sans** remplacer `DetermineBasalAIMI2.kt` ni `OpenAPSAIMIPlugin.kt`.

- **Clinique** = référence `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
- **Câblage** = study tip post-#79 **`91b076ae6d9c5041b787f98054f26217eacc5a7e`**, puis merge study **`61206f7c4715675606df4ca9396fb7af822c2f2d`** (humain, 2026-09-10)
- **HEAD** = **`2a5707e77b497651d57720c223ec82beaed81167`**
- **Règle :** formules / ordre d’observation / reason-tags = référence. Ports Metro (`AimiAuditor`, `AimiSmbComparison`, `AimiTpo`, `AimiEmergencySos`, `AimiBehaviorProfileSource`), `AimiJson`, `pkPdLearnedState` ctor, Context/File androidMain = étude.
- **Tests** = **`commonTest`** + **`kotlin.test`**

Pas de copie aveugle Hilt/javax/`org.json`/`Locale.US`/`StringKey.exportable`. Pas de second exemplaire des instruments P0.1–P0.7.

### Tableau des hunks (7 commits §7.8)

| Commit | Sujet | Statut P0.8 |
|---|---|---|
| `eb84e078f5` | `ObservedSensitivityMeter` tick | **Déjà P0.3** (`#75`) — champs `isf_obs_*`, observe/read, export `AimiJson.NULL` |
| `81e370bfbf` | Plancher late-fat 0.5 + fenêtre ombre | **Appliqué** — `SmbDamping.coerceIn(0.5, 1.0)` ; `MealAbsorptionMemory.onsetAtMs` / `onsetAgeMin` ; export `late_fat_*` ; `isLateFatDampingWindow` **ombre** (rien ne dose dessus) ; `lateFatRiseFlag` membre **non assigné** (comme la ref) |
| `f03fa321a6` | `MaxSmbLadder` + `shortAvgDelta` | **Déjà P0.5** (`#77`) |
| `da9bc789ce` | Harmonia CF + origin meter | **Déjà P0.6** (`#78`) — `IobSurveillanceExport` conservé à côté |
| `7f8aa0109c` | `SmbTrainingRowBuffer` | **Déjà P0.7** (`#79`) sauf le fill `smbMpcRequestedU` |
| `db21308e6c` | lire l’instrument avant le frein | **Partiel** — `CommandedIsf` déjà P0.4 ; **appliqué ici :** `SmbBindingTrace.mpcRequestedU` + fill AutodriveV3 `lastMpcRawSmbU.takeIf { it.isFinite() }` (ticks non-Autodrive : `null`, jamais un 0 synthétique) + `stampOrigin(smbMpcRequestedU = bindingTrace.mpcRequestedU)` ; `HarmoniaProductionDecision.appliedMatchesRequest` (observation) |
| `02c90656b1` | corpus + profil actif dans le paquet support | **Différé** — `AimiProfileAdvisorActivity` / `AimiDiagnosticsManager` sont **parkés** dans `_docs/kmp/staging/openAPSAIMI-android-wip/` (pas sur un source set). PORTING : ne pas recoller le dump. Pas de ZIP support live à greffer sans déparquer l’Activity. |
| `c5db5a0333` | re-grid glucose | **Hors lot** (loop, pas AIMI) |

**Autodrive rewrite (`db21308e6c` leftovers) différé :** `clearTickObservations`, override coefficient `ControlBarrierShield.enforce`, export `anchor_is_dynamic_isf`. Exception honorée : champ `mpcRequestedU` + fill au **même** site que la référence (draft AutodriveV3, après `tick()`). `lastMpcRawSmbU` défaut `0.0` n’est **pas** lu à `stampOrigin`.

`OpenAPSAIMIPlugin` **non modifié** (hunk `CommandedIsf` déjà P0.4). Coutures étude intactes.

### Après le merge study (2026-09-10)

Merge humain `kmp-aimi-migration-study` → cette branche (`2eaee1fc9f`). Greffes cliniques intactes, pas de marqueurs de conflit. Suite à `e34b01f666` (virgule interdite dans un nom backtick `commonTest` sur Kotlin/Native) : une virgule restait dans `SmbBindingTraceMpcRequestTest` — retirée dans **`2a5707e77b`**. Pas de changement de lock.

### Preuves

**2026-09-07** (tip `02724f9d12`, avant le merge study) :

```
./gradlew :app:assembleFullDebug --no-daemon --no-parallel --max-workers=2 \
  -Dorg.gradle.jvmargs="-Xmx4g -XX:+UseParallelGC -Xss512m"
→ BUILD SUCCESSFUL in 2m 5s (938 tasks). :plugins:aps:compileAndroidMain dans le graphe.
```

**2026-09-10** (après merge + fix nom Native) :

```
./gradlew :plugins:aps:jvmTest --tests '...physio.MealAbsorptionMemoryTest' \
  --tests '...pkpd.SmbDampingTest' \
  --tests '...quality.SmbBindingTraceMpcRequestTest' \
  --tests '...patient.HarmoniaAppliedMatchesRequestTest'
→ BUILD SUCCESSFUL — 13 tests, 0 fail, 0 err, 0 skip

./gradlew :plugins:aps:compileTestKotlinIosArm64
→ BUILD SUCCESSFUL in 1m 8s (commonTest compile Native — le nom sans virgule passe)
```

### GitHub CI (cette PR, avant le merge)

| Check | Résultat | Lecture |
|---|---|---|
| iOS — Compile the Apple targets | **success** | klib AIMI / commonMain de ce lot compile sur le runner macOS |
| iOS — `iosSimulatorArm64Test` (`:ios:shell`) | **fail** | **Préexistant**, identique à `#79` : `ambiguous-variants` sur plugins Android-only au link `:ios:shell`. Ce job ne lance **pas** `:plugins:aps` tests. Hors lot P0.8. |
| claude-review | **fail** | **Préexistant** (`#79`) : OIDC `401` / `ANTHROPIC_API_KEY` vide. Pas une revue du diff. |

⚠️ ASYNC IMPACT: none (pas de nouvelles coroutines). `MealAbsorptionMemory.onsetAtMs` est `@Volatile` comme `lastActiveAtMs`.

---

## EN

Lot **P0.8** only — remaining clinical tick hunks from the seven PORTING §7.8 commits, grafted into the study file. **Do not** wholesale-replace `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`.

- **Clinical** = `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
- **Wiring** = study tip after #79 **`91b076ae6d9c5041b787f98054f26217eacc5a7e`**, then human merge of study **`61206f7c47`** (2026-09-10)
- **HEAD** = **`2a5707e77b497651d57720c223ec82beaed81167`**
- Metro ports, `AimiJson`, `pkPdLearnedState` ctor kept. No Hilt/javax/`org.json`/`Locale.US`/`StringKey.exportable`.
- Tests in **`commonTest`**.

### Hunk table

| Commit | Topic | P0.8 status |
|---|---|---|
| `eb84e078f5` | ObservedSensitivityMeter tick | **Already P0.3** |
| `81e370bfbf` | Late-fat damping floor + shadow window | **Applied** (floor 0.5; onset stamp; shadow export only; member `lateFatRiseFlag` still unassigned) |
| `f03fa321a6` | MaxSmbLadder rise-by-delta | **Already P0.5** |
| `da9bc789ce` | Harmonia CF + origin meter | **Already P0.6** (`IobSurveillanceExport` kept beside) |
| `7f8aa0109c` | SmbTrainingRowBuffer | **Already P0.7** except mpc fill |
| `db21308e6c` | instrument-before-brake leftovers | **Partial** — CommandedIsf already P0.4; **this lot:** `mpcRequestedU` on the trace, filled only on AutodriveV3 after `tick()` (`null` when unknown, never a fake 0); `appliedMatchesRequest` on Harmonia production JSON |
| `02c90656b1` | training corpus in support package | **Deferred** — advisor Activity/DiagnosticsManager parked in staging dump; grafting would unpark UI, out of this lot |
| `c5db5a0333` | glucose re-grid | **Out of lot** (loop, not AIMI) |

Autodrive rewrite leftover (`clearTickObservations`, unfloored coefficient override, `anchor_is_dynamic_isf`) **deferred**. `OpenAPSAIMIPlugin` untouched.

### After the study merge (2026-09-10)

Human merge `kmp-aimi-migration-study` → this branch (`2eaee1fc9f`). Clinical grafts intact, no conflict markers. Follow-up to `e34b01f666` (Kotlin/Native rejects commas in backtick `commonTest` names): one remaining comma in `SmbBindingTraceMpcRequestTest` removed in **`2a5707e77b`**. Locks unchanged.

### Evidence

**2026-09-07** (`02724f9d12`, pre-merge): `:app:assembleFullDebug` **BUILD SUCCESSFUL**.

**2026-09-10** (post-merge + Native name fix): P0.8 commonTest locks **13/13**. `:plugins:aps:compileTestKotlinIosArm64` **BUILD SUCCESSFUL**.

⚠️ ASYNC IMPACT: none (no new coroutines). `MealAbsorptionMemory.onsetAtMs` is `@Volatile` like `lastActiveAtMs`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2309fd-dfb6-4b42-8be5-c14f979d5c5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2309fd-dfb6-4b42-8be5-c14f979d5c5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

