### PR TITLE
P0.9 — Autodrive observation leftovers from db21308e6c

### DIFF
--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngineCoefficientShadowTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngineCoefficientShadowTest.kt
@@ -1,0 +1,147 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive
+
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.controller.MpcController
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.estimator.ContinuousStateEstimator
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveAuditor
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveDataBackfiller
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveDataLake
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.MechanismAttentionGate
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.OnlineLearner
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveCommand
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveState
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.safety.ControlBarrierShield
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+/**
+ * End of the wire for the unfloored counterfactual, with a real barrier in place.
+ *
+ * `ControlBarrierShieldUnflooredShadowTest` proves the shield can now be asked for an unfloored
+ * answer. This one proves the engine actually asks for it, and that asking costs the production
+ * decision nothing.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (unchanged on freeze `c5db5a0333`).
+ * Study source set: [AutodriveEngine] is androidMain, so this lives in `androidHostTest` + mockito
+ * (not mockk). Production calls `updateAndPredict(state, tickId = observationId)` — two named args;
+ * Mockito stubs the JVM 3-arg form so that named-arg call still matches.
+ */
+class AutodriveEngineCoefficientShadowTest : TestBase() {
+
+    @Mock private lateinit var estimator: ContinuousStateEstimator
+    @Mock private lateinit var mpc: MpcController
+    @Mock private lateinit var attention: MechanismAttentionGate
+    @Mock private lateinit var dataLake: AutodriveDataLake
+    @Mock private lateinit var dataBackfiller: AutodriveDataBackfiller
+
+    /** Median profile ISF on this deployment, and well under the reference 45. */
+    private val resistantIsf = 30.0
+
+    private val state = AutoDriveState(
+        bg = 150.0,
+        bgVelocity = -1.0,
+        iob = 2.0,
+        estimatedSI = resistantIsf / 10000.0,
+        estimatedRa = 1.0,
+        physiologicalStressMask = DoubleArray(0),
+        maxIOB = 60.0,
+    )
+
+    /** More than the barrier can permit here, so the barrier is what limits the result. */
+    private val request = AutoDriveCommand(
+        scheduledMicroBolus = 6.0,
+        temporaryBasalRate = 1.2,
+        isSafe = true,
+        reason = "test",
+    )
+
+    private fun engine(): AutodriveEngine {
+        whenever(attention.applyAttention(any())).thenAnswer { it.getArgument(0) }
+        whenever(estimator.getLastRa()).thenReturn(state.estimatedRa)
+        whenever(estimator.updateAndPredict(any(), any(), any())).thenAnswer { it.getArgument(0) }
+        whenever(mpc.calculateOptimalDose(any(), any(), any())).thenReturn(request)
+        return AutodriveEngine(
+            aapsLogger = aapsLogger,
+            stateEstimator = estimator,
+            mpcController = mpc,
+            // The real shield: the whole point is what its arithmetic does with the two coefficients.
+            safetyShield = ControlBarrierShield(aapsLogger),
+            onlineLearner = OnlineLearner(aapsLogger),
+            autodriveAuditor = AutodriveAuditor(),
+            dataLake = dataLake,
+            dataBackfiller = dataBackfiller,
+            attentionGate = attention,
+        )
+    }
+
+    private fun AutodriveEngine.runTick(): AutoDriveCommand? {
+        setShadowMode(false)
+        setIsActive(true)
+        return tick(
+            currentState = state,
+            profileBasal = 1.0,
+            profileIsf = resistantIsf,
+            lgsThreshold = 70.0,
+            hour = 3,
+            steps = 0,
+            hr = 60,
+            rhr = 58,
+            currentEpochMs = 1_000L,
+            tickId = 1_000L,
+            observationId = 1L,
+        )
+    }
+
+    /**
+     * The lock for the shadow. Before the fix these two were equal on every tick, because the
+     * "unfloored sensitivity" the shadow built reduced to the sensitivity production already used.
+     */
+    @Test
+    fun `the unfloored shadow permits more than the floored barrier at ISF under 45`() {
+        val engine = engine()
+        engine.runTick()
+
+        assertThat(engine.lastControlCoefficientUsed)
+            .isWithin(1e-12).of(InsulinActionModel.LEGACY_CONTROL_COEFFICIENT)
+        assertThat(engine.lastControlCoefficientUnfloored)
+            .isLessThan(engine.lastControlCoefficientUsed)
+        assertThat(engine.lastCbfPermittedUnflooredU).isGreaterThan(engine.lastCbfPermittedU)
+    }
+
+    /**
+     * The shadow runs `enforce` a second time on the same tick. What the loop reads afterwards must
+     * still describe the production call: the returned command, and the barrier terms.
+     */
+    @Test
+    fun `the shadow leaves the production command and diagnostics untouched`() {
+        val engine = engine()
+        val command = engine.runTick()
+
+        assertThat(command).isNotNull()
+        val permitted = command!!.scheduledMicroBolus + command.temporaryBasalRate / 12.0
+        assertThat(permitted).isWithin(1e-12).of(engine.lastCbfPermittedU)
+
+        val diagnostics = engine.lastBarrierDiagnostics
+        assertThat(diagnostics).isNotNull()
+        // The floored coefficient, i.e. the production call, not the shadow's unfloored one.
+        assertThat(diagnostics!!.siMetabolic)
+            .isWithin(1e-12).of(InsulinActionModel.LEGACY_CONTROL_COEFFICIENT)
+    }
+
+    /**
+     * FIX F: the anchor the barrier is handed is the dynamic ISF, and the export must say so.
+     *
+     * The engine defaults `profileIsfIsDynamic` to `true` because the only production caller passes
+     * `profile.sens`. This is a diagnostic, not a behaviour: nothing in the dose reads it.
+     */
+    @Test
+    fun `the barrier records that its anchor is the dynamic ISF`() {
+        val engine = engine()
+        engine.runTick()
+
+        assertThat(engine.lastBarrierDiagnostics!!.anchorIsDynamicIsf).isTrue()
+    }
+}

