### PR TITLE
P0.10 — Autodrive GateKind export + meal-first label

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -527,6 +527,19 @@ internal data class AimiDecisionContext(
         /** Profile ISF the barrier was handed, so the two above are interpretable. */
         var cbf_profile_isf_mgdl: Double? = null,
         /**
+         * Whether the Autodrive gate let the MPC run this tick.
+         *
+         * Everything the barrier exports only exists on engaged ticks. Without this the disengaged
+         * ticks are a blank, and a blank reads as "nothing happened" rather than "the gate was shut".
+         *
+         * Observation only. Nothing dose-facing reads these three fields.
+         */
+        var autodrive_gate_engaged: Boolean? = null,
+        /** Stable token for why the gate opened or stayed shut, for counting. */
+        var autodrive_gate_kind: String? = null,
+        /** The same reason with its live numbers, for reading. */
+        var autodrive_gate_reason: String? = null,
+        /**
          * Effort SMB reduction, as actually applied at the universal SMB exit.
          *
          * `_requested` is what the effort belief asked for, `_applied` is what was used after the
@@ -845,6 +858,9 @@ internal data class AimiDecisionContext(
             base.put("cbf_permitted_u", baseline_state.cbf_permitted_u ?: AimiJson.NULL)
             base.put("cbf_permitted_unfloored_u", baseline_state.cbf_permitted_unfloored_u ?: AimiJson.NULL)
             base.put("cbf_profile_isf_mgdl", baseline_state.cbf_profile_isf_mgdl ?: AimiJson.NULL)
+            base.put("autodrive_gate_engaged", baseline_state.autodrive_gate_engaged ?: AimiJson.NULL)
+            base.put("autodrive_gate_kind", baseline_state.autodrive_gate_kind ?: AimiJson.NULL)
+            base.put("autodrive_gate_reason", baseline_state.autodrive_gate_reason ?: AimiJson.NULL)
             base.put("effort_smb_factor_requested", baseline_state.effort_smb_factor_requested ?: AimiJson.NULL)
             base.put("effort_smb_factor_applied", baseline_state.effort_smb_factor_applied ?: AimiJson.NULL)
             base.put("effort_smb_before_u", baseline_state.effort_smb_before_u ?: AimiJson.NULL)
@@ -5355,6 +5371,15 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             estimatedRa = continuousStateEstimator.getLastRa(),
             mealChannelHint = lastRbtAppliedHints?.mealChannel,
         )
+
+        // Observation only — recorded for both outcomes, before the branch. The engaged path already
+        // logged its reason to the console; the disengaged path threw it away, so two thirds of a day
+        // had no explanation at all. Nothing dose-facing reads these fields.
+        pendingDecisionCtxForExport?.baseline_state?.let { baseline ->
+            baseline.autodrive_gate_engaged = gate.engage
+            baseline.autodrive_gate_kind = gate.kind.name
+            baseline.autodrive_gate_reason = gate.reason
+        }
 
         if (!gate.engage) {
             // Estimation is unconditional; actuation is gated. Nothing inside the engaged branch

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGater.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGater.kt
@@ -52,7 +52,8 @@ class AutoDriveGater @Inject constructor(
             val reason = if (hardHRBlock) "❤️ HR High (${health.hrNow})" else "🏃 Activity (BG=$bg, Steps15m=${health.stepsLast15m}, Steps5m=${health.stepsLast5m})"
             return GatingResult(
                 engage = false,
-                reason = "🏃 Activity Prohibited: $reason"
+                reason = "🏃 Activity Prohibited: $reason",
+                kind = if (hardHRBlock) GateKind.HR_HIGH else GateKind.ACTIVITY,
             )
         }
 
@@ -86,12 +87,22 @@ class AutoDriveGater @Inject constructor(
                 "BG stable (<150) and rise too weak " +
                     "(BG=$bg, Trend=$combinedDelta, COB=$cob, UAM=$uamConfidence, mealCtx=$implicitMealContext, minBg75=$minBgLookback75m)"
             aapsLogger.debug(LTag.APS, "${CorrectionAggressionGate.LOG_PREFIX}_V3_GATER: disengage $reason")
-            return GatingResult(engage = false, reason = "🧘 $reason")
+            return GatingResult(engage = false, reason = "🧘 $reason", kind = GateKind.RISE_TOO_WEAK)
         }
 
-        val engageReason = when {
-            isHighPlateau -> "High plateau"
-            isMealRising -> "Meal-aware rise"
+        // The meal reason is read first on purpose. `shouldEngage` above is a plain OR, so this
+        // order cannot change whether the gate opens; it only changes the name written on the tick.
+        // With the plateau read first, every tick above BG 150 was called HIGH_PLATEAU even when a
+        // meal was what opened the gate, and MEAL_AWARE_RISE could only ever be seen below 150. A
+        // meal is the more specific fact, so it wins the label.
+        val engageKind = when {
+            isMealRising -> GateKind.MEAL_AWARE_RISE
+            isHighPlateau -> GateKind.HIGH_PLATEAU
+            else -> GateKind.STRONG_RISE
+        }
+        val engageReason = when (engageKind) {
+            GateKind.HIGH_PLATEAU -> "High plateau"
+            GateKind.MEAL_AWARE_RISE -> "Meal-aware rise"
             else -> "Strong rise"
         }
         aapsLogger.debug(
@@ -100,9 +111,56 @@ class AutoDriveGater @Inject constructor(
         )
         return GatingResult(
             engage = true,
-            reason = "🚀 V3 ENGAGED [$engageReason] (BG=$bg, Trend=$combinedDelta, COB=$cob, UAM=$uamConfidence)"
+            reason = "🚀 V3 ENGAGED [$engageReason] (BG=$bg, Trend=$combinedDelta, COB=$cob, UAM=$uamConfidence)",
+            kind = engageKind,
         )
     }
 
-    data class GatingResult(val engage: Boolean, val reason: String)
+    /**
+     * Why the gate opened or stayed shut.
+     *
+     * [reason] carries the live numbers and is meant to be read by a person; every string is unique,
+     * so it cannot be grouped. [kind] is the stable token to count on: measured on 2026-09-07, the
+     * gate stayed shut on 884 ticks out of 1351 and nothing exported said why, so two thirds of the
+     * day could not be explained at all.
+     */
+    data class GatingResult(
+        val engage: Boolean,
+        val reason: String,
+        val kind: GateKind = GateKind.RISE_TOO_WEAK,
+    )
+
+    /** The stable reasons `shouldEngageV3` can return, for counting rather than reading. */
+    enum class GateKind {
+
+        /** Heart rate at or above 140: a hard block whatever the glucose does. */
+        HR_HIGH,
+
+        /** Moving fast while glucose is still fragile (under 160). */
+        ACTIVITY,
+
+        /** Glucose under 150 and the rise below the entry thresholds. The common case. */
+        RISE_TOO_WEAK,
+
+        /**
+         * Glucose above 150 and no meal context on the tick.
+         *
+         * This is the weaker of the two open labels: when a meal context is also present,
+         * [MEAL_AWARE_RISE] is written instead, because a meal says more about why the gate opened
+         * than the glucose level alone.
+         */
+        HIGH_PLATEAU,
+
+        /**
+         * A meal context plus any rise worth the name.
+         *
+         * This label wins over [HIGH_PLATEAU] when both are true. Before that, the plateau was read
+         * first, so above BG 150 a meal was never named and this label could only appear below 150.
+         * It never appeared at all on the measured day.
+         */
+        MEAL_AWARE_RISE,
+
+        /** A rise strong enough on its own. */
+        STRONG_RISE,
+    }
 }

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGaterEngageKindOrderTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGaterEngageKindOrderTest.kt
@@ -1,0 +1,176 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive.safety
+
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.safety.AutoDriveGater.GateKind
+import app.aaps.plugins.aps.openAPSAIMI.physio.HealthContextSnapshot
+import app.aaps.plugins.aps.openAPSAIMI.ports.AimiHealthContext
+import app.aaps.plugins.aps.openAPSAIMI.recursive.MealChannelHint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The order of the branches in `AutoDriveGater.shouldEngageV3` decides only the name of the tick.
+ *
+ * Measured on 2026-09-08: the gate opened 472 times, 306 of them named HIGH_PLATEAU, and
+ * [GateKind.MEAL_AWARE_RISE] was never written once. The plateau was read first so above BG 150
+ * the meal was hidden by the glucose level and the meal label could only ever appear below 150.
+ * Reading the meal first fixes the name. It must not move the gate itself: `shouldEngage` is a
+ * plain OR of the three conditions so this grid pins that `engage` is the same for all eight
+ * combinations and that the only name that moved is the one case where both a plateau and a meal
+ * were true at once.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `0ca7744184`. Study: commonTest + kotlin.test + a
+ * no-op logger / idle [AimiHealthContext] — not androidHostTest mockito. Backtick names omit
+ * commas (Kotlin/Native).
+ */
+class AutoDriveGaterEngageKindOrderTest {
+
+    /**
+     * Steps and heart rate stay at zero so neither the activity block nor the heart-rate block
+     * can fire and hide the glycemic branches under test.
+     */
+    private object IdleHealth : AimiHealthContext {
+        override fun fetchSnapshot() = HealthContextSnapshot()
+        override fun fetchSnapshotForAutodriveGater() = HealthContextSnapshot()
+        override fun getLastSnapshot() = HealthContextSnapshot()
+    }
+
+    private val gater = AutoDriveGater(IdleHealth, NoOpAapsLogger)
+
+    /** One row of the grid: the three conditions and the inputs that produce them. */
+    private data class Row(
+        val highPlateau: Boolean,
+        val activelyRising: Boolean,
+        val mealRising: Boolean,
+        val bg: Double,
+        val combinedDelta: Double,
+        val explicitMealMode: Boolean,
+    )
+
+    /**
+     * bg 180 is above the plateau line (150); bg 110 is below it and below the 120 rise branch
+     * where a rise needs delta above 2.0. A delta of 0.3 is above the meal line (0.25) but under
+     * every rise line so it separates "meal rising" from "actively rising" cleanly.
+     */
+    private val grid = listOf(
+        Row(highPlateau = true, activelyRising = true, mealRising = true, bg = 180.0, combinedDelta = 1.5, explicitMealMode = true),
+        Row(highPlateau = true, activelyRising = true, mealRising = false, bg = 180.0, combinedDelta = 1.5, explicitMealMode = false),
+        Row(highPlateau = true, activelyRising = false, mealRising = true, bg = 180.0, combinedDelta = 0.3, explicitMealMode = true),
+        Row(highPlateau = true, activelyRising = false, mealRising = false, bg = 180.0, combinedDelta = 0.3, explicitMealMode = false),
+        Row(highPlateau = false, activelyRising = true, mealRising = true, bg = 110.0, combinedDelta = 2.5, explicitMealMode = true),
+        Row(highPlateau = false, activelyRising = true, mealRising = false, bg = 110.0, combinedDelta = 2.5, explicitMealMode = false),
+        Row(highPlateau = false, activelyRising = false, mealRising = true, bg = 110.0, combinedDelta = 0.3, explicitMealMode = true),
+        Row(highPlateau = false, activelyRising = false, mealRising = false, bg = 110.0, combinedDelta = 0.3, explicitMealMode = false),
+    )
+
+    private fun run(row: Row) = gater.shouldEngageV3(
+        bg = row.bg,
+        combinedDelta = row.combinedDelta,
+        explicitMealMode = row.explicitMealMode,
+    )
+
+    /** The label the gate wrote before the branches were reordered: plateau first, meal second. */
+    private fun kindBeforeReorder(row: Row): GateKind = when {
+        row.highPlateau -> GateKind.HIGH_PLATEAU
+        row.mealRising -> GateKind.MEAL_AWARE_RISE
+        else -> GateKind.STRONG_RISE
+    }
+
+    @Test
+    fun `the grid really covers the eight combinations`() {
+        assertEquals(8, grid.size)
+        assertEquals(8, grid.map { Triple(it.highPlateau, it.activelyRising, it.mealRising) }.toSet().size)
+    }
+
+    @Test
+    fun `engage is the plain OR of the three conditions whatever the branch order`() {
+        grid.forEach { row ->
+            val expected = row.highPlateau || row.activelyRising || row.mealRising
+            assertEquals(expected, run(row).engage, row.toString())
+        }
+    }
+
+    @Test
+    fun `only the plateau-and-meal tick changed its name`() {
+        grid.forEach { row ->
+            val kind = run(row).kind
+            val before = kindBeforeReorder(row)
+            if (row.highPlateau && row.mealRising) {
+                assertEquals(GateKind.MEAL_AWARE_RISE, kind, row.toString())
+                assertEquals(GateKind.HIGH_PLATEAU, before, row.toString())
+            } else if (row.highPlateau || row.activelyRising || row.mealRising) {
+                assertEquals(before, kind, row.toString())
+            } else {
+                assertEquals(GateKind.RISE_TOO_WEAK, kind, row.toString())
+            }
+        }
+    }
+
+    @Test
+    fun `a meal is named even above the plateau line`() {
+        val result = gater.shouldEngageV3(bg = 180.0, combinedDelta = 1.5, explicitMealMode = true)
+
+        assertTrue(result.engage)
+        assertEquals(GateKind.MEAL_AWARE_RISE, result.kind)
+        assertTrue(result.reason.contains("Meal-aware rise"))
+    }
+
+    /**
+     * The meal channel from the recursive belief tree is one of the ways a meal context is seen.
+     * On the measured day the gate was always handed `null` here because the tree is resolved
+     * later in the same tick than the gate so this path was never exercised in production.
+     */
+    @Test
+    fun `the recursive belief meal channel can open the gate on its own`() {
+        val withoutHint = gater.shouldEngageV3(bg = 110.0, combinedDelta = 0.3, mealChannelHint = null)
+        val withHint = gater.shouldEngageV3(bg = 110.0, combinedDelta = 0.3, mealChannelHint = MealChannelHint.PRIORITY)
+
+        assertFalse(withoutHint.engage)
+        assertEquals(GateKind.RISE_TOO_WEAK, withoutHint.kind)
+        assertTrue(withHint.engage)
+        assertEquals(GateKind.MEAL_AWARE_RISE, withHint.kind)
+    }
+
+    /** A suppressed meal channel must still win over any other meal evidence. */
+    @Test
+    fun `a suppressed meal channel keeps the meal name away`() {
+        val result = gater.shouldEngageV3(
+            bg = 180.0,
+            combinedDelta = 1.5,
+            explicitMealMode = true,
+            mealChannelHint = MealChannelHint.SUPPRESS,
+        )
+
+        assertTrue(result.engage)
+        assertEquals(GateKind.HIGH_PLATEAU, result.kind)
+    }
+
+    /**
+     * commonMain no-op [AAPSLogger]: [AutoDriveGater] only logs; nothing in these locks
+     * reads the log. Kept local so `commonTest` does not grow a mockito / shared-tests dependency.
+     */
+    private object NoOpAapsLogger : AAPSLogger {
+        override fun debug(message: String) = Unit
+        override fun debug(enable: Boolean, tag: LTag, message: String) = Unit
+        override fun debug(tag: LTag, message: String) = Unit
+        override fun debug(tag: LTag, accessor: () -> String) = Unit
+        override fun debug(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun warn(tag: LTag, message: String) = Unit
+        override fun warn(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun info(tag: LTag, message: String) = Unit
+        override fun info(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun error(tag: LTag, message: String) = Unit
+        override fun error(tag: LTag, message: String, throwable: Throwable) = Unit
+        override fun error(tag: LTag, format: String, vararg arguments: Any?) = Unit
+        override fun error(message: String) = Unit
+        override fun error(message: String, throwable: Throwable) = Unit
+        override fun error(format: String, vararg arguments: Any?) = Unit
+        override fun debug(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun info(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun warn(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+        override fun error(className: String, methodName: String, lineNumber: Int, tag: LTag, message: String) = Unit
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGaterKindTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/safety/AutoDriveGaterKindTest.kt
@@ -1,0 +1,58 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive.safety
+
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.safety.AutoDriveGater.GateKind
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.safety.AutoDriveGater.GatingResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * The gate must say why it stayed shut in a form that can be counted.
+ *
+ * Measured on 2026-09-07: the gate was shut on 884 ticks out of 1351 and nothing exported said why.
+ * Two thirds of the day had no explanation and every field the barrier writes only exists on the
+ * other third. `reason` cannot fill that gap on its own: it embeds the live glucose and trend so
+ * every string is unique and no two ticks ever group together.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `078a51514c` (Kind) then `0ca7744184` (meal-first).
+ * Study source set: [AutoDriveGater] is commonMain (ports + Metro only) so these live in
+ * `commonTest` (`kotlin.test`) — not `androidHostTest` (mockito/Robolectric). Backtick names omit
+ * commas: Kotlin/Native rejects them (see `e34b01f666`).
+ */
+class AutoDriveGaterKindTest {
+
+    @Test
+    fun `every kind is distinct so counting them means something`() {
+        val kinds = GateKind.entries
+        assertEquals(kinds.size, kinds.map { it.name }.toSet().size)
+        assertTrue(
+            kinds.containsAll(
+                listOf(
+                    GateKind.HR_HIGH,
+                    GateKind.ACTIVITY,
+                    GateKind.RISE_TOO_WEAK,
+                    GateKind.HIGH_PLATEAU,
+                    GateKind.MEAL_AWARE_RISE,
+                    GateKind.STRONG_RISE,
+                )
+            )
+        )
+    }
+
+    /** The reason stays human text; the kind is what a count can rely on. */
+    @Test
+    fun `two disengaged ticks share a kind even when their reasons differ`() {
+        val first = GatingResult(engage = false, reason = "🧘 BG stable (BG=101.0, Trend=0.2)", kind = GateKind.RISE_TOO_WEAK)
+        val second = GatingResult(engage = false, reason = "🧘 BG stable (BG=118.0, Trend=0.9)", kind = GateKind.RISE_TOO_WEAK)
+
+        assertNotEquals(first.reason, second.reason)
+        assertEquals(first.kind, second.kind)
+    }
+
+    /** The default keeps the old two-argument call sites compiling and it is a shut gate. */
+    @Test
+    fun `the default kind is the common disengaged case`() {
+        assertEquals(GateKind.RISE_TOO_WEAK, GatingResult(engage = false, reason = "test").kind)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.10** uniquement — observation Autodrive gate : export `GateKind` + libellé repas en premier. Boucle fermée médicale : comportement clinique depuis la référence ; câblage study/Milos. **Observation seule — le booléen `engage` et les doses ne bougent pas.**

- **Étude (base)** = `kmp-aimi-migration-study` tip post-P0.9 **`172654f2619c0ee131452062ab4c6154e472233b`**
- **Sources référence** sur `origin/dev_OAPSAIMI` :
  1. `078a51514c` — feat(aimi): say why the Autodrive gate stayed shut
  2. `0ca7744184` — fix(aimi): let a meal keep its name above the plateau line
- Tip contexte `fe96b64f12` — **pas** d’autres commits post-gel (`f519` IAM floor, DescentRedoseGuard, SMB smbGiven, barrier replay, viewer, etc.)
- Metro (`@Inject` / `@SingleIn(AppScope)`), `AimiJson`, expect/actual, source sets study conservés
- `AutoDriveGater` déplacé `androidMain` → `commonMain` (logique pure, ports déjà common) ; tests en `commonTest` + `kotlin.test` + logger / health no-op (pas mockk). Noms backtick sans virgules (Kotlin/Native, `e34b01f666`)
- **HEAD** = **`c1776c5d3731f47a4214f7e458be7774777407f4`**

### Tableau des 2 items

| # | Item | Statut P0.10 |
|---|---|---|
| 1 | `GateKind` + export (`078a51514c`) | **Appliqué** — `GateKind` / `kind` sur `GatingResult` (défaut `RISE_TOO_WEAK`, sites à 2 args inchangés). Trois champs dans `baseline_state` / export, écrits **avant** le `if (!gate.engage)` : `autodrive_gate_engaged`, `autodrive_gate_kind`, `autodrive_gate_reason`. Rien côté dose ne les lit. Test `AutoDriveGaterKindTest`. |
| 2 | Libellé repas en premier (`0ca7744184`) | **Appliqué** — `isMealRising` évalué avant `isHighPlateau` pour le **kind/label** seulement. `engage` reste `isHighPlateau \|\| isActivelyRising \|\| isMealRising` (OR identique). Seule la cellule plateau+repas change de nom (`HIGH_PLATEAU` → `MEAL_AWARE_RISE`). Test `AutoDriveGaterEngageKindOrderTest` (grille des 8 combinaisons). |

### Hors lot

- P0.11 IAM floor `f519`
- P0.12 barrier replay
- P1.1 SMB smbGiven
- P1.2 DescentRedoseGuard
- Advisor ZIP / dashboard UI
- Remplacement en bloc de `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine`

### Preuves

```
./gradlew :plugins:aps:compileAndroidMain
→ BUILD SUCCESSFUL in 1m 6s

./gradlew :plugins:aps:compileKotlinIosArm64
→ BUILD SUCCESSFUL (AutoDriveGater désormais commonMain, compilé Native)

./gradlew :plugins:aps:jvmTest \
  --tests '...AutoDriveGaterKindTest' \
  --tests '...AutoDriveGaterEngageKindOrderTest'
→ BUILD SUCCESSFUL
   AutoDriveGaterKindTest: 3 tests, 0 fail, 0 err, 0 skip
   AutoDriveGaterEngageKindOrderTest: 6 tests, 0 fail, 0 err, 0 skip

Red/green du libellé (ordre plateau d’abord restauré temporairement) :
   expected: <MEAL_AWARE_RISE> but was: <HIGH_PLATEAU>
   — identique au message de 0ca7744184. Restauration meal-first → 9/9 vert.
```

**Engage inchangé ; seuls kind / reason / label / export changent.** `DetermineBasalAIMI2` branche toujours uniquement sur `gate.engage`.

⚠️ ASYNC IMPACT: aucun (pas de nouvelles coroutines ; `shouldEngageV3` reste synchrone ; signature inchangée).

### Questions ouvertes

- Le déplacement `androidMain` → `commonMain` de `AutoDriveGater` est un placement KMP, pas un changement de contrat Metro. Il n’avait pas d’import Android.
- `kind` n’a qu’un consommateur : l’export `baseline_state`. Le texte `engageReason` ne va qu’à une ligne de debug.
- `HR_HIGH` / `ACTIVITY` ne sont pas exercés par la grille (santé idle) — comme la ref `078a` qui ne lockait que l’enum / le défaut.

---

## EN

Lot **P0.10** only — Autodrive gate observation: `GateKind` export + meal-first label. Medical closed-loop: clinical behaviour from reference; wiring from KMP study/Milos. **Observation-only — do not change doses / engage boolean.**

- **Study base** = `kmp-aimi-migration-study` tip **`172654f2619c0ee131452062ab4c6154e472233b`** (post P0.9)
- **Reference sources** on `origin/dev_OAPSAIMI`:
  1. `078a51514c` — feat(aimi): say why the Autodrive gate stayed shut
  2. `0ca7744184` — fix(aimi): let a meal keep its name above the plateau line
- Ref tip context `fe96b64f12` — do **not** pull other post-freeze commits
- Metro / `AimiJson` / study source sets kept
- `AutoDriveGater` moved androidMain → commonMain (pure logic); tests in `commonTest` + `kotlin.test` (not mockk). Backtick names omit commas (Kotlin/Native)
- **HEAD** = **`c1776c5d37`**

### Table of 2 items

| # | Item | P0.10 status |
|---|---|---|
| 1 | `GateKind` + export (`078a51514c`) | **Applied** — `GateKind` / `kind` on `GatingResult` (default `RISE_TOO_WEAK`). Three fields in `baseline_state` / export, written **before** the engage branch: `autodrive_gate_engaged`, `autodrive_gate_kind`, `autodrive_gate_reason`. Nothing dose-facing reads them. `AutoDriveGaterKindTest`. |
| 2 | Meal-first label (`0ca7744184`) | **Applied** — `isMealRising` before `isHighPlateau` for **kind/label only**. `engage` stays `isHighPlateau \|\| isActivelyRising \|\| isMealRising` (OR-identical). Only the plateau-and-meal cell changes name (`HIGH_PLATEAU` → `MEAL_AWARE_RISE`). `AutoDriveGaterEngageKindOrderTest` (8-cell grid). |

### Out of scope

- P0.11 IAM floor `f519`
- P0.12 barrier replay
- P1.1 SMB smbGiven
- P1.2 DescentRedoseGuard
- Advisor ZIP / dashboard UI
- Wholesale replace of `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine`

### Evidence

```
:plugins:aps:compileAndroidMain → BUILD SUCCESSFUL in 1m 6s
:plugins:aps:compileKotlinIosArm64 → BUILD SUCCESSFUL (gater now commonMain)
:plugins:aps:jvmTest gater tests → 9/9 (Kind 3 + Order 6)

Red/green with plateau-first temporarily restored:
  expected: <MEAL_AWARE_RISE> but was: <HIGH_PLATEAU>
  — same failure text as 0ca7744184. Meal-first restored → 9/9 green.
```

**Engage boolean unchanged; only kind / reason / label / export.** `DetermineBasalAIMI2` still branches only on `gate.engage`.

⚠️ ASYNC IMPACT: none (no new coroutines; `shouldEngageV3` stays synchronous; signature unchanged).

### Open questions

- Moving `AutoDriveGater` androidMain → commonMain is KMP placement, not a Metro contract change (no Android-only imports).
- `kind` has one consumer: `baseline_state` export. `engageReason` only reaches a debug line.
- `HR_HIGH` / `ACTIVITY` are not exercised by the idle-health grid — same as ref `078a`, which locked the enum / default only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05620a98-f0e5-4d5f-adfb-8ab36c8af0c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05620a98-f0e5-4d5f-adfb-8ab36c8af0c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

