### PR TITLE
P0.11 — IAM barrier floor as sensitivity (f519)

### DIFF
--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/InsulinActionModel.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/InsulinActionModel.kt
@@ -116,8 +116,46 @@ object InsulinActionModel {
     /**
      * Effective coefficient of the pre-unification code: `estimatedSI * 0.05` against a sensitivity
      * floored at 0.1. Equals [metabolicCoefficient] at ISF 45 with [MPC_TAU_MIN].
+     *
+     * Kept only as the last resort of [controlCoefficient], for inputs where no coefficient can be
+     * computed at all. The floor itself is now [MIN_FLOOR_ISF_MGDL_PER_U]; see the note there for why
+     * the same number is better written as a sensitivity.
      */
     const val LEGACY_CONTROL_COEFFICIENT: Double = 0.005
+
+    /**
+     * Lowest sensitivity the barrier and the controller will assume, as ISF in mg/dL per U.
+     *
+     * This is [LEGACY_CONTROL_COEFFICIENT] written as what it means: below this sensitivity the
+     * barrier stops believing the patient and keeps reasoning as if insulin were this strong.
+     * `45 / (75 * 120) = 0.005` exactly, so at [MPC_TAU_MIN] the two forms agree bit for bit and no
+     * dose moves.
+     *
+     * Two things the coefficient form could not say.
+     *
+     * The number was never derived. It is `0.1 * 0.05`, the product of the old `METABOLIC_SI_BASE` and
+     * a sensitivity floored at 0.1 in `AutoDriveState.createSafe`. That 0.1 was an ISF/10000 compared
+     * against a plain ISF, so it stood for 1000 mg/dL per U and clamped every patient on every tick.
+     * The commit that unified the expressions froze the result of that mistake so that no dose would
+     * change. The reference "ISF 45" is circular in the same way: one equation,
+     * `isf / (120 * tau) = 0.005`, for two unknowns, with `tau = 75` chosen — as the note on
+     * [MPC_TAU_MIN] says — to keep the refactor dose-neutral. At the honest tau of 175 the same floor
+     * would read as ISF 105. The value is inherited, not measured; naming it in mg/dL per U at least
+     * lets a future reader argue with it.
+     *
+     * As a coefficient it also swallowed [MPC_TAU_MIN]. `max(isf / (120 * tau), 0.005)` only depends on
+     * tau in the branch that is not taken when the floor bites, so raising tau moved the switch point
+     * from ISF 45 to ISF 90 and changed nothing where the floor was already active. Written as a
+     * sensitivity, `max(isf, floor) / (120 * tau)` is homogeneous in tau: tau factors out of the
+     * comparison, the set of floored ticks stops depending on the calibration, and a change to tau
+     * reaches every tick.
+     *
+     * Measured over 2 604 ticks where the barrier ran, between 1 and 7 September 2026: the floor bites
+     * on 37.8 % of them, never once between midnight and noon, and on 59 % of the ticks from noon to
+     * midnight — it is the daytime regime rather than a rare guard. Lowering it is a separate decision
+     * and needs the replay the note on [controlCoefficient] asks for.
+     */
+    const val MIN_FLOOR_ISF_MGDL_PER_U: Double = 45.0
 
     /**
      * Coefficient for the controller and the safety barrier — proportional to ISF, but never looser
@@ -139,8 +177,17 @@ object InsulinActionModel {
      * ISF the barrier gets stricter, below it stays exactly where it was. Removing this floor is the
      * next step and it needs a replay with a measured before/after, not a one-line edit.
      */
-    fun controlCoefficient(isfMgdlPerU: Double, tauMin: Double): Double =
-        maxOf(metabolicCoefficient(isfMgdlPerU, tauMin), LEGACY_CONTROL_COEFFICIENT)
+    fun controlCoefficient(isfMgdlPerU: Double, tauMin: Double): Double {
+        val proportional = metabolicCoefficient(isfMgdlPerU, tauMin)
+        val floored = metabolicCoefficient(MIN_FLOOR_ISF_MGDL_PER_U, tauMin)
+        val coefficient = maxOf(proportional, floored)
+        // Last resort. [metabolicCoefficient] answers 0.0 for an ISF that is not finite and for a tau
+        // that is not positive, and both terms can hit that at once when tau is wrong. A zero here
+        // would set `lgh = -siMetabolic * bg` to zero and send `safeU` to infinity, which removes the
+        // barrier instead of tightening it. The old form could not reach zero because it compared
+        // against a constant, and that property has to survive this rewrite.
+        return if (coefficient > 0.0) coefficient else LEGACY_CONTROL_COEFFICIENT
+    }
 
     /**
      * Converts the sensitivity carried on `AutoDriveState` back to an ISF in mg/dL/U.

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/InsulinActionModelFloorFormTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/autodrive/InsulinActionModelFloorFormTest.kt
@@ -1,0 +1,136 @@
+package app.aaps.plugins.aps.openAPSAIMI.autodrive
+
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel.LEGACY_CONTROL_COEFFICIENT
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel.MIN_FLOOR_ISF_MGDL_PER_U
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel.MPC_TAU_MIN
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel.controlCoefficient
+import app.aaps.plugins.aps.openAPSAIMI.autodrive.InsulinActionModel.metabolicCoefficient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The floor moved from a coefficient to a sensitivity, and no dose may move with it.
+ *
+ * The old form was `max(metabolicCoefficient(isf, tau), 0.005)`. The new one is
+ * `max(metabolicCoefficient(isf, tau), metabolicCoefficient(45, tau))`, with the constant kept only as
+ * a last resort. At [MPC_TAU_MIN] the two agree exactly, because `45 / (75 * 120)` is the same double
+ * as `0.005`. These tests hold that equality and, just as important, hold the edge cases where the
+ * rewrite could quietly turn a floor into a zero.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `f519320841`. Study source set: [InsulinActionModel]
+ * is commonMain, so the tests live in `commonTest` (`kotlin.test`) — not `androidHostTest`
+ * (Truth / JUnit / mockk). Backtick names omit commas (Kotlin/Native).
+ */
+class InsulinActionModelFloorFormTest {
+
+    /** The old expression, kept here so the comparison is against real code and not against a memory. */
+    private fun oldForm(isf: Double, tau: Double): Double =
+        maxOf(metabolicCoefficient(isf, tau), LEGACY_CONTROL_COEFFICIENT)
+
+    private val sensitivities = listOf(
+        1.0, 5.0, 9.0, 25.0, 27.0, 30.0, 35.0, 44.999, 45.0, 45.001,
+        50.0, 60.0, 90.0, 120.0, 400.0, 1e9, 0.0, -5.0,
+        Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+    )
+
+    @Test
+    fun `at the production tau the new form is the old one bit for bit`() {
+        sensitivities.forEach { isf ->
+            val expected = oldForm(isf, MPC_TAU_MIN)
+            val actual = controlCoefficient(isf, MPC_TAU_MIN)
+            assertEquals(
+                expected.toRawBits(),
+                actual.toRawBits(),
+                "isf=$isf expected=$expected actual=$actual",
+            )
+        }
+    }
+
+    /** The equality above rests on this one exact division. If it ever drifts, everything else does. */
+    @Test
+    fun `the floor sensitivity divides into exactly the legacy coefficient`() {
+        val writtenAsSensitivity = MIN_FLOOR_ISF_MGDL_PER_U / (MPC_TAU_MIN * 120.0)
+        assertEquals(
+            LEGACY_CONTROL_COEFFICIENT.toRawBits(),
+            writtenAsSensitivity.toRawBits(),
+            "45/(75*120)=$writtenAsSensitivity vs LEGACY=$LEGACY_CONTROL_COEFFICIENT",
+        )
+        assertEquals(
+            LEGACY_CONTROL_COEFFICIENT.toRawBits(),
+            metabolicCoefficient(MIN_FLOOR_ISF_MGDL_PER_U, MPC_TAU_MIN).toRawBits(),
+        )
+    }
+
+    /**
+     * A zero coefficient would set `lgh` to zero and send `safeU` to infinity: the barrier would not
+     * tighten, it would disappear. No input may produce one.
+     */
+    @Test
+    fun `no input can drive the coefficient to zero`() {
+        val taus = listOf(MPC_TAU_MIN, 150.0, 200.0, 1.0, 0.0, -1.0, Double.NaN)
+        taus.forEach { tau ->
+            sensitivities.forEach { isf ->
+                assertTrue(
+                    controlCoefficient(isf, tau) > 0.0,
+                    "isf=$isf tau=$tau produced ${controlCoefficient(isf, tau)}",
+                )
+            }
+        }
+    }
+
+    /** A sensitivity that cannot be read must not loosen the barrier below the floor. */
+    @Test
+    fun `an unusable sensitivity still gets the floor`() {
+        listOf(Double.NaN, Double.POSITIVE_INFINITY, 0.0, -5.0).forEach { isf ->
+            assertEquals(LEGACY_CONTROL_COEFFICIENT, controlCoefficient(isf, MPC_TAU_MIN), 0.0)
+        }
+    }
+
+    /** A tau that cannot be used falls back to the constant rather than to nothing. */
+    @Test
+    fun `an unusable tau falls back to the legacy coefficient`() {
+        listOf(0.0, -1.0, Double.NaN).forEach { tau ->
+            assertEquals(LEGACY_CONTROL_COEFFICIENT, controlCoefficient(45.0, tau), 0.0)
+        }
+    }
+
+    /**
+     * The point of the rewrite: tau now reaches the floored ticks too.
+     *
+     * In the old form a tick at ISF 30 answered 0.005 at every tau, because the floor was a constant.
+     * The switch point moved with tau instead of the value, so raising tau changed nothing exactly
+     * where the floor was already active.
+     */
+    @Test
+    fun `the floor now follows tau instead of swallowing it`() {
+        val resistant = 30.0
+        assertEquals(oldForm(resistant, 75.0), oldForm(resistant, 150.0), 0.0)
+
+        assertTrue(
+            controlCoefficient(resistant, 150.0) < controlCoefficient(resistant, 75.0),
+            "floored coefficient at tau=150 should be smaller than at tau=75",
+        )
+        assertEquals(
+            controlCoefficient(resistant, 75.0) / 2.0,
+            controlCoefficient(resistant, 150.0),
+            1e-15,
+        )
+    }
+
+    /** Whatever tau is, a sensitivity under the floor is treated as the floor and never below it. */
+    @Test
+    fun `the switch point is the sensitivity not a coefficient that depends on tau`() {
+        listOf(75.0, 150.0, 200.0).forEach { tau ->
+            assertEquals(
+                controlCoefficient(MIN_FLOOR_ISF_MGDL_PER_U, tau),
+                controlCoefficient(30.0, tau),
+                0.0,
+            )
+            assertTrue(
+                controlCoefficient(60.0, tau) > controlCoefficient(MIN_FLOOR_ISF_MGDL_PER_U, tau),
+                "isf=60 at tau=$tau should sit above the floor",
+            )
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P0.11** uniquement — plancher IAM de la barrière réécrit comme une sensibilité, pas comme un coefficient. Boucle fermée médicale : comportement clinique depuis la référence ; câblage study/Milos. **Chemin dose-facing, mais dose-neutre au τ de production (`MPC_TAU_MIN` = 75).**

- **Étude (base)** = `kmp-aimi-migration-study` tip post-P0.10 **`3201700fe8fc9b7a2e7d54db813ecc86b9dfbb68`**
- **Source référence** sur `origin/dev_OAPSAIMI` : `f519320841` — refactor(aimi): write the barrier floor as a sensitivity, not as a coefficient
- Ne pas tirer : P0.12 barrier replay `79588b42cb`, P1.1 SMB smbGiven `6c0c0285ff`, P1.2 DescentRedoseGuard `fe96b64f12`, viewer, advisor ZIP, dashboard
- Metro / `AimiJson` / signatures study conservés
- **HEAD** = **`c3cf64f488`**

### Ce qui change

| # | Item | Statut P0.11 |
|---|---|---|
| 1 | Plancher IAM en sensibilité (`f519320841`) | **Appliqué** — `controlCoefficient` passe de `max(metabolic(isf, τ), 0.005)` à `max(metabolic(isf, τ), metabolic(45, τ))`. Constante `MIN_FLOOR_ISF_MGDL_PER_U = 45`. `LEGACY_CONTROL_COEFFICIENT` ne reste que comme garde-fou si le coefficient n’est pas calculable (ISF/τ invalides → 0 ou NaN). Signature inchangée. Test `InsulinActionModelFloorFormTest` en `commonTest` + `kotlin.test` (pas mockk ; noms backtick sans virgules). |

Fichiers : `InsulinActionModel.kt` (commonMain) + `InsulinActionModelFloorFormTest.kt` (commonTest). Pas de retouche de `AutodriveEngine` / `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`.

### Preuve dose-neutre à τ prod

`45 / (75 · 120) = 0.005` est le même double IEEE que `LEGACY_CONTROL_COEFFICIENT` (`3f747ae147ae147b`). Au `MPC_TAU_MIN` les deux formes sont bit-identiques sur la grille de 21 sensibilités (dont 44.999, 45, 45.001, 0, négatif, NaN, ±∞). Les appels production (`MpcController`, `ControlBarrierShield`, `AutodriveEngine`) passent déjà `MPC_TAU_MIN` : aucun dose ne bouge.

| isf | old τ=75 | new τ=75 |
|---|---|---|
| 30 (médiane, plancher actif) | `0.005` | `0.005` |
| 44.999 | `0.005` | `0.005` |
| 45 | `0.005` | `0.005` |
| 45.001 | `0.00500011111111` | `0.00500011111111` |
| 60 | `0.00666666666667` | `0.00666666666667` |
| NaN / 0 / −5 / ±∞ | `0.005` | `0.005` |

Ce que la forme coefficient ne pouvait pas dire :

- Le `0.005` n’a jamais été dérivé : c’est `0.1 × 0.05` (ancien `METABOLIC_SI_BASE` × plancher `createSafe` en mauvaises unités).
- `max(isf/(120·τ), 0.005)` n’utilise τ que sur la branche non prise quand le plancher mord. En sensibilité, `max(isf, 45)/(120·τ)` est homogène en τ : ISF 30 à τ=150 donne `0.0025` (la moitié), alors que l’ancienne forme restait `0.005`.

### Hors lot

- P0.12 barrier replay `79588b42cb`
- P1.1 SMB smbGiven `6c0c0285ff`
- P1.2 DescentRedoseGuard `fe96b64f12`
- Advisor ZIP / dashboard / viewer
- Remplacement en bloc de `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine`

### Preuves

```
RED (plancher encore en coefficient, constante MIN_FLOOR déjà là) :
  4/7 failed — attendu :
  - the floor now follows tau instead of swallowing it
  - an unusable tau falls back to the legacy coefficient  (NaN τ → NaN)
  - no input can drive the coefficient to zero            (NaN τ → NaN)
  - the switch point is the sensitivity not a coefficient that depends on tau

./gradlew :plugins:aps:compileAndroidMain
→ BUILD SUCCESSFUL in 53s

./gradlew :plugins:aps:compileKotlinIosArm64
→ BUILD SUCCESSFUL (commonMain compilé Native)

./gradlew :plugins:aps:jvmTest \
  --tests '...InsulinActionModelFloorFormTest'
→ BUILD SUCCESSFUL
   InsulinActionModelFloorFormTest: 7 tests, 0 fail, 0 err, 0 skip
```

⚠️ ASYNC IMPACT: aucun. `controlCoefficient` reste une fonction pure synchrone `Double → Double`. Pas de coroutine / Flow / callback. Callers inchangés (`MpcController`, `ControlBarrierShield`). Le chemin barrière est touché, mais au τ prod le coefficient est bit-identique : `lgh` / `safeU` ne bougent pas.

---

## EN

Lot **P0.11** only — IAM barrier floor rewritten as a sensitivity, not a coefficient. Medical closed-loop: clinical behaviour from reference; wiring from KMP study/Milos. **Dose-facing path, but dose-neutral at production τ (`MPC_TAU_MIN` = 75).**

- **Study base** = `kmp-aimi-migration-study` tip **`3201700fe8fc9b7a2e7d54db813ecc86b9dfbb68`** (post P0.10 merge)
- **Reference source** on `origin/dev_OAPSAIMI`: `f519320841` — refactor(aimi): write the barrier floor as a sensitivity, not as a coefficient
- Do **not** pull: P0.12 barrier replay `79588b42cb`, P1.1 SMB smbGiven `6c0c0285ff`, P1.2 DescentRedoseGuard `fe96b64f12`, viewer, advisor ZIP, dashboard
- Metro / `AimiJson` / study signatures kept
- **HEAD** = **`c3cf64f488`**

### What changed

| # | Item | P0.11 status |
|---|---|---|
| 1 | IAM floor as sensitivity (`f519320841`) | **Applied** — `controlCoefficient` from `max(metabolic(isf, τ), 0.005)` to `max(metabolic(isf, τ), metabolic(45, τ))`. New `MIN_FLOOR_ISF_MGDL_PER_U = 45`. `LEGACY_CONTROL_COEFFICIENT` kept only as last resort when no coefficient can be computed. Signature unchanged. `InsulinActionModelFloorFormTest` in `commonTest` + `kotlin.test` (not mockk; backtick names omit commas). |

Files: `InsulinActionModel.kt` (commonMain) + `InsulinActionModelFloorFormTest.kt` (commonTest). No edits to `AutodriveEngine` / `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`.

### Dose-neutral-at-τ-prod proof

`45 / (75 · 120) = 0.005` is the same IEEE double as `LEGACY_CONTROL_COEFFICIENT` (`3f747ae147ae147b`). At `MPC_TAU_MIN` the two forms agree bit-for-bit across a 21-sensitivity grid (including 44.999, 45, 45.001, zero, negative, NaN, both infinities). Production callers already pass `MPC_TAU_MIN`: no dose moves.

| isf | old τ=75 | new τ=75 |
|---|---|---|
| 30 (median, floor active) | `0.005` | `0.005` |
| 44.999 | `0.005` | `0.005` |
| 45 | `0.005` | `0.005` |
| 45.001 | `0.00500011111111` | `0.00500011111111` |
| 60 | `0.00666666666667` | `0.00666666666667` |
| NaN / 0 / −5 / ±∞ | `0.005` | `0.005` |

Two things the coefficient form could not say:

- The number was never derived: it is `0.1 × 0.05` (old `METABOLIC_SI_BASE` times the `createSafe` floor in the wrong units).
- `max(isf/(120·τ), 0.005)` only uses τ on the branch that is not taken when the floor bites. As a sensitivity, `max(isf, 45)/(120·τ)` is homogeneous in τ: ISF 30 at τ=150 answers `0.0025` (half), while the old form stayed `0.005`.

### Out of scope

- P0.12 barrier replay `79588b42cb`
- P1.1 SMB smbGiven `6c0c0285ff`
- P1.2 DescentRedoseGuard `fe96b64f12`
- Advisor ZIP / dashboard / viewer
- Wholesale replace of `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine`

### Evidence

```
RED (coefficient floor still in place, MIN_FLOOR constant already present):
  4/7 failed — expected:
  - the floor now follows tau instead of swallowing it
  - an unusable tau falls back to the legacy coefficient  (NaN τ → NaN)
  - no input can drive the coefficient to zero            (NaN τ → NaN)
  - the switch point is the sensitivity not a coefficient that depends on tau

:plugins:aps:compileAndroidMain → BUILD SUCCESSFUL in 53s
:plugins:aps:compileKotlinIosArm64 → BUILD SUCCESSFUL (commonMain on Native)
:plugins:aps:jvmTest InsulinActionModelFloorFormTest → 7/7 (0 fail, 0 err, 0 skip)
```

⚠️ ASYNC IMPACT: none. `controlCoefficient` stays a pure synchronous `Double → Double`. No coroutine / Flow / callback. Callers unchanged (`MpcController`, `ControlBarrierShield`). The barrier path is touched, but at production τ the coefficient is bit-identical: `lgh` / `safeU` do not move.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d574edc-dc39-4e86-983d-31fccf941971?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d574edc-dc39-4e86-983d-31fccf941971&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