--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngineStaleObservationTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngineStaleObservationTest.kt
@@ -1,0 +1,117 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive
+
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.controller.MpcController
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.estimator.ContinuousStateEstimator
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveAuditor
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveDataBackfiller
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.AutodriveDataLake
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.MechanismAttentionGate
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.learning.OnlineLearner
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveCommand
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveState
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.safety.ControlBarrierShield
+import app.aaps.shared.tests.TestBase
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+/**
+ * A tick that leaves early must not hand the previous tick's barrier to the export.
+ *
+ * Every field the `control_barrier` export reads is written late inside [AutodriveEngine.tick], and
+ * `tick` has two exits that come before all of them. Nothing used to clear those fields, so a tick
+ * that left early published the last tick that did run. Measured on the night of 2026-09-05 the
+ * export carried a barrier block on 281 ticks out of 712, and nothing in it said which tick it
+ * described.
+ *
+ * Matching test from `origin/dev_OAPSAIMI` @ `db21308e6c` (unchanged on freeze `c5db5a0333`).
+ * Study source set: [AutodriveEngine] is androidMain, so this lives in `androidHostTest` + mockito
+ * (not mockk). Production calls `updateAndPredict(state, tickId = observationId)` — two named args;
+ * `nowMs` is the Kotlin default. Mockito stubs the JVM 3-arg form so that named-arg call still matches.
+ */
+class AutodriveEngineStaleObservationTest : TestBase() {
+
+    @Mock private lateinit var estimator: ContinuousStateEstimator
+    @Mock private lateinit var mpc: MpcController
+    @Mock private lateinit var attention: MechanismAttentionGate
+    @Mock private lateinit var dataLake: AutodriveDataLake
+    @Mock private lateinit var dataBackfiller: AutodriveDataBackfiller
+
+    private val state = AutoDriveState(
+        bg = 150.0,
+        bgVelocity = -1.0,
+        iob = 2.0,
+        estimatedSI = 30.0 / 10000.0,
+        estimatedRa = 1.0,
+        physiologicalStressMask = DoubleArray(0),
+        maxIOB = 60.0,
+    )
+
+    private val request = AutoDriveCommand(
+        scheduledMicroBolus = 6.0,
+        temporaryBasalRate = 1.2,
+        isSafe = true,
+        reason = "test",
+    )
+
+    private fun engine(): AutodriveEngine {
+        whenever(attention.applyAttention(any())).thenAnswer { it.getArgument(0) }
+        whenever(estimator.getLastRa()).thenReturn(state.estimatedRa)
+        whenever(estimator.updateAndPredict(any(), any(), any())).thenAnswer { it.getArgument(0) }
+        whenever(mpc.calculateOptimalDose(any(), any(), any())).thenReturn(request)
+        return AutodriveEngine(
+            aapsLogger = aapsLogger,
+            stateEstimator = estimator,
+            mpcController = mpc,
+            safetyShield = ControlBarrierShield(aapsLogger),
+            onlineLearner = OnlineLearner(aapsLogger),
+            autodriveAuditor = AutodriveAuditor(),
+            dataLake = dataLake,
+            dataBackfiller = dataBackfiller,
+            attentionGate = attention,
+        )
+    }
+
+    private fun AutodriveEngine.runTick(observationId: Long): AutoDriveCommand? = tick(
+        currentState = state,
+        profileBasal = 1.0,
+        profileIsf = 30.0,
+        lgsThreshold = 70.0,
+        hour = 3,
+        steps = 0,
+        hr = 60,
+        rhr = 58,
+        currentEpochMs = 1_000L * observationId,
+        tickId = 1_000L * observationId,
+        observationId = observationId,
+    )
+
+    @Test
+    fun `an early exit leaves no barrier observation behind`() {
+        val engine = engine()
+
+        // A tick that really runs, so every observation field holds a value.
+        engine.setShadowMode(false)
+        engine.setIsActive(true)
+        engine.runTick(observationId = 1L)
+        assertThat(engine.lastBarrierDiagnostics).isNotNull()
+        assertThat(engine.lastCbfPermittedU.isFinite()).isTrue()
+        assertThat(engine.lastProfileIsfSeen).isGreaterThan(0.0)
+
+        // The next tick leaves at the "neither active nor shadow" exit, before any of them is written.
+        engine.setIsActive(false)
+        engine.setShadowMode(false)
+        assertThat(engine.runTick(observationId = 2L)).isNull()
+
+        assertThat(engine.lastBarrierDiagnostics).isNull()
+        assertThat(engine.lastMpcRawSmbU.isFinite()).isFalse()
+        assertThat(engine.lastMpcRawTbrUph.isFinite()).isFalse()
+        assertThat(engine.lastCbfPermittedU.isFinite()).isFalse()
+        assertThat(engine.lastCbfPermittedUnflooredU.isFinite()).isFalse()
+        assertThat(engine.lastControlCoefficientUsed).isEqualTo(0.0)
+        assertThat(engine.lastControlCoefficientUnfloored).isEqualTo(0.0)
+        assertThat(engine.lastProfileIsfSeen).isEqualTo(0.0)
+    }
+}

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -5274,6 +5274,7 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             put("system_evolution", d.systemEvolution)
             put("si_metabolic", d.siMetabolic)
             put("fully_suspended", d.fullySuspended)
+            put("anchor_is_dynamic_isf", d.anchorIsDynamicIsf)
             d.safeU?.let { put("safe_u", it) }
         }.build()
     }
