### PR TITLE
docs(kmp): ancre P0.11 #86 — GO vs f519 IAM floor

### DIFF
--- a/_docs/kmp/P0.11-ANCHOR.md
+++ b/_docs/kmp/P0.11-ANCHOR.md
@@ -1,0 +1,182 @@
+# P0.11 — Ancre référence (plancher IAM en sensibilité)
+
+**Verdict : GO**
+
+Lot **P0.11** = plancher IAM réécrit comme une sensibilité, un seul PR, **chemin barrière touché, dose-neutre au τ de production (`MPC_TAU_MIN` = 75)**.
+Relecture du code (study / HEAD #86 / `f519320841`). Rien n’est inventé depuis le texte du PR.
+
+| Rôle | SHA | Branche / objet |
+|---|---|---|
+| Study post-P0.10 (base #86) | `3201700fe8fc9b7a2e7d54db813ecc86b9dfbb68` | `kmp-aimi-migration-study` après merge #84 |
+| HEAD P0.11 | `c3cf64f488a359e5ffea16eb0aeeb401a62f0186` | PR **#86** `cursor/iam-barrier-floor-sensitivity-1971` |
+| Source plancher IAM | `f519320841fb3fb47962604ec92a2200c8f89978` | `refactor(aimi): write the barrier floor as a sensitivity, not as a coefficient` |
+| Blob production `InsulinActionModel.kt` | `44f7d71d07335808714001007e2f93c0953aaf89` | **identique** `f519` (`src/main`) ↔ #86 (`commonMain`) |
+
+`f519` est le commit source. Le fichier production study @ `c3cf64f488` et le fichier ref @ `f519` ont le **même blob git** et le même SHA-256 (`c3e545df1fdf97dab5450b13652a991761bd61026ebe5c3fc316673b63658acc`). Le diff des deux chemins est vide.
+
+---
+
+## 1. Contenu réel de PR #86
+
+- **1 commit** : `c3cf64f488` — *P0.11 — IAM barrier floor as sensitivity (f519)*
+- **2 fichiers**, +185 / −2
+- Base GitHub : `kmp-aimi-migration-study` @ `3201700fe8`
+- Parent du commit = `3201700fe8` (aucun autre commit study)
+
+| Fichier study | Statut |
+|---|---|
+| `plugins/aps/src/commonMain/.../autodrive/InsulinActionModel.kt` | modifié (+49 / −2) |
+| `plugins/aps/src/commonTest/.../autodrive/InsulinActionModelFloorFormTest.kt` | ajouté (+136) |
+
+Pas d’autre fichier. Pas de `OpenAPSAIMIPlugin`, pas d’`AutodriveEngine`, pas de `DetermineBasalAIMI2`, pas de dump staging, pas d’Advisor, pas de `DescentRedoseGuard`, pas de replay barrière `79588b42cb`, pas de `smbGiven` `6c0c0285ff`.
+
+---
+
+## 2. Tableau des items
+
+| # | Item | Statut | Fidélité vs `f519` | Preuve |
+|---|---|---|---|---|
+| 1 | Plancher IAM en sensibilité (`f519320841`) | **Appliqué** | `controlCoefficient` : `max(metabolic(isf, τ), metabolic(45, τ))` puis garde-fou `LEGACY` si le coefficient ≤ 0. Constante `MIN_FLOOR_ISF_MGDL_PER_U = 45`. Signature inchangée. | Blob production **identique** `44f7d71d`. KDoc `MIN_FLOOR` / corps de fonction byte-identiques. |
+
+Un seul item clinique. Les 7 locks de `InsulinActionModelFloorFormTest` sont le port KMP du test `f519` (`src/test` + Truth / JUnit).
+
+---
+
+## 3. Fidélité clinique vs `f519`
+
+### 3.1 Formule
+
+Avant P0.11 (study `3201700fe8`, et parent de `f519`) :
+
+```
+controlCoefficient(isf, τ) = max(metabolic(isf, τ), 0.005)
+```
+
+Après `f519` = après #86 :
+
+```
+proportional = metabolic(isf, τ)          // isf / (τ · 120)  si isf fini et τ > 0, sinon 0
+floored      = metabolic(45, τ)
+coefficient  = max(proportional, floored)
+return coefficient > 0 ? coefficient : LEGACY_CONTROL_COEFFICIENT   // 0.005
+```
+
+Équivalent, quand les deux termes sont calculables et positifs, à :
+
+```
+max(isf, 45) / (120 · τ)
+```
+
+`metabolicCoefficient`, `MPC_TAU_MIN = 75`, `REFERENCE_BG_MGDL = 120`, `LEGACY_CONTROL_COEFFICIENT = 0.005` : **inchangés** vs base study et vs `f519`.
+
+### 3.2 Équivalence à τ = 75
+
+`45 / (75 · 120) = 0.005` est le même double IEEE que `LEGACY_CONTROL_COEFFICIENT` :
+
+| Expression | Valeur | Bits IEEE |
+|---|---|---|
+| `LEGACY_CONTROL_COEFFICIENT` | `0.005` | `3f747ae147ae147b` |
+| `45 / (75 · 120)` | `0.005` | `3f747ae147ae147b` |
+
+Vérifié hors Gradle (Python IEEE) sur la grille de 21 sensibilités du test (`1 … 400`, `1e9`, `0`, `−5`, NaN, ±∞) : **21/21 bit-identiques** ancienne forme ↔ nouvelle forme à `τ = 75`.
+
+| isf | old τ=75 | new τ=75 | bits |
+|---|---|---|---|
+| 30 (médiane, plancher actif) | `0.005` | `0.005` | `3f747ae147ae147b` |
+| 44.999 | `0.005` | `0.005` | `3f747ae147ae147b` |
+| 45 | `0.005` | `0.005` | `3f747ae147ae147b` |
+| 45.001 | `0.00500011111111` | `0.00500011111111` | `3f747aff1b2d6b13` |
+| 60 | `0.00666666666667` | `0.00666666666667` | `3f7b4e81b4e81b4f` |
+| NaN / 0 / −5 / ±∞ | `0.005` | `0.005` | `3f747ae147ae147b` |
+
+### 3.3 Garde-fou LEGACY
+
+`metabolicCoefficient` répond `0.0` si l’ISF n’est pas fini ou si `τ ≤ 0`. Les deux termes peuvent donc être nuls (ou NaN si `τ` est NaN : `NaN ≤ 0` est faux, donc la division produit NaN). Un zéro / NaN mettrait `lgh = −siMetabolic · bg` à zéro / NaN et enverrait `safeU` à l’infini — la barrière disparaîtrait.
+
+L’ancienne forme ne pouvait pas atteindre zéro parce qu’elle comparait à la constante `0.005`. La nouvelle forme conserve cette propriété via `if (coefficient > 0.0) coefficient else LEGACY`. Corps **identique** à `f519` (commentaire « Last resort » inclus).
+
+À `τ` inutilisable (`0`, `−1`, NaN) : les deux formes Kotlin retombent sur `0.005` (ancienne via `maxOf(NaN ou 0, 0.005)` ; nouvelle via le garde-fou). Aucun caller production ne passe un τ autre que `MPC_TAU_MIN`.
+
+### 3.4 Dose-neutre au τ prod — callers
+
+Les **seuls** call sites `controlCoefficient(` du tree study / #86 :
+
+| Caller | τ passé | Dose-facing ? |
+|---|---|---|
+| `MpcController` (`commonMain`) | `InsulinActionModel.MPC_TAU_MIN` | Oui — coefficient `si` de la trajectoire |
+| `ControlBarrierShield.enforce` (`commonMain`) | `InsulinActionModel.MPC_TAU_MIN` | Oui — `siMetabolic` → `lgh` / `safeU` (sauf override ombre) |
+| `AutodriveEngine.recordCoefficientShadow` (`androidMain`) | `InsulinActionModel.MPC_TAU_MIN` | Non — export seulement ; la commande ombre n’est pas retournée |
+
+Aucun caller ne passe `150`, `175`, ni un τ profil. Au τ prod le coefficient est bit-identique : `lgh` / `safeU` / dose MPC ne bougent pas.
+
+Ce que la forme coefficient ne pouvait pas dire (voulu par `f519`, **inactif en prod**) : à ISF 30, `τ = 150` l’ancienne forme restait `0.005` ; la nouvelle répond `0.0025` (homogène en τ). Lock : `the floor now follows tau instead of swallowing it`. Changer `MPC_TAU_MIN` reste un autre lot (replay P0.12).
+
+---
+
+## 4. Hors-scope respecté
+
+| Interdit P0.11 | Constat @ `c3cf64f488` |
+|---|---|
+| P0.12 barrier replay `79588b42cb` | Hors PR. Aucun `ReplayTick` / fixture barrière. |
+| P1.1 SMB `smbGiven` `6c0c0285ff` | Hors PR. `SmbTrainingRowBuffer` / `AimiSmbTrainer` absents du diff. |
+| P1.2 `DescentRedoseGuard` `fe96b64f12` | Hors PR. |
+| Advisor ZIP / dashboard / viewer | Aucun fichier UI / Advisor / staging. |
+| Remplacement `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine` | Non. Engine / tick / plugin absents du diff. |
+
+⚠️ ASYNC IMPACT : aucun. `controlCoefficient` reste une fonction pure synchrone `Double → Double`. Pas de coroutine / Flow / callback. Callers inchangés.
+
+---
+
+## 5. Adaptations KMP (câblage) vs divergences sémantiques
+
+| Sujet | Adaptation KMP | Divergence sémantique ? |
+|---|---|---|
+| Fichier production | `src/main` → déjà `commonMain` sur study. Contenu **byte-identique** à `f519`. | Non. |
+| Signature | `controlCoefficient(isfMgdlPerU, tauMin): Double` inchangée. | Non. |
+| Tests | `commonTest` + `kotlin.test` (ref `src/test` + Truth + JUnit5). | Non. Mêmes 7 cas, même grille de 21 sensibilités, mêmes τ (`75/150/200/1/0/−1/NaN`). |
+| Égalité bits | Study : `toRawBits()` (plus strict que `==` sur NaN). Ref : Truth `isEqualTo`. À τ=75 les deux formes sont finies (`0.005` ou proportionnel) : équivalent. | Non. Plus strict. |
+| Noms backtick | Virgules retirées (`e34b01f666`, Kotlin/Native). Ex. `the old one bit for bit` (ref : `the old one, bit for bit`). | Non. Assertions identiques. |
+| Metro / `AimiJson` | Non touchés. | — |
+
+**Aucune divergence sémantique** sur l’item clinique. Le changement de forme à τ ≠ 75 est **celui de `f519`**, pas une adaptation KMP.
+
+---
+
+## 6. Caveats vs blockers
+
+### Blockers
+
+Aucun. Formule = `f519`. Bit-identique à τ prod. Garde-fou LEGACY présent. Hors-scope tenu. Callers déjà sur `MPC_TAU_MIN`.
+
+### Caveats (suivre, ne bloquent pas le merge P0.11)
+
+1. **Commentaires callers encore rédigés « floors at `LEGACY_CONTROL_COEFFICIENT` »** — `AutodriveEngine.profileAnchoredSafetySi` et `DetermineBasalAIMI2` (`command_isf_mgdl`). **Identique sur `f519`** : le commit source n’a pas retouché ces commentaires. Au τ=75 le nombre exporté reste `0.005` ; le libellé « plancher = constante » est juste devenu incomplet. Hors lot (pas de retouche engine / tick).
+2. **CI GitHub #86** — `ios` fail + `claude-review` fail. Même forme que #80 / #82 / #84 (préexistant, hors lot). Ne juge pas ce diff.
+3. **Preuves de build** — le corps du PR cite `compileAndroidMain`, `compileKotlinIosArm64`, `jvmTest` `InsulinActionModelFloorFormTest` 7/7, et un RED 4/7 avec le plancher encore en coefficient. Cette ancre **relit le code** et **recalcule l’IEEE** ; elle ne relance pas Gradle.
+4. **Homogénéité en τ** — sémantique nouvelle dès que `τ ≠ 75`. Aucun caller prod ne le fait aujourd’hui. Baisser / monter `MPC_TAU_MIN` (ou passer un autre τ) **n’est plus** un no-op sur les ticks plancher : c’est le but de `f519`, et ça exige le replay P0.12.
+
+---
+
+## 7. Checklist preuves
+
+- [x] PR #86 : 1 commit `c3cf64f488`, 2 fichiers, base / parent `3201700fe8`
+- [x] `f519320841` relu (même `controlCoefficient`, même `MIN_FLOOR_ISF_MGDL_PER_U = 45`, même garde-fou LEGACY)
+- [x] Blob production `44f7d71d` : `f519` `src/main` ≡ #86 `commonMain` (diff vide)
+- [x] `45/(75·120)` bits = `LEGACY` bits = `3f747ae147ae147b`
+- [x] Grille 21 sensibilités : old τ=75 ≡ new τ=75 bit-pour-bit (preuve IEEE locale)
+- [x] 3 callers `controlCoefficient` : tous passent `MPC_TAU_MIN` ; 2 dose-facing, 1 ombre
+- [x] Signature `controlCoefficient` inchangée ; `metabolicCoefficient` / `MPC_TAU_MIN` / `REFERENCE_BG` inchangés
+- [x] Aucun fichier hors lot ; pas de replay / `smbGiven` / `DescentRedoseGuard` / Advisor
+- [x] Test porté (7 locks équivalents, `commonTest`, noms sans virgule, `toRawBits`)
+
+---
+
+## 8. Recommandation
+
+| Action | Reco |
+|---|---|
+| **Merge #86** | **Oui** — fidèle à `f519` (fichier production byte-identique), dose-neutre au τ prod, hors-scope tenu. |
+| **Fix avant merge** | **Non** — pas de blocker clinique. |
+| **Suite** | P0.12 barrier replay `79588b42cb` (le replay que les notes `controlCoefficient` / `recordCoefficientShadow` demandent). Ne pas greffer `smbGiven` / `DescentRedoseGuard` / Advisor dans le même PR. |
+
+P0.10 (#84) était observation only. P0.11 touche le chemin barrière **sans bouger la dose au τ calibré**. Le prochain lot qui change τ, ou qui retire le plancher 45, n’est plus de l’arithmétique : c’est un replay.

--- a/_docs/kmp/README.md
+++ b/_docs/kmp/README.md
@@ -75,6 +75,7 @@ blueprint et ces annexes spécialisées font autorité sur `AIMI_KMP_MIGRATION_S
 4. [`w6-m1-read-registry.md`](w6-m1-read-registry.md) — freeze field and service-read inventory (W6, not a rewrite) ;
 5. [`w8-go-nogo.md`](w8-go-nogo.md) — W8 GO/NO-GO for empty AIMI KMP shells ;
 6. [`aimi-kmp-port-ledger.md`](aimi-kmp-port-ledger.md) — folder-by-folder AIMI port (Milos SMB pattern) ;
+6b. [`P0.11-ANCHOR.md`](P0.11-ANCHOR.md) — ancre P0.11 (#86) plancher IAM en sensibilité vs `f519320841` ;
 7. annexe 6 pour le protocole Tree → Harmonia → RBT → safety ;
 8. annexe 5 pour les modèles et learners ;
 9. annexe 7 pour l'intégration iOS ;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre référence pour **PR #86 P0.11** (plancher IAM en sensibilité). Aucun changement clinique.

**Verdict : GO**

- Study HEAD #86 = `c3cf64f488`
- Base study post-#84 = `3201700fe8`
- Source = `f519320841` (IAM floor) sur `origin/dev_OAPSAIMI`
- Blob production `InsulinActionModel.kt` = `44f7d71d` — **identique** `f519` (`src/main`) ↔ #86 (`commonMain`)

Formule `max(isf, 45)/(120·τ)` + garde-fou `LEGACY` si le coefficient n’est pas calculable. Bit-identique à `MPC_TAU_MIN=75` (`45/(75·120)` bits = `3f747ae147ae147b`). Les 3 callers passent déjà `MPC_TAU_MIN`. Hors-scope tenu (pas de replay P0.12, pas `smbGiven`, pas `DescentRedoseGuard`).

Livrable : [`_docs/kmp/P0.11-ANCHOR.md`](_docs/kmp/P0.11-ANCHOR.md)

### Reco

- **Merge #86** — oui (fidèle à `f519`, dose-neutre au τ prod).
- **Fix avant merge** — non.
- **Suite** — P0.12 barrier replay `79588b42cb`, pas ce PR.

## EN

Anchor review of PR #86. Docs only. Verdict **GO**. Production file is the same git blob as `f519320841`. Bit-identical at production τ. Merge the IAM floor rewrite; do not pull barrier replay / smbGiven / DescentRedoseGuard into the same lot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e004029f-76b4-4d10-b8f9-8144d1235c36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e004029f-76b4-4d10-b8f9-8144d1235c36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

