### PR TITLE
docs(kmp): ancre P0.12 #88 — GO vs 79588 barrier replay

### DIFF
--- a/_docs/kmp/P0.12-ANCHOR.md
+++ b/_docs/kmp/P0.12-ANCHOR.md
@@ -1,0 +1,192 @@
+# P0.12 — Ancre référence (harnais barrier replay)
+
+**Verdict : GO**
+
+Lot **P0.12** = harnais de rejeu `ControlBarrierShield` rendu exécutable. **Observation / `commonTest` seulement — le chemin de dose production ne change pas.**
+Relecture du code (study / HEAD #88 / `79588b42cb`). Rien n’est inventé depuis le texte du PR.
+
+| Rôle | SHA | Branche / objet |
+|---|---|---|
+| Study post-P0.11 (base #88) | `f9c086992e62bfa18582149b64a02b1534600f92` | `kmp-aimi-migration-study` après merge #86 |
+| HEAD P0.12 | `838de62c7ddfd08cb12457c8929d589bf12a6605` | PR **#88** `cursor/p012-barrier-replay-harness-4671` |
+| Source harness | `79588b42cbc1b6df9fa2ed9185fc49dbebb07268` | `test(aimi): make the barrier replay the repo asks for actually runnable` |
+| Fixture `barrier_ticks.jsonl` | SHA-256 `b4539ea42c143a5fb6e2fcad0692d90429f7e1f3d1aa3880191962a9270645fd` | **72 lignes, byte-identique** `79588` (`src/test/resources`) ↔ #88 (`commonTest/resources`) |
+
+`79588` est le commit source. Le fixture study @ `838de62c7d` et le fixture ref @ `79588` ont le **même SHA-256**. `cmp` des deux fichiers : identique.
+
+---
+
+## 1. Contenu réel de PR #88
+
+- **1 commit** : `838de62c7d` — *P0.12 — Barrier replay harness from 79588b42cb*
+- **8 fichiers**, +1441 / −0
+- Base GitHub : `kmp-aimi-migration-study` @ `f9c086992e`
+- Parent du commit = `f9c086992e` (aucun autre commit study)
+
+| Fichier study | Statut |
+|---|---|
+| `plugins/aps/src/commonTest/.../replay/BarrierReplay.kt` | ajouté |
+| `plugins/aps/src/commonTest/.../replay/BarrierReplayTest.kt` | ajouté |
+| `plugins/aps/src/commonTest/.../replay/BarrierTicksJsonl.kt` | ajouté (KMP : fixture chargeable Native) |
+| `plugins/aps/src/commonTest/.../replay/ReplayCorpus.kt` | ajouté |
+| `plugins/aps/src/commonTest/.../replay/ReplayTick.kt` | ajouté |
+| `plugins/aps/src/commonTest/resources/replay/barrier_ticks.jsonl` | ajouté |
+| `plugins/aps/src/commonTest/resources/replay/README.md` | ajouté |
+| `scripts/aimi_replay_fixture.py` | ajouté |
+
+**Aucun** fichier `commonMain` / `androidMain` / `iosMain` / `src/main`. Pas de `DetermineBasalAIMI2`, pas d’`OpenAPSAIMIPlugin`, pas d’`AutodriveEngine`, pas de `ControlBarrierShield`, pas d’`InsulinActionModel`, pas de dump staging, pas d’Advisor, pas de `DescentRedoseGuard`, pas de `smbGiven`.
+
+Blobs production **identiques** base ↔ HEAD #88 :
+
+| Fichier | Blob | Base ≡ HEAD |
+|---|---|---|
+| `ControlBarrierShield.kt` (`commonMain`) | `78d7061e4d6ddc88d5afbd5e981bdb9daf943972` | oui |
+| `InsulinActionModel.kt` (`commonMain`) | `44f7d71d07335808714001007e2f93c0953aaf89` | oui |
+| `DetermineBasalAIMI2.kt` (`androidMain`) | `e5f44b53e6cffd402bb669fb6064aa293fe88205` | oui |
+| `OpenAPSAIMIPlugin.kt` (`androidMain`) | `3e73c194529b1d20306f4f4f907bc2e142195331` | oui |
+| `AutodriveEngine.kt` (`androidMain`) | `f727f13c7a346a1a604f4297e20b9d3c870cf2b3` | oui |
+| `AimiDetermineBasalTickOrchestrator.kt` | `85f8b9ccbaec038bceb0e5dae7203c376df3ba43` | oui |
+| `DetermineBasalCoordinator.kt` | `52e7a734c6a966bbe55f0bd4423d7c3b4d63d87c` | oui |
+
+---
+
+## 2. Tableau des items
+
+| # | Item | Statut | Fidélité vs `79588` | Preuve |
+|---|---|---|---|---|
+| 1 | Harnais `BarrierReplay` | **Appliqué** | Même `replay` / `reproduction` / `compare` / `gammaDriver` / `replayable`. `REPRODUCTION_TOLERANCE = 1e-9`. Gamma lock `1e-12`. | Diff : formatage `NumberFormat` + `SilentLogger` en `Unit`. Corps arithmétique identique. |
+| 2 | `ReplayTick` + reconstruction `cbf*` | **Appliqué** | Mêmes propriétés, mêmes clés JSON, mêmes formules `cbfBg` / `cbfIob` / `cbfEstimatedRa` / `cbfSafetySi`. | kotlinx `JsonObject` à la place de `org.json`. Clés `cb_*` / `cbf*` identiques. |
+| 3 | Fixture 72 ticks | **Appliqué** | Même fichier. 72/72 ticks replayables. | SHA-256 `b4539ea4…645fd`. `BarrierTicksJsonl.TEXT` = les 72 mêmes lignes. |
+| 4 | Tests lock | **Appliqué** | `safe_u` 72/72, gamma 72/72, permitted ≥ 90 % (les 3 misses de la ref). | `assertEquals(ticks, safeUReproduced)` + `assertEquals(ticks, gammaReproduced)` + `permittedRate >= 90`. Study ajoute `assertEquals(72, ticks.size)`. |
+| 5 | Script `aimi_replay_fixture.py` | **Appliqué** | Même `barrier()` / `BARRIER_KEYS` / `subsample`. | Seule retouche : chemin `commonTest/resources` dans le docstring. |
+
+Un seul item clinique (le harnais). Les 7 tests `BarrierReplayTest` sont le port KMP des 7 tests `79588` (`src/test` + JUnit5).
+
+---
+
+## 3. Fidélité vs `79588`
+
+### 3.1 Tolérances (identiques)
+
+| Grandeur | Constante | Où |
+|---|---|---|
+| `safe_u` / permitted | `REPRODUCTION_TOLERANCE = 1e-9` relatif : `abs(a−b) ≤ 1e-9 · max(1, abs(b))` | `BarrierReplay.close` / `sameSafeU` |
+| Branche gamma | `abs(activeGamma − recorded) ≤ 1e-12` | `TickOutcome.gammaReproduced` |
+| Sélection branche | `recordedGamma ≶ NOMINAL_GAMMA ± 1e-12` | `gammaDriver` (`NOMINAL_GAMMA = 0.04`) |
+| Monotonie unfloored | `1e-12` sur `safeU` et `permittedU` | `BarrierReplayTest` |
+
+`PRODUCTION` lit `cbfCoefficientUsed ?: cbfSiMetabolic`. `UNFLOORED` lit `cbfCoefficientUnfloored`. **Pas** `controlCoefficient` : le fixture reste une référence avant/après après le rewrite P0.11.
+
+### 3.2 Reconstruction d’état (identiques)
+
+| Entrée `enforce` | Source replay | Formule |
+|---|---|---|
+| `bg` | `cbfHMgdl + 80` | `BG_DANGER_THRESHOLD_MGDL = 80` |
+| `iob` | `−insulinTerm / (siMetabolic · bg)` | pas le `iob` baseline |
+| `estimatedRa` | `lfh + 0.015 · (bg − 100) − insulinTerm` | `p1 = 0.015` |
+| `bgVelocity` | synthétique via `gammaDriver` | pas le `vel` exporté |
+| `maxIOB` | `maxiob` | |
+| `safetySi` | `cbfProfileIsf / 10000` | override coefficient passé à part |
+| `cob` | `0.0` volontaire | la relaxation meal passe par `combinedDelta` |
+
+`gammaDriver` : accélération (`v = −1`, priming `0`), nominal (`v = 0`), meal (`v = 0.2`, `combinedDelta = 2.0`). `isHighRiseMeal` (seuil 0.6) reste désarmé — **même commentaire, mêmes constantes** que `79588`. Shield **frais** par tick ; priming sous `observationId` distinct.
+
+### 3.3 Lock annoncé 72/72 et 69/72
+
+Le test **n’assert pas 69** (ni en ref ni en study). Il assert :
+
+- `reproduction.ticks == 72`
+- `gammaReproduced == ticks` → 72/72
+- `safeUReproduced == ticks` → 72/72
+- `permittedRate >= 90` → 69/72 = 95.8 % passe
+
+Les 3 misses permitted sont ceux de `79588` : `isHighRiseMeal` (vélocité non exportée) et basal profil parfois différent de celui remis à `enforce`. Commentaire **identique** dans les deux `BarrierReplayTest`.
+
+`flooredAtIsf` utilise déjà `InsulinActionModel.metabolicCoefficient` **dans `79588`** (blob IAM `44f7d71d` identique study ↔ ref). Pas une invention study.
+
+### 3.4 Shield study vs shield `79588`
+
+Le blob `ControlBarrierShield` study (`78d7061e`) **n’est pas** le blob `79588` (`353aa64b`). Diff hors #88 (déjà sur la base post-P0.11) :
+
+- Metro (`@SingleIn(AppScope)` / `@Inject`) à la place de `javax.inject`
+- `LTag.AIMI` à la place de `LTag.APS` (logs)
+- `NumberFormat` à la place de `"%.Nf".format` (logs)
+
+**Aucune** retouche de `h` / `lfh` / `lgh` / `safeU` / branches gamma. Le replay silencieux (`SilentLogger`) ne lit pas ces logs. `IAM` est le même blob.
+
+---
+
+## 4. Hors-scope respecté
+
+| Interdit P0.12 | Constat @ `838de62c7d` |
+|---|---|
+| P1.1 SMB `smbGiven` `6c0c0285ff` | Hors PR. Aucun symbole dans les 8 fichiers. |
+| P1.2 `DescentRedoseGuard` `fe96b64f12` | Hors PR. |
+| Advisor ZIP / dashboard / viewer Flutter | Aucun fichier UI / Advisor / staging. |
+| Remplacement `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin` / `AutodriveEngine` | Non. Blobs inchangés. |
+| Fixtures jour (`day_in_range` / rebound / hyper) | Non copiées. `load()` d’un jour absent **échoue** (nommé). |
+| `quality/ReplayQualityExport` | Non touché. README le distingue. |
+
+⚠️ ASYNC IMPACT : aucun. Harnais synchrone. `ControlBarrierShield.enforce` déjà synchrone. Pas de coroutine / Flow / callback. Callers production non touchés.
+
+---
+
+## 5. Adaptations KMP (câblage) vs divergences sémantiques
+
+| Sujet | Adaptation KMP | Divergence sémantique ? |
+|---|---|---|
+| Source set | `src/test` → `commonTest` | Non. |
+| Assertions | JUnit Jupiter → `kotlin.test` | Non. Mêmes 7 cas. |
+| JSON | `org.json.JSONObject` → kotlinx `JsonObject` | Non sur ce fixture (nombres / booléens). Parseurs study un peu plus tolérants (string→double, double→long) : **non exercé** par `barrier_ticks.jsonl`. |
+| Formatage rapport | `"%.1f".format` / `"%11.3f".format` → `NumberFormat` + pad | Non. Affichage seulement. |
+| Chargement fixture | `ClassLoader` → `BarrierTicksJsonl.TEXT` | Non. 72 lignes identiques au jsonl. |
+| Fixtures jour | Non portées. Test `dayFixturesAreNotBundledOnTheStudyTree` à la place de `dayFixturesPredateTheBarrierFieldsAndStayLoadable`. | Non. Hors lot annoncé. `load()` fail-closed. |
+| `loadLocal()` | `File` / `System.getenv` → `emptyMap()` | Non. Contrat « skip, jamais rien à reporter » conservé. |
+| README | `60` → `72` (le README `79588` disait encore 60 alors que le fichier avait 72) | Non. Aligné sur le fixture réel. |
+| Script | Chemin `commonTest/resources` | Non. `barrier()` / clés / subsample inchangés. |
+| Metro / `AimiJson` / tick | Non touchés. | — |
+
+**Aucune divergence sémantique** sur le lock. Les 3 misses permitted sont ceux de la ref, pas une adaptation KMP.
+
+---
+
+## 6. Caveats vs blockers
+
+### Blockers
+
+Aucun. Harnais = `79588`. Fixture byte-identique. Prod path intact. Hors-scope tenu. Tolérances identiques.
+
+### Caveats (suivre, ne bloquent pas le merge P0.12)
+
+1. **Double copie du fixture** — `barrier_ticks.jsonl` (humain / script) **et** `BarrierTicksJsonl.TEXT` (runtime Native). Les 72 ticks sont identiques aujourd’hui. Une régénération doit mettre à jour les deux, sinon le lock tourne sur l’embed.
+2. **`loadLocal()` no-op** — le corpus privé `AIMI_REPLAY_CORPUS` ne peut pas être lu depuis `commonTest`. Annoncé. Les callers doivent toujours traiter empty = skip.
+3. **Permitted 69/72 n’est pas un assert exact** — identique à `79588` (`>= 90 %` + println). Le corps du PR imprime 69 / 31.351 U / 43.913 U ; cette ancre **relit le code** qui produit ces chiffres. Elle n’a pas relancé Gradle (pas de `ANDROID_HOME` sur l’agent ancre).
+4. **CI GitHub #88** — `mergeable_state: unstable`, 0 status au moment de l’ancre. Ne juge pas ce diff.
+5. **Shield study ≠ blob `79588`** — Metro + `LTag.AIMI` + `NumberFormat` (déjà sur la base post-P0.11). Arithmétique `enforce` inchangée. Hors lot.
+
+---
+
+## 7. Checklist preuves
+
+- [x] PR #88 : 1 commit `838de62c7d`, 8 fichiers, +1441 / −0, base / parent `f9c086992e`
+- [x] `79588b42cb` relu (`BarrierReplay`, `BarrierReplayTest`, `ReplayTick`, `ReplayCorpus`, fixture, script, README)
+- [x] Fixture SHA-256 `b4539ea4…645fd` : `79588` ≡ #88 ; 72 lignes ; embed `BarrierTicksJsonl` = mêmes 72 ticks
+- [x] `REPRODUCTION_TOLERANCE = 1e-9` ; gamma `1e-12` ; `NOMINAL_GAMMA = 0.04` ; `TBR_TO_UNITS_PER_TICK = 12`
+- [x] `replayable` / `gammaDriver` / `PRODUCTION` / `UNFLOORED` / `flooredAtIsf` / `sameSafeU` / `close` identiques
+- [x] Tests : 72/72 `safe_u` + gamma assertés ; permitted ≥ 90 % (lock 69/72 de la ref)
+- [x] Aucun fichier prod dans le diff ; 7 blobs tick / shield / plugin / engine / IAM inchangés
+- [x] Aucun `smbGiven` / `DescentRedoseGuard` / Advisor dans les 8 fichiers
+- [x] Adaptations KMP listées ; pas de divergence sémantique sur le lock
+- [x] Script : seule ligne changée = chemin `commonTest/resources`
+
+---
+
+## 8. Recommandation
+
+| Action | Reco |
+|---|---|
+| **Merge #88** | **Oui** — harnais fidèle à `79588`, fixture byte-identique, prod path intact, hors-scope tenu. |
+| **Fix avant merge** | **Non** — pas de blocker clinique. |
+| **Suite** | P1.1 `smbGiven` `6c0c0285ff` / P1.2 `DescentRedoseGuard` `fe96b64f12` en lots séparés. Ne pas greffer Advisor / fixtures jour / corpus privé dans le même PR. |
+
+P0.11 (#86) a réécrit le plancher IAM **sans** le replay que les notes `controlCoefficient` / `recordCoefficientShadow` demandaient. P0.12 livre ce replay, **sans toucher la dose**. Le prochain lot qui retire le plancher 45, ou qui change `MPC_TAU_MIN`, n’est plus de l’arithmétique : c’est ce harnais qu’il faut relire.

--- a/_docs/kmp/README.md
+++ b/_docs/kmp/README.md
@@ -75,6 +75,7 @@ blueprint et ces annexes spécialisées font autorité sur `AIMI_KMP_MIGRATION_S
 4. [`w6-m1-read-registry.md`](w6-m1-read-registry.md) — freeze field and service-read inventory (W6, not a rewrite) ;
 5. [`w8-go-nogo.md`](w8-go-nogo.md) — W8 GO/NO-GO for empty AIMI KMP shells ;
 6. [`aimi-kmp-port-ledger.md`](aimi-kmp-port-ledger.md) — folder-by-folder AIMI port (Milos SMB pattern) ;
+6b. [`P0.12-ANCHOR.md`](P0.12-ANCHOR.md) — ancre P0.12 (#88) barrier replay harness vs `79588b42cb` ;
 7. annexe 6 pour le protocole Tree → Harmonia → RBT → safety ;
 8. annexe 5 pour les modèles et learners ;
 9. annexe 7 pour l'intégration iOS ;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre référence pour **PR #88 P0.12** (harnais barrier replay). Aucun changement clinique.

**Verdict : GO**

- Study HEAD #88 = `838de62c7d`
- Base study post-#86 = `f9c086992e`
- Source = `79588b42cb` (barrier replay harness) sur `origin/dev_OAPSAIMI`
- Fixture `barrier_ticks.jsonl` SHA-256 = `b4539ea42c143a5fb6e2fcad0692d90429f7e1f3d1aa3880191962a9270645fd` — **byte-identique** `79588` ↔ #88

Harnais `BarrierReplay` / `ReplayTick` / lock `safe_u` 72/72 @ 1e-9 + gamma 72/72 + permitted 69/72 (= ref). 8 fichiers tests/script. Prod path untouched (tick / `ControlBarrierShield` / plugin / engine / IAM blobs identiques base ↔ HEAD). Hors-scope tenu (pas `smbGiven` / `DescentRedoseGuard` / Advisor).

Livrable : [`_docs/kmp/P0.12-ANCHOR.md`](_docs/kmp/P0.12-ANCHOR.md)

### Reco

- **Merge #88** — oui (fidèle à `79588`, observation only).
- **Fix avant merge** — non.
- **Suite** — P1.1 `smbGiven` / P1.2 `DescentRedoseGuard` en lots séparés, pas ce PR.

## EN

Anchor review of PR #88. Docs only. Verdict **GO**. Fixture is the same SHA-256 as `79588b42cb`. Production files unchanged. Merge the barrier replay harness; do not pull smbGiven / DescentRedoseGuard / Advisor into the same lot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f1fcde-91af-4a65-aa15-b1f275765288?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f1fcde-91af-4a65-aa15-b1f275765288&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