@@ -5503,6 +5504,10 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                 tickId = ctx.currentTime,
                 observationId = raObservationId(ctx),
                 engaged = true,
+                // Diagnostic only: the caller passes `profile.sens` (dynamic ISF). The flag is
+                // copied into `control_barrier.anchor_is_dynamic_isf`. The anchor itself stays
+                // `profile.sens` — moving it would change the dose.
+                profileIsfIsDynamic = true,
             )
 
             // Called here, after `tick`, and not before it. The barrier fields this reads
@@ -18811,6 +18816,8 @@ class DetermineBasalaimiSMB2 @Inject constructor(
                 observationId = raObservationId(ctx),
                 // Shadow tick: it enacts nothing, so it must not be labelled as owning the dose.
                 engaged = false,
+                // Same honesty as the engaged path: `profile.sens` is the dynamic ISF.
+                profileIsfIsDynamic = true,
             )
             consoleLog.add("👻 [T3c_SHADOW] DataLake tick fired for V3 ML continuity.")
         } catch (e: Exception) {

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngine.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/AutodriveEngine.kt
@@ -330,7 +330,16 @@ class AutodriveEngine @Inject constructor(
          * as engaged.
          */
         engaged: Boolean = true,
+        /**
+         * Whether [profileIsf] is the **dynamic** ISF rather than an independent profile block.
+         *
+         * Diagnostic only: it is copied into `ControlBarrierShield.Diagnostics` and never enters the
+         * arithmetic. The default is `true` because that is what the only production caller does
+         * today — it passes `profile.sens`. See `profileAnchoredSafetySi` for why that matters.
+         */
+        profileIsfIsDynamic: Boolean = true,
     ): AutoDriveCommand? {
+        clearTickObservations()
         val state = systemState.get() as? AimiState.AutoDrive ?: return null
         if (!state.isActive && !state.isShadowMode) return null
 
@@ -407,16 +416,27 @@ class AutodriveEngine @Inject constructor(
         // This is the same failure the attention gate was clamped for — except that arm had never run,
         // and this one runs on every tick.
         //
-        // The barrier therefore anchors on the profile ISF, and takes whichever of the two is *more*
-        // restrictive, so this can only ever tighten the barrier relative to today: a defensive
-        // learner raising `estimatedSI` is kept, a policy lowering it is ignored.
+        // The barrier therefore takes whichever of the two is *more* restrictive, so this can only
+        // ever tighten the barrier relative to before.
+        //
+        // ⚠️ But the "profile" side of that maximum is not a profile block today: the only production
+        // caller passes `profile.sens`, the dynamic ISF. The intended protection — a learner able to
+        // lower sensitivity cannot loosen the barrier — is therefore NOT in place. See
+        // `profileAnchoredSafetySi` for the measurement, and [profileIsfIsDynamic] for the flag that
+        // exposes it. Changing the anchor changes the dose, so it is deliberately not done here.
         //
         // Passed as an argument, not carried on the state: a `copy()` here would re-run
         // `AutoDriveState.init` on the dosing path, turning a non-finite estimate into a throw where
         // it used to be tolerated.
         val safetySi = profileAnchoredSafetySi(profileIsf, estimatedState.estimatedSI)
         lastSafetySiUsed = safetySi
-        val safeCommand = safetyShield.enforce(rawCommand, estimatedState, profileBasal, safetySi, observationId)
+        // Production path: same five dose-facing arguments as before. The named diagnostic is the
+        // observation flag only — it does not enter the arithmetic. `siMetabolicOverride` is not
+        // passed here (default null); the shadow path below is the only caller that uses it.
+        val safeCommand = safetyShield.enforce(
+            rawCommand, estimatedState, profileBasal, safetySi, observationId,
+            anchorIsDynamicIsf = profileIsfIsDynamic,
+        )
         // Captured here on purpose: recordCoefficientShadow below runs `enforce` a second time for the
         // unfloored shadow, which would overwrite the shield's own record of the production call.
         lastBarrierDiagnostics = safetyShield.lastDiagnostics
@@ -486,21 +506,6 @@ class AutodriveEngine @Inject constructor(
     }
 
     /**
-     * Sensitivity the safety barrier reads, anchored on the profile and never looser than today.
-     *
-     * [profileIsf] is the profile ISF in mg/dL/U; the state carries sensitivity as ISF/10000, so it is
-     * rescaled. The result is `max(profile-anchored, commanded)` because a **higher** sensitivity
-     * makes `lgh = -siMetabolic * bg` larger in magnitude and the permitted dose smaller. Taking the
-     * maximum means:
-     *
-     * - a policy multiplier that lowers the commanded sensitivity no longer loosens the barrier;
-     * - a defensive learner that raises it is still honoured;
-     * - the barrier can never end up looser than it is today, whatever the inputs.
-     *
-     * On a non-finite or non-positive profile ISF there is no anchor to trust, so the commanded value
-     * is used unchanged and the event is logged rather than silently substituted.
-     */
-    /**
      * Measures what removing the coefficient floor would cost, without letting it reach the pump.
      *
      * `InsulinActionModel.controlCoefficient` floors at the pre-unification value so this refactor can
@@ -509,9 +514,29 @@ class AutodriveEngine @Inject constructor(
      * unfloored coefficient is 0.67x and the barrier would be about a third more permissive.
      *
      * A third more permissive **on the median tick** is not something to ship on arithmetic. So the
-     * unfloored barrier is run here on the same state, and only its result is exported. `enforce` is
-     * pure apart from its acceleration memory, and that memory is now keyed on [observationId], so the
-     * second call reads the same acceleration as the first instead of resetting it.
+     * unfloored barrier is run here on the same state, and only its result is exported.
+     *
+     * ## Why the shadow needs `siMetabolicOverride`
+     *
+     * The first version of this shadow tried to express "no floor" as a sensitivity, and that is
+     * algebraically impossible. It computed
+     * `unflooredEquivalentSi = coefUnfloored * REFERENCE_BG_MGDL * MPC_TAU_MIN / 10000`, which
+     * reduces to `isf / 10000` — exactly the `safetySi` the production call already passes. `enforce`
+     * then fed it back through `InsulinActionModel.controlCoefficient` and re-applied the very floor
+     * being measured, so the shadow reproduced the production number. That is the mechanical reason
+     * `cbf_permitted_unfloored_u` equalled `cbf_permitted_u` on 281 of 281 ticks on the 2026-09-05
+     * night, which was read as "the floor cost nothing". It cost: with the floor really removed the
+     * permitted total over that night goes from 19.7 U to 27.0 U and the full blocks from 32 to 28,
+     * including 3.779 U of the 7.350 U asked for between 21:55 and 22:15.
+     *
+     * The coefficient is therefore handed to `enforce` directly.
+     *
+     * ## Why this cannot touch the dose
+     *
+     * `enforce` is pure apart from its acceleration memory, and that memory is keyed on
+     * [observationId], so the second call reads the same acceleration as the first instead of
+     * resetting it. Its other trace, `ControlBarrierShield.lastDiagnostics`, is captured by the
+     * caller **before** this function runs. The command built here is only measured, never returned.
      */
     private fun recordCoefficientShadow(
         profileIsf: Double,
@@ -530,12 +555,12 @@ class AutodriveEngine @Inject constructor(
                 InsulinActionModel.metabolicCoefficient(isf, InsulinActionModel.MPC_TAU_MIN)
             lastCbfPermittedU = safeCommand.scheduledMicroBolus + safeCommand.temporaryBasalRate / 12.0
 
-            // Same barrier, same state, only the floor removed. Expressed as the sensitivity that
-            // yields the unfloored coefficient, so `enforce` needs no new parameter.
-            val unflooredEquivalentSi = lastControlCoefficientUnfloored * InsulinActionModel.REFERENCE_BG_MGDL *
-                InsulinActionModel.MPC_TAU_MIN / 10000.0
+            // Same barrier, same state, same sensitivity — only the floor removed. The coefficient is
+            // passed straight in, because expressing it as a sensitivity sends it back through
+            // `controlCoefficient` and the floor comes straight back. See the doc above.
             val unflooredCommand = safetyShield.enforce(
-                rawCommand, estimatedState, profileBasal, unflooredEquivalentSi, observationId,
+                rawCommand, estimatedState, profileBasal, safetySi, observationId,
+                siMetabolicOverride = lastControlCoefficientUnfloored,
             )
             lastCbfPermittedUnflooredU =
                 unflooredCommand.scheduledMicroBolus + unflooredCommand.temporaryBasalRate / 12.0
@@ -543,6 +568,66 @@ class AutodriveEngine @Inject constructor(
         }
     }
 
+    /**
+     * Clears everything the export reads about **this** tick, before any early exit can skip it.
+     *
+     * These fields are written late in [tick]: the raw command around the middle, the barrier
+     * diagnostics after `enforce`. `tick` can also return before either, when the state is not an
+     * autodrive state or the engine is neither active nor in shadow mode. Without this reset those
+     * fields keep the values of the last tick that did run, and the export then presents an older
+     * tick's barrier as the current one. That is the same "read a value after the step that set it"
+     * mistake the barrier and ISF witnesses were making, so it is cleared here rather than guarded
+     * at each of the six read sites.
+     *
+     * The cleared values are all ones the readers already treat as unknown: `null` diagnostics makes
+     * the whole `control_barrier` block absent, and the numeric fields fall outside the
+     * `takeIf { it > 0.0 }` and `takeIf { it.isFinite() }` guards the export applies.
+     */
+    private fun clearTickObservations() {
+        lastBarrierDiagnostics = null
+        lastMpcRawSmbU = Double.NaN
+        lastMpcRawTbrUph = Double.NaN
+        lastControlCoefficientUsed = 0.0
+        lastControlCoefficientUnfloored = 0.0
+        lastCbfPermittedU = Double.NaN
+        lastCbfPermittedUnflooredU = Double.NaN
+        lastProfileIsfSeen = 0.0
+    }
+
+    /**
+     * Sensitivity the safety barrier reads. Named for an anchor it does not have yet.
+     *
+     * [profileIsf] is a profile ISF in mg/dL/U; the state carries sensitivity as ISF/10000, so it is
+     * rescaled. The result is `max(anchored, commanded)` because a **higher** sensitivity makes
+     * `lgh = -siMetabolic * bg` larger in magnitude and the permitted dose smaller. Taking the
+     * maximum was meant to give three properties:
+     *
+     * - a policy multiplier that lowers the commanded sensitivity no longer loosens the barrier;
+     * - a defensive learner that raises it is still honoured;
+     * - the barrier can never end up looser than it is today, whatever the inputs.
+     *
+     * ## Only the third property holds today
+     *
+     * The maximum is real, but the first two need [profileIsf] to be **independent** of the value it
+     * is protecting against, and it is not. The only production caller passes `profile.sens`, which
+     * is the dynamic ISF — the same number the learners move. So the "anchor" moves with the
+     * controller, and a learner that lowers sensitivity still loosens the barrier.
+     *
+     * Measured on the 2026-09-05 night: `cbf_profile_isf_mgdl`, `profile_isf_mgdl` and
+     * `command_isf_mgdl` were the same value on 281 ticks out of 281, and that value went from 28.2
+     * to 62.4 between 22:20 and 22:30 — tightening the barrier by a factor 1.39 at the moment the
+     * insulin term was at its worst (-19.75 mg/dL/min predicted against -1.22 measured). The static
+     * profile block, exported as `profile_isf_static_mgdl`, is 50 in the evening and 120 at night and
+     * never reaches the barrier at all.
+     *
+     * Passing the static block instead is the fix, and it is **not** done here: it changes the
+     * permitted dose on every tick and needs a replay first. Until then
+     * [ControlBarrierShield.Diagnostics.anchorIsDynamicIsf] makes the situation readable from the
+     * export instead of leaving the doc claiming a protection that is not in place.
+     *
+     * On a non-finite or non-positive profile ISF there is no anchor to trust, so the commanded value
+     * is used unchanged and the event is logged rather than silently substituted.
+     */
     private fun profileAnchoredSafetySi(profileIsf: Double, commandedSi: Double): Double {
         if (!profileIsf.isFinite() || profileIsf <= 0.0) {
             aapsLogger.warn(

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/ControlBarrierShield.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/ControlBarrierShield.kt
@@ -62,6 +62,21 @@ class ControlBarrierShield @Inject constructor(
         val safeU: Double?,
         val siMetabolic: Double,
         val fullySuspended: Boolean,
+        /**
+         * Whether the sensitivity handed to the barrier was the **dynamic** ISF.
+         *
+         * Read this before reading anything else about the anchor. The comment on [enforce] used to
+         * promise that `safetySi` was anchored on the profile ISF, so that a learner able to lower
+         * sensitivity could not loosen the barrier. That promise is not kept today: the only
+         * production caller passes `profile.sens`, which is the dynamic ISF, so the "anchor" and the
+         * value it is supposed to protect against are the same number. On the 2026-09-05 night
+         * `cbf_profile_isf_mgdl`, `profile_isf_mgdl` and `command_isf_mgdl` were equal on 281 of 281
+         * ticks, and that shared value moved from 28.2 to 62.4 in ten minutes.
+         *
+         * `true` here means "the number below carries no independent information". It changes
+         * nothing in the arithmetic; it only makes the hole visible from the export.
+         */
+        val anchorIsDynamicIsf: Boolean,
     )
 
     /** Set on every [enforce] call. */
@@ -85,6 +100,16 @@ class ControlBarrierShield @Inject constructor(
      *   barrier a different number from the one the controller optimised against, without a second
      *   sensitivity field in the domain model — and without a `copy()` re-running the state's `init`
      *   checks on the dosing path. `null` falls back to `state.estimatedSI`.
+     * @param siMetabolicOverride Coefficient to use instead of deriving one from [safetySi], or
+     *   `null` for the normal path. It exists for the unfloored counterfactual described in
+     *   `AutodriveEngine.recordCoefficientShadow`: expressing that counterfactual as a sensitivity
+     *   was algebraically impossible, because whatever sensitivity is passed in goes back through
+     *   `InsulinActionModel.controlCoefficient`, which re-applies the very floor being measured.
+     *   Non-finite or non-positive values are ignored, so a bad shadow can never widen the barrier.
+     * @param anchorIsDynamicIsf What the caller knows about the sensitivity it just handed over:
+     *   `true` when it is the dynamic ISF, `false` when it is an independent profile block. Recorded
+     *   in [Diagnostics] only, never used in the arithmetic. Defaults to `true` because that is what
+     *   production passes today.
      */
     fun enforce(
         rawCommand: AutoDriveCommand,
@@ -97,6 +122,8 @@ class ControlBarrierShield @Inject constructor(
          * Used only to keep the acceleration memory one-per-observation — see [lastBgVelocity].
          */
         observationId: Long = 0L,
+        siMetabolicOverride: Double? = null,
+        anchorIsDynamicIsf: Boolean = true,
     ): AutoDriveCommand {
         
         // --- 1. Définition de la distance à la zone de danger, h(x) ---
@@ -126,13 +153,27 @@ class ControlBarrierShield @Inject constructor(
         // sait baisser la sensibilité sait donc desserrer cette barrière — c'est vrai du
         // multiplicateur d'agressivité de `PkPdIntegration` comme d'un futur learner.
         //
-        // `safetySi` est ancré sur l'ISF du profil et pris comme le plus restrictif des deux (voir
-        // `AutodriveEngine.profileAnchoredSafetySi`). Le repli sur `estimatedSI` conserve le
-        // comportement d'avant pour les états construits hors du moteur.
-        val siMetabolic = InsulinActionModel.controlCoefficient(
-            isfMgdlPerU = InsulinActionModel.isfFromStateSi(safetySi ?: state.estimatedSI),
-            tauMin = InsulinActionModel.MPC_TAU_MIN,
-        )
+        // ⚠️ `safetySi` n'est PAS une ancre indépendante aujourd'hui.
+        //
+        // `AutodriveEngine.profileAnchoredSafetySi` prend bien le plus restrictif des deux valeurs,
+        // mais la seule valeur "profil" qu'on lui passe en production est `profile.sens`, c'est-à-dire
+        // l'ISF **dynamique** — le même nombre que les learners font bouger. La protection annoncée
+        // ("tout ce qui sait baisser la sensibilité sait desserrer cette barrière, donc on l'ancre au
+        // profil") n'est donc pas en place: mesuré sur la nuit du 2026-09-05, l'ancre était égale à
+        // l'ISF commandé sur 281 ticks sur 281, et passait de 28,2 à 62,4 en dix minutes.
+        // Le drapeau [Diagnostics.anchorIsDynamicIsf] rend ce fait lisible dans l'export. Changer
+        // l'ancre changerait les doses et demande un rejeu, donc ce n'est pas fait ici.
+        //
+        // Le repli sur `estimatedSI` conserve le comportement d'avant pour les états construits hors
+        // du moteur.
+        //
+        // `siMetabolicOverride` court-circuite ce calcul pour le contrefactuel sans plancher: repasser
+        // par `controlCoefficient` y réappliquerait le plancher qu'on cherche justement à mesurer.
+        val siMetabolic = siMetabolicOverride?.takeIf { it.isFinite() && it > 0.0 }
+            ?: InsulinActionModel.controlCoefficient(
+                isfMgdlPerU = InsulinActionModel.isfFromStateSi(safetySi ?: state.estimatedSI),
+                tauMin = InsulinActionModel.MPC_TAU_MIN,
+            )
         val lfh = - p1 * (state.bg - 100.0) - (siMetabolic * state.iob * state.bg) + state.estimatedRa
 
         // Lie Derivative L_g(h) : Impact de l'action de contrôle (Dose_u)
@@ -228,6 +269,7 @@ class ControlBarrierShield @Inject constructor(
             safeU = diagnosticSafeU,
             siMetabolic = siMetabolic,
             fullySuspended = diagnosticSafeU != null && diagnosticSafeU <= 0.0,
+            anchorIsDynamicIsf = anchorIsDynamicIsf,
         )
 
         var (finalTbr, finalSmb) = if (systemEvolution >= safetyBoundary) {

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/ControlBarrierShieldUnflooredShadowTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/ControlBarrierShieldUnflooredShadowTest.kt
@@ -1,0 +1,191 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive.safety
+
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveCommand
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.models.AutoDriveState
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The unfloored counterfactual must really remove the floor.
+ *
+ * `AutodriveEngine.recordCoefficientShadow` exports `cbf_permitted_unfloored_u` to answer one
+ * question: what does `InsulinActionModel.LEGACY_CONTROL_COEFFICIENT` cost? Its first version tried
+ * to express "no floor" as a sensitivity:
+ *
+ * ```
+ * unflooredEquivalentSi = coefUnfloored * REFERENCE_BG_MGDL * MPC_TAU_MIN / 10000
+ * ```
+ *
+ * which reduces to `isf / 10000`, i.e. exactly the `safetySi` production already passes. `enforce`
+ * then sent it back through `controlCoefficient`, which re-applied the floor. The counterfactual was
+ * therefore an algebraic no-op, and the export showed `cbf_permitted_unfloored_u == cbf_permitted_u`
+ * on 281 of 281 ticks on the 2026-09-05 night — read as "the floor cost nothing".
+ *
+ * The first test below writes down that no-op. It was green before the fix and stays green after,
+ * because the arithmetic it describes has not changed: it is the reason the shadow needed a new
+ * entry point, not a bug in the shield. The second test is the lock, and it was red before the fix.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `db21308e6c` (unchanged on freeze `c5db5a0333`).
+ * Study source set: [ControlBarrierShield] is commonMain, so the tests live in `commonTest`
+ * (`kotlin.test`) + a no-op logger — not `androidHostTest` (mockito/Robolectric).
+ */
+class ControlBarrierShieldUnflooredShadowTest {
+
+    /** Fresh instance per call: `lastBgVelocity` is instance state and would change `activeGamma`. */
+    private fun shield() = ControlBarrierShield(NoOpAapsLogger)
+
+    /**
+     * A profile ISF of 30 mg/dL/U, well under the reference 45, so the floor is active.
+     *
+     * At ISF 30 the honest coefficient is `30 / (75 * 120)` = 3.33e-3 and the floor holds it at
+     * 5.0e-3, i.e. the barrier behaves as if the patient were 50 % more insulin sensitive than they
+     * are. 30 is the median profile ISF on this deployment.
+     */
+    private val resistantIsf = 30.0
+
+    private val safetySi = resistantIsf / 10000.0
+
+    /** Falling glucose with real headroom, so the barrier binds and the difference is visible. */
+    private fun state() = AutoDriveState(
+        bg = 150.0,
+        bgVelocity = -1.0,
+        iob = 2.0,
+        estimatedSI = safetySi,
+        estimatedRa = 1.0,
+        physiologicalStressMask = DoubleArray(0),
+        maxIOB = 60.0,
+    )
+
+    /** More than the barrier can ever permit here, so the barrier is what limits the result. */
+    private fun request() = AutoDriveCommand(
+        scheduledMicroBolus = 6.0,
+        temporaryBasalRate = 1.2,
+        isSafe = true,
+        reason = "test",
+    )
+
+    private fun AutoDriveCommand.totalU() = scheduledMicroBolus + temporaryBasalRate / 12.0
+
+    private fun production() =
+        shield().enforce(request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L)
+
+    /**
+     * The old recipe could not remove the floor, whatever number it computed.
+     *
+     * This is not a defect of the shield: any sensitivity handed to `enforce` goes through
+     * `controlCoefficient`, so the floor comes back. It is why the shadow now passes the coefficient
+     * itself.
+     */
+    @Test
+    fun `expressing the unfloored coefficient as a sensitivity reproduces the production dose`() {
+        val unflooredCoefficient =
+            InsulinActionModel.metabolicCoefficient(resistantIsf, InsulinActionModel.MPC_TAU_MIN)
+        val oldRecipeSi = unflooredCoefficient * InsulinActionModel.REFERENCE_BG_MGDL *
+            InsulinActionModel.MPC_TAU_MIN / 10000.0
+
+        // Step one: the "unfloored equivalent sensitivity" is the sensitivity we already had.
+        assertEquals(safetySi, oldRecipeSi, 1e-15)
+
+        // Step two: so the shadow command is the production command, to the last digit.
+        val shadow = shield()
+            .enforce(request(), state(), profileBasal = 1.0, safetySi = oldRecipeSi, observationId = 1L)
+        assertEquals(production().totalU(), shadow.totalU(), 1e-12)
+    }
+
+    /**
+     * With the coefficient passed straight in, the floor's cost becomes visible.
+     *
+     * This is the lock. Before the fix the two numbers were equal on every tick; the floor holds the
+     * coefficient 50 % above the honest value at ISF 30, which shrinks the permitted dose by the
+     * same kind of factor.
+     */
+    @Test
+    fun `passing the unfloored coefficient permits strictly more than the floored barrier`() {
+        val unflooredCoefficient =
+            InsulinActionModel.metabolicCoefficient(resistantIsf, InsulinActionModel.MPC_TAU_MIN)
+        assertTrue(unflooredCoefficient < InsulinActionModel.LEGACY_CONTROL_COEFFICIENT)
+
+        val unfloored = shield().enforce(
+            request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L,
+            siMetabolicOverride = unflooredCoefficient,
+        )
+
+        assertTrue(unfloored.totalU() > production().totalU())
+    }
+
+    /**
+     * A shadow run must leave nothing behind that a later production run could read.
+     *
+     * `enforce` is pure apart from `lastBgVelocity`, which is keyed on the observation id. Two
+     * shields see the same production tick; only one of them also runs the shadow. The next
+     * production tick must be identical on both.
+     */
+    @Test
+    fun `running the shadow does not change the next production command`() {
+        val clean = shield()
+        val shadowed = shield()
+
+        clean.enforce(request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L)
+        shadowed.enforce(request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L)
+        shadowed.enforce(
+            request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L,
+            siMetabolicOverride = InsulinActionModel
+                .metabolicCoefficient(resistantIsf, InsulinActionModel.MPC_TAU_MIN),
+        )
+
+        // Second observation, so the acceleration memory of the first one is what is being read.
+        val nextClean =
+            clean.enforce(request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 2L)
+        val nextShadowed =
+            shadowed.enforce(request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 2L)
+
+        assertEquals(nextClean.totalU(), nextShadowed.totalU(), 1e-12)
+        assertEquals(nextClean.temporaryBasalRate, nextShadowed.temporaryBasalRate, 1e-12)
+        assertEquals(nextClean.scheduledMicroBolus, nextShadowed.scheduledMicroBolus, 1e-12)
+    }
+
+    /** A broken shadow value must never widen the barrier: it falls back to the normal path. */
+    @Test
+    fun `a non-finite or non-positive override is ignored`() {
+        val expected = production().totalU()
+
+        for (bad in listOf(Double.NaN, Double.POSITIVE_INFINITY, 0.0, -1.0)) {
+            val out = shield().enforce(
+                request(), state(), profileBasal = 1.0, safetySi = safetySi, observationId = 1L,
+                siMetabolicOverride = bad,
+            )
+            assertTrue(abs(out.totalU() - expected) < 1e-12, "override $bad must be ignored")
+        }
+    }
+
+    /**
+     * commonMain no-op [AAPSLogger]: [ControlBarrierShield] only logs; nothing in these locks
+     * reads the log. Kept local so `commonTest` does not grow a mockito / shared-tests dependency.
+     */
+    private object NoOpAapsLogger : AAPSLogger {
+        override fun debug(message: String) = Unit
+        override fun debug(enable: Boolean, tag: LTag, message: String) = Unit
+        override fun debug(tag: LTag, message: String) = Unit
+        override fun debug(tag: LTag, accessor: () -> String) = Unit
+        override fun debug(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun warn(tag: LTag, message: String) = Unit
+        override fun warn(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun info(tag: LTag, message: String) = Unit
+        override fun info(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun error(tag: LTag, message: String) = Unit
+        override fun error(tag: LTag, message: String, throwable: Throwable) = Unit
+        override fun error(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun error(message: String) = Unit
+        override fun error(message: String, throwable: Throwable) = Unit
+        override fun error(format: String, vararg arguments: Any?) = Unit
+        override fun debug(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun info(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun warn(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun error(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.9** uniquement — restes d’observation Autodrive de `db21308e6c` sur la branche d’étude KMP. Boucle fermée médicale : comportement clinique depuis le gel de référence ; câblage study/Milos. **Observation seule — aucune dose ne bouge.**

- **Étude (base)** = `kmp-aimi-migration-study` tip post-P0.8 **`bff270393a228d72f03a43c0ae43734cd06a382e`**
- **Gel clinique** = `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
- **Source** = `db21308e6c` (`fix(aimi): read each instrument before the brake it measures`)
- Tip `dev_OAPSAIMI` peut être en avance (`fe96b64f`) — **pas** de post-gel AIMI (`f519` IAM floor, DescentRedoseGuard, etc.)
- Metro (`@Inject` / `@SingleIn(AppScope)`), `AimiJson`, signatures study (`updateAndPredict(state, tickId = …)`) conservés
- Tests : shield → `commonTest` + `kotlin.test` + logger no-op ; engine → `androidHostTest` + **mockito** (pas mockk)
- **HEAD** = **`987cf4d856d7a036ea6e5135a8a4d8621114e317`**

### Tableau des 3 items

| # | Item | Statut P0.9 |
|---|---|---|
| 1 | `clearTickObservations` dans `AutodriveEngine.tick()` | **Appliqué** — reset `lastBarrierDiagnostics` / `lastMpc*` / coefficients / `lastCbf*` / `lastProfileIsfSeen` en tête de `tick()`, comme la ref, pour qu’une sortie précoce ne republie pas le `control_barrier` du tick précédent. Le défaut study `0.0` (fini) empoisonnait l’export via `takeIf { isFinite() }`. |
| 2 | `ControlBarrierShield.enforce` + `siMetabolicOverride` optionnel | **Appliqué** — params défaut ; l’appel production garde les cinq arguments dose-facing. L’ombre `recordCoefficientShadow` passe le coefficient non plafonné (plus de no-op algébrique `unflooredEquivalentSi`). `anchorIsDynamicIsf` sur Diagnostics / enforce. Metro inchangé. |
| 3 | Export `anchor_is_dynamic_isf` dans `control_barrier` | **Appliqué** — booléen toujours connu, jamais `AimiJson.NULL`. Ancre **inchangée** : `profile.sens` (dynamique). `tick(..., profileIsfIsDynamic=true)` + KDoc honnête sur `profileAnchoredSafetySi`. Déplacer l’ancre changerait les doses (hors lot, besoin de replay). |

### Hors lot

- `02c90656b1` advisor ZIP / dump staging
- `c5db5a0333` re-grid glucose (loop)
- Dashboard AIMI / Overview UI
- Remplacement en bloc de `tick` / `AutodriveEngine`
- Commits tip après le gel

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain \
  :plugins:aps:jvmTest --tests '...ControlBarrierShieldUnflooredShadowTest' \
  :plugins:aps:testAndroidHostTest \
    --tests '...AutodriveEngineStaleObservationTest' \
    --tests '...AutodriveEngineCoefficientShadowTest'
→ BUILD SUCCESSFUL in 4m 6s
   jvmTest shield: 4 tests, 0 fail, 0 err, 0 skip
   androidHostTest engine: 4 tests (1+3), 0 fail, 0 err, 0 skip
   CBF log lock: U_req=6.10 → U_safe=2.07 (floored) vs U_safe=4.10 (unfloored)
   = même couple que db21308e6c (« ISF 30 : 2.067 U → 4.100 U »)

./gradlew :plugins:aps:compileKotlinIosArm64
→ BUILD SUCCESSFUL in 1m 1s (commonMain + ControlBarrierShield sur Native)

./gradlew :app:assembleFullDebug
→ BUILD SUCCESSFUL in 1m 15s (938 tasks). Metro : constructeurs AutodriveEngine /
  ControlBarrierShield inchangés (@Inject / @SingleIn(AppScope)).
```

⚠️ ASYNC IMPACT: aucun (pas de nouvelles coroutines). `clearTickObservations` est un reset synchrone de champs d’export.

### Questions ouvertes

- L’ancre barrière reste `profile.sens` (ISF dynamique). Passer le bloc profil statique est le correctif dose-facing ; il demande un replay, pas ce lot.
- `lastSafetySiUsed` n’est **pas** cleared (comme la ref). Si un export le lit après une sortie précoce, il peut encore porter le tick précédent.

---

## EN

Lot **P0.9** only — Autodrive observation leftovers from `db21308e6c` onto the KMP study branch. Medical closed-loop: clinical behaviour from the reference freeze; wiring from study/Milos. **Observation-only — do not change doses.**

- **Study tip** = `kmp-aimi-migration-study` after P0.8 **`bff270393a228d72f03a43c0ae43734cd06a382e`**
- **Clinical freeze** = `origin/dev_OAPSAIMI` @ **`c5db5a033379390bceb7851ff92004b72ef055bf`**
- **Source** = `db21308e6c`
- Do **not** pull post-freeze AIMI (`fe96b64f` / `f519` IAM floor, DescentRedoseGuard, etc.)
- Metro / `AimiJson` / study `updateAndPredict(state, tickId = …)` kept
- Tests: shield → `commonTest` + `kotlin.test` + no-op logger; engine → `androidHostTest` + mockito (not mockk)
- **HEAD** = **`987cf4d856`**

### Table of 3 items

| # | Item | P0.9 status |
|---|---|---|
| 1 | `clearTickObservations` at start of `tick()` | **Applied** — reset barrier diagnostics / lastMpc* to NaN/null as on ref so early exits do not republish the previous tick’s `control_barrier`. Study’s finite `0.0` default was poisoning export via `takeIf { isFinite() }`. |
| 2 | `ControlBarrierShield.enforce` optional `siMetabolicOverride` | **Applied** — defaulted params; production `enforce(...)` keeps the five dose-facing arguments. Shadow path `recordCoefficientShadow` passes the unfloored coefficient (fixes algebraic no-op `unflooredEquivalentSi`). `anchorIsDynamicIsf` on Diagnostics / enforce. Metro `@Inject` / `@SingleIn(AppScope)` kept. |
| 3 | Export `anchor_is_dynamic_isf` in tick `control_barrier` JSON | **Applied** — boolean always known, not `AimiJson.NULL`. Anchor itself stays `profile.sens` (dynamic). `tick(..., profileIsfIsDynamic=true)` + honest KDoc on `profileAnchoredSafetySi`. Moving the anchor is dose-facing and needs replay. |

### Out of scope

- `02c90656b1` advisor ZIP / staging dump
- `c5db5a0333` glucose re-grid (loop)
- Dashboard AIMI / Overview UI
- Wholesale replace of tick or AutodriveEngine
- Tip commits after freeze

### Evidence

```
compileAndroidMain + lot tests: BUILD SUCCESSFUL
  ControlBarrierShieldUnflooredShadowTest: 4/4
  AutodriveEngineStaleObservationTest: 1/1
  AutodriveEngineCoefficientShadowTest: 3/3
  CBF numbers: U_safe 2.07 (floored) vs 4.10 (unfloored) at ISF 30 — same pair as db21308e6c

:plugins:aps:compileKotlinIosArm64: BUILD SUCCESSFUL
:app:assembleFullDebug: BUILD SUCCESSFUL (938 tasks)
```

⚠️ ASYNC IMPACT: none (no new coroutines). `clearTickObservations` is a synchronous export-field reset.

### Open questions

- Barrier anchor remains `profile.sens` (dynamic ISF). Switching to the static profile block is the dose-facing fix and needs a replay, not this lot.
- `lastSafetySiUsed` is **not** cleared (same as ref). An export that reads it after an early exit can still carry the previous tick.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10b14e80-a976-4dc1-8af0-ba1b050407c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10b14e80-a976-4dc1-8af0-ba1b050407c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

