### PR TITLE
docs(kmp): ancre P0.8 — PR #80 vs freeze c5db5a0333

### DIFF
--- a/_docs/kmp/P0.8-ANCHOR.md
+++ b/_docs/kmp/P0.8-ANCHOR.md
@@ -1,0 +1,165 @@
+# Ancre P0.8 — PR #80 vs `origin/dev_OAPSAIMI` @ `c5db5a0333`
+
+**Verdict : `GO_WITH_CAVEATS`**
+
+Relu le **2026-09-10** sur le code (pas sur le texte du PR). Aucun changement clinique dans cette ancre.
+
+| Rôle | SHA | Branche / objet |
+|---|---|---|
+| HEAD study de #80 | `02724f9d127efd5a297880a264714560a68194c3` | `cursor/p08-clinical-tick-plugin-hunk-sync-5c5b` |
+| Base #80 (post-P0.7) | `91b076ae6d9c5041b787f98054f26217eacc5a7e` | merge `#79` |
+| Tip study au jour de l’ancre | `61206f7c4715675606df4ca9396fb7af822c2f2d` | `kmp-aimi-migration-study` (merge `kmp` + log P0.1–P0.7 ; **fichiers P0.8 inchangés** vs `91b076ae`) |
+| Référence clinique gelée | `c5db5a033379390bceb7851ff92004b72ef055bf` | `origin/dev_OAPSAIMI` **au freeze P0** |
+| Tip `origin/dev_OAPSAIMI` aujourd’hui | `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc` | **6 commits AIMI après le freeze** — hors lot P0.8 |
+
+Source des items : PORTING **§7.8** (`docs/kmp-migration/PORTING-against-milos-kmp.md` PR #74) + DELTA P0.8 (PR #69). Les 7 commits à rejouer sur le tick étude, plus `c5db5a0333` (loop, hors lot).
+
+PR : https://github.com/MTR93600/OpenApsAIMI/pull/80
+
+---
+
+## 1. Contenu réel de PR #80
+
+Deux commits, **9 fichiers**, `+424 / −5`. **Pas** de remplacement de `DetermineBasalAIMI2` ni de `OpenAPSAIMIPlugin`.
+
+| Commit | Sujet |
+|---|---|
+| `f141259a83cd2e47463de23aefecc89ff2566fd0` | greffe hunks cliniques restants |
+| `02724f9d127efd5a297880a264714560a68194c3` | fix tests `JsonNull` kotlinx |
+
+Fichiers touchés (tous sous `:plugins:aps`) :
+
+- `androidMain/.../DetermineBasalAIMI2.kt` (`+60 / −4`)
+- `commonMain/.../patient/HarmoniaDecision.kt`
+- `commonMain/.../physio/MealAbsorptionMemory.kt`
+- `commonMain/.../pkpd/SmbDamping.kt`
+- `commonMain/.../quality/SmbBindingTrace.kt`
+- `commonTest` : `MealAbsorptionMemoryTest`, `SmbDampingTest`, `SmbBindingTraceMpcRequestTest`, `HarmoniaAppliedMatchesRequestTest`
+
+**Non touchés (preuve `git diff 91b076ae..02724f9d --stat` vide sur ces chemins) :**
+
+- `OpenAPSAIMIPlugin.kt`
+- `AutodriveEngine.kt`
+- `ControlBarrierShield.kt`
+- `SmbTrainingRowBuffer.kt` / `ObservedSensitivityMeter.kt` / `MaxSmbLadder.kt` / `HarmoniaCounterfactual.kt` / `InsulinOriginMeter.kt` / `CommandedIsf.kt`
+- `plugins/sync/**` (`LoopHubImpl` re-grid)
+
+Tick : 19 233 lignes (`91b076ae`) → 19 289 (`02724f9d`) vs 19 312 sur la ref `src/main`. L’écart restant (~23) n’est **pas** un hunk P0.8 manquant : identifiants AIMI encore absents du tick étude = `anchorIsDynamicIsf` / `anchor_is_dynamic_isf` (leftover Autodrive `db21308e6c`, différé). Le reste des identifiants ref-only sont du câblage (`JSONObject`, `javax`, `AuditorOrchestrator`, …).
+
+---
+
+## 2. Tableau §7.8 — applied / already P0.x / deferred
+
+| Item §7.8 | Commit ref | Classe | Preuve |
+|---|---|---|---|
+| Tick `ObservedSensitivityMeter` (`isf_obs_*`, observe/read, export `AimiJson.NULL`) | `eb84e078f5` | **already P0.3** (`#75` `4ccd0d73ce`) | Compteurs `isf_obs_last_window` = 12/12/12 sur study/head/ref **avant** #80. Fichier `commonMain/.../ISF/ObservedSensitivityMeter.kt` déjà sur `91b076ae`. #80 n’y touche pas. |
+| Plancher late-fat `coerceIn(0.5, 1.0)` | `81e370bfbf` | **applied** | `SmbDamping.kt` study `val base = policy.lateFattyMealDamping` → head/ref `coerceIn(0.5, 1.0)`. Pref `OApsAIMISmbLateFatDamping` range `0.0..1.0` (`DoubleKey.kt:399`) — sans plancher, 0.0 zéroie le SMB jusqu’à 4 h. **Seul changement dose-facing du lot.** |
+| `MealAbsorptionMemory.onsetAtMs` / `onsetAgeMin` | `81e370bfbf` | **applied** | Champs + stamp `if (!prev.isActive \|\| onsetAtMs == 0L) onsetAtMs = nowMs` + `reset` identiques head/ref. Study KMP : `kotlin.concurrent.Volatile` (déjà le pattern du fichier). |
+| Fenêtre ombre `isLateFatDampingWindow` + export `late_fat_*` | `81e370bfbf` | **applied** | Prédicat **byte-identique** head l.15416–15428 / ref l.15438–15450 (`ageMin in 120..420`, `cob<=1`, pas de meal flags, `rising`/`highish`, `stackFloorU = max(2×basal, 0.15×TDD24h, 1)`). Appelé **uniquement** dans le `runCatching` d’export. Rien dans la chaîne de dose ne lit `late_fat_damping_window`. |
+| Membre `lateFatRiseFlag` non assigné ; export via `lateFatRiseFlagForExport` | `81e370bfbf` | **applied** (fidèle à la ref, y compris le piège) | `private var lateFatRiseFlag = false` jamais écrit ; un `val lateFatRiseFlag = isLateFatProteinRise(...)` **shadow** le membre ; `lateFatRiseFlagForExport = lateFatRiseFlag` (local). Identique ref. La dose continue d’utiliser le prédicat **rise** (`suspectedLateFatMeal`), pas la fenêtre ombre. |
+| `MaxSmbLadder` + `shortAvgDelta >= 8.0` | `f03fa321a6` | **already P0.5** (`#77` `b30a62ea76`) | `RISE_SHORT_DELTA_THRESHOLD = 8.0` déjà sur `91b076ae` et sur la ref. #80 n’y touche pas. |
+| Harmonia CF + `InsulinOriginMeter` | `da9bc789ce` | **already P0.6** (`#78` `c666ad3b49`) | Types présents sur study avant #80. `IobSurveillanceExport` **conservé à côté** (tick head importe les deux). |
+| `SmbTrainingRowBuffer` (colonnes origin/outcome + `stampOrigin(..., smbMpcRequestedU)`) | `7f8aa0109c` + fill `db21308e6c` | **already P0.7** sauf le fill | Signature `stampOrigin` déjà avec `smbMpcRequestedU` sur `91b076ae`. Avant #80 le tick passait `smbMpcRequestedU = null` (commentaire : pas de `mpcRequestedU` sur la trace). |
+| `CommandedIsf` « lire l’instrument avant le frein » (plugin) | `db21308e6c` | **already P0.4** (`#76` `2ffbfa32d9`) | Plugin **identique** study/head/ref sur le call site `CommandedIsf.floorAgainstProfileAndRecordShadow`. #80 ne touche pas le plugin. |
+| `SmbBindingTrace.mpcRequestedU` + fill AutodriveV3 après `tick()` | `db21308e6c` | **applied** | Champ + export `mpc_requested_u` + fill `lastMpcRawSmbU.takeIf { it.isFinite() }` **au même site** que la ref (draft AutodriveV3, après `tick()`). `stampOrigin` lit `bindingTrace.mpcRequestedU`. Ticks non-Autodrive : champ reste `null`, jamais un 0 synthétique. |
+| `HarmoniaProductionDecision.appliedMatchesRequest` (tolérance 0.05 U/h, `null` si inconnu) | `db21308e6c` | **applied** | Getter identique head/ref. Export kotlinx `JsonNull` vs ref `JSONObject.NULL` — même sémantique. `mode = APPLIED` non réécrit. |
+| Leftovers Autodrive `db21308e6c` : `clearTickObservations`, `siMetabolicOverride` / coef unfloored sur `enforce`, export `anchor_is_dynamic_isf` | `db21308e6c` | **deferred** | `clearTickObservations` : 0/0/2 study/head/ref. `enforce(...)` study/head **sans** `siMetabolicOverride` / `anchorIsDynamicIsf` ; ref les a. `AutodriveEngine.kt` / `ControlBarrierShield.kt` non modifiés. `lastMpcRawSmbU` défaut `0.0` **non lu** hors chemin AutodriveV3. |
+| Corpus + profil actif dans le paquet support | `02c90656b1` | **deferred** | `AimiProfileAdvisorActivity` / `AimiDiagnosticsManager` **absents** des source sets study/head ; parkés `_docs/kmp/staging/openAPSAIMI-android-wip/`. PORTING Don’t : ne pas recoller le dump. Test ref `AimiDiagnosticsActiveProfileTest` non porté. |
+| Re-grid glucose | `c5db5a0333` | **deferred / hors lot** | Commit loop : `LoopHubImpl.kt` seulement. Absent du diff #80. |
+
+---
+
+## 3. Fidélité clinique (items *applied* seulement)
+
+Formules / ordre d’observation / reason-tags = référence. Vérifié hunk par hunk :
+
+| Hunk appliqué | Fidélité vs `c5db5a0333` | Note |
+|---|---|---|
+| `coerceIn(0.5, 1.0)` | identique | Dose-facing, voulu par `81e370bfbf` |
+| onset stamp / age | identique | Observation pour la fenêtre ombre |
+| `isLateFatDampingWindow` | identique | Ombre : **pas** branché sur le meal engine ni sur un floor SMB |
+| export `late_fat_*` | identique (null via `AimiJson.NULL` au lieu de `JSONObject.NULL`) | Couture étude |
+| fill `mpcRequestedU` | identique, même site | `null` ≠ 0 |
+| `appliedMatchesRequest` | identique (`abs(applied-bounded) < 0.05`) | Observation ; `APPLIED` inchangé |
+| tests | mêmes cas (02:58 0.85 vs 3.14 ; NaN → unknown ; zéro réel reste 0) | `commonTest` + `kotlin.test` + kotlinx JSON |
+
+`isLateFatProteinRise` reste le prédicat doseur (late-fat **rise**). La fenêtre damping est un témoin pour mesurer la divergence, comme sur la ref.
+
+---
+
+## 4. Adaptations KMP vs divergences sémantiques
+
+**Adaptations (autorisées, PORTING §3 / §7.8) :**
+
+- `AimiJson.NULL` / kotlinx `JsonNull` / `JsonObject` à la place de `org.json`
+- tests en `commonTest` (`kotlin.test`), pas `src/test` + JUnit/`org.json`
+- `MealAbsorptionMemory.onsetAtMs` : `@Volatile` = `kotlin.concurrent.Volatile` (déjà le fichier étude)
+- `SmbTrainingRowBuffer.stampOrigin` : `AapsLock.withLock` (P0.7) vs corps non verrouillé sur la ref — **pas introduit par #80**
+- Metro / ports / `pkPdLearnedState` ctor / `Context` androidMain **intacts**
+
+**Pas de collage interdit dans le diff #80 :** pas de Hilt, `javax.inject`, `Locale.US`, `StringKey.exportable`, `@IntKey(225)`, pas de dump staging recollé.
+
+**Divergences sémantiques restantes vs ref (volontaires, hors *applied*) :**
+
+- pas de `clearTickObservations()` → `lastMpcRawSmbU` n’est pas remis à `NaN` en tête de tick. Acceptable **parce que** #80 ne lit cette valeur qu’après `tick()` sur le chemin AutodriveV3.
+- `ControlBarrierShield.enforce` sans override coef / `anchorIsDynamicIsf` : leftover Autodrive, pas un hunk greffé à moitié.
+
+---
+
+## 5. Hors-scope respecté
+
+- `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` **non** remplacés.
+- Instruments P0.1–P0.7 **non** re-portés (fichiers types absents du diff).
+- `02c90656b1` **non** recollé depuis staging.
+- `c5db5a0333` loop **non** greffé.
+- Leftovers Autodrive `db21308e6c` **non** collés dans `AutodriveEngine` / `ControlBarrierShield`.
+
+---
+
+## 6. Caveats vs blockers
+
+**Blockers : aucun** pour merger le lot tel que défini (§7.8 = greffe hunk-par-hunk, pas parité Autodrive complète, pas UI advisor).
+
+**Caveats (ne bloquent pas #80) :**
+
+1. **`db21308e6c` est partiel par construction.** Le rewrite Autodrive (`clearTickObservations`, override `enforce`, `anchor_is_dynamic_isf`) reste un delta réel vs ref. Lot suivant dédié, pas un oubli de #80.
+2. **`02c90656b1` différé.** DELTA disait « also bring if in those commits » ; PORTING Don’t interdit de recoller le dump. Justifié. À replanifier après déparquage Activity.
+3. **Freeze clinique `c5db5a0333` ≠ tip `origin/dev_OAPSAIMI` d’aujourd’hui** (`fe96b64f12`). Six commits AIMI post-freeze (`6c0c0285ff` smbGiven, `078a51514c` gate Autodrive, `f519320841` barrier-as-sensitivity, `79588b42cb` replay tests, `0ca7744184` meal name, `fe96b64f12` `DescentRedoseGuard`) sont **hors P0.8**.
+4. **CI GitHub de #80 :** `ios` (`iosSimulatorArm64Test` / variants Android-only) et `claude-review` (OIDC 401) rouges, **préexistants #79**. Le job `ios` ne lance pas `:plugins:aps` tests. Pas une régression clinique P0.8.
+5. **Cette ancre n’a pas relancé Gradle.** Preuves = lecture SHA. Les 13 locks `commonTest` sont **présents** dans le diff ; le body #80 les revendique (2026-09-07) — non rejoués ici.
+6. **Membre `lateFatRiseFlag` toujours mort** (shadow par un `val` local) — **identique à la ref**, pas une divergence KMP.
+
+⚠️ ASYNC IMPACT: none. `onsetAtMs` est `@Volatile` comme `lastActiveAtMs`. Pas de nouvelle coroutine.
+
+---
+
+## 7. Checklist preuves
+
+- [x] Diff #80 = 9 fichiers, tick `+60/−4`, plugin 0
+- [x] 7 commits §7.8 classés avec SHA study / head / ref
+- [x] `isLateFatDampingWindow` head == ref ; 0 lecture dose
+- [x] `coerceIn(0.5, 1.0)` head == ref ; pref range commence à 0.0
+- [x] `mpcRequestedU` fill au site AutodriveV3 ; `stampOrigin` n’utilise plus `null` forcé
+- [x] `appliedMatchesRequest` 0.05 U/h, `null` si manquant
+- [x] P0.3/P0.4/P0.5/P0.6/P0.7 types + call sites déjà sur `91b076ae`
+- [x] `IobSurveillanceExport` toujours à côté de `InsulinOriginMeter`
+- [x] Pas de Hilt / `org.json` / dump staging / `LoopHubImpl`
+- [x] Merge study tip `61206f7c` : fichiers P0.8 identiques à la base `91b076ae` (conflit attendu : aucun)
+
+---
+
+## 8. Reco
+
+**Merger #80** sur `kmp-aimi-migration-study` (rebase/merge trivial : tip study n’a pas retouché ces fichiers).
+
+**Ne pas** « compléter » #80 avec les leftovers Autodrive ni le ZIP advisor — ce serait un autre lot, et le dump staging casserait la règle PORTING.
+
+**Suite (hors #80) :**
+
+| Priorité | Lot | Pourquoi |
+|---|---|---|
+| P0.8b / P0.9 | Leftovers Autodrive `db21308e6c` (`clearTickObservations`, `enforce` override, `anchor_is_dynamic_isf`) | Seul delta AIMI **du freeze** encore ouvert après #80 |
+| plus tard | `02c90656b1` support package | Après déparquage `AimiProfileAdvisorActivity` |
+| nouvelle série | 6 commits AIMI **post-**`c5db5a0333` | Le freeze P0 est clos ; ne pas les glisser dans #80 |
+
+P1 (seams `java.time` / `File` / `Context` du tick) peut démarrer une fois #80 mergé ; P3.1 capture read-only aussi.

--- a/_docs/kmp/README.md
+++ b/_docs/kmp/README.md
@@ -75,6 +75,7 @@ blueprint et ces annexes spécialisées font autorité sur `AIMI_KMP_MIGRATION_S
 4. [`w6-m1-read-registry.md`](w6-m1-read-registry.md) — freeze field and service-read inventory (W6, not a rewrite) ;
 5. [`w8-go-nogo.md`](w8-go-nogo.md) — W8 GO/NO-GO for empty AIMI KMP shells ;
 6. [`aimi-kmp-port-ledger.md`](aimi-kmp-port-ledger.md) — folder-by-folder AIMI port (Milos SMB pattern) ;
+6b. [`P0.8-ANCHOR.md`](P0.8-ANCHOR.md) — ancre PR #80 vs freeze `c5db5a0333` (GO_WITH_CAVEATS) ;
 7. annexe 6 pour le protocole Tree → Harmonia → RBT → safety ;
 8. annexe 5 pour les modèles et learners ;
 9. annexe 7 pour l'intégration iOS ;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre indépendante de **PR #80 (P0.8)** — lecture SHA, pas le texte du PR.

**Verdict : `GO_WITH_CAVEATS`**

- Clinique gelée : `origin/dev_OAPSAIMI` @ `c5db5a033379390bceb7851ff92004b72ef055bf`
- HEAD #80 : `02724f9d127efd5a297880a264714560a68194c3`
- Base #80 : `91b076ae6d9c5041b787f98054f26217eacc5a7e` (post-#79)
- Aucun changement clinique dans *cette* PR docs.

**§7.8 en une ligne**

| Classe | Items |
|---|---|
| **applied** | plancher late-fat 0.5 ; onset + fenêtre ombre ; `mpcRequestedU` fill AutodriveV3 ; `appliedMatchesRequest` |
| **already P0.x** | `eb84e078f5` P0.3 ; `f03fa321a6` P0.5 ; `da9bc789ce` P0.6 ; `7f8aa0109c` P0.7 (sauf fill) ; `CommandedIsf` plugin P0.4 |
| **deferred** | leftovers Autodrive `db21308e6c` ; ZIP advisor `02c90656b1` ; re-grid loop `c5db5a0333` |

**Reco :** merger #80. Ne pas y coller Autodrive rewrite ni le dump staging. Suite = leftovers `db213` puis commits AIMI **post-freeze** (`origin/dev_OAPSAIMI` est déjà à `fe96b64f12`).

Livrable : `_docs/kmp/P0.8-ANCHOR.md`

## EN

Independent SHA-level anchor of P0.8. Applied hunks match the frozen reference formulas and observation order. Remaining Autodrive leftovers and the parked advisor ZIP are intentional, not misses. Merge #80; do not extend it.

No clinical code in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f819f959-5232-4ecb-bb90-c5ab92a8e023?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f819f959-5232-4ecb-bb90-c5ab92a8e023&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

