### PR TITLE
P1.1 — SMB train on smbGiven (6c0c)

### DIFF
--- a/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpusFileTest.kt
+++ b/plugins/aps/src/androidHostTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpusFileTest.kt
@@ -1,0 +1,113 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * File/store half of the `6c0c0285ff` corpus contract.
+ *
+ * The rewrite rule and the header guard are locked in commonTest
+ * ([AimiSmbCorpusGuardTest]). These tests cover the androidMain File wrapper and
+ * [AimiSmbModelStore.delete], which commonMain cannot see. No mocks.
+ *
+ * Dose-facing: deleting the weight file (and, on this study tree, its `.bak` / `.tmp` siblings)
+ * leaves `refine()` on the rule-based dose until a clean training run publishes new weights.
+ */
+class AimiSmbCorpusFileTest {
+
+    private val staleProductionHeader: List<String> = listOf(
+        "dateStr",
+        "bg",
+        "iob",
+        "cob",
+        "delta",
+        "shortAvgDelta",
+        "longAvgDelta",
+        "tdd7DaysPerHour",
+        "tdd2DaysPerHour",
+        "tddPerHour",
+        "tdd24HrsPerHour",
+        "predictedSMB",
+        "smbGiven",
+    )
+
+    private fun currentShapeRow(smbGiven: String = "0.0000"): String = listOf(
+        "09/07/2026 12:30",
+        "152", "1.2", "9.0", "3.5", "2.9", "1.7", "0.8", "0.7", "0.9", "1.0",
+        "0.4100", "0.9293", "0.9100", "0.6400",
+        "0.9000", "0.1800", "0.8400",
+        "0.8300", "0.1200", "0.7900",
+        "2", "4", "3", "1", "3",
+        "0.20", "0.10", "",
+        "0.15", smbGiven, "55", "7.0",
+        "0.1500", "0.0000", "governed", "harmonia", "148.0", "0.2000",
+    ).joinToString(",")
+
+    private fun legacyShapeRow(smbGiven: String = "0.3000"): String =
+        currentShapeRow(smbGiven = smbGiven).split(",").take(33).joinToString(",")
+
+    @Test
+    fun a_stale_header_is_replaced_in_place_and_every_data_row_is_kept(@TempDir dir: File) {
+        val file = File(dir, "oapsaimiML2_records.csv")
+        val dataRows = listOf(legacyShapeRow(), currentShapeRow())
+        file.writeText(staleProductionHeader.joinToString(", ") + "\n" + dataRows.joinToString("\n") + "\n")
+
+        val outcome = TrainingCsvHeader.ensureCurrent(file, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertThat(outcome).isEqualTo(TrainingCsvHeader.Outcome.REPLACED)
+        val lines = file.readLines()
+        assertThat(lines.first()).isEqualTo(SmbRefinementFeatureSchema.trainingCsvHeaderLine())
+        assertThat(lines.drop(1)).isEqualTo(dataRows)
+        assertThat(dir.listFiles()!!.map { it.name }).containsExactly("oapsaimiML2_records.csv")
+    }
+
+    @Test
+    fun a_current_header_is_left_alone(@TempDir dir: File) {
+        val file = File(dir, "oapsaimiML2_records.csv")
+        val content = SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n" + currentShapeRow() + "\n"
+        file.writeText(content)
+
+        val outcome = TrainingCsvHeader.ensureCurrent(file, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertThat(outcome).isEqualTo(TrainingCsvHeader.Outcome.ALREADY_CURRENT)
+        assertThat(file.readText()).isEqualTo(content)
+    }
+
+    @Test
+    fun a_missing_file_is_created_with_the_current_header(@TempDir dir: File) {
+        val file = File(dir, "oapsaimiML2_records.csv")
+
+        val outcome = TrainingCsvHeader.ensureCurrent(file, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertThat(outcome).isEqualTo(TrainingCsvHeader.Outcome.CREATED)
+        assertThat(file.readLines()).containsExactly(SmbRefinementFeatureSchema.trainingCsvHeaderLine())
+    }
+
+    @Test
+    fun deleting_the_weight_file_leaves_refine_on_the_rule_based_dose(@TempDir dir: File) {
+        val weights = AimiSmbModelStore.modelFile(dir)
+        weights.writeText("{}")
+        File(dir, weights.name + ".bak").writeText("{}")
+        assertThat(weights.exists()).isTrue()
+
+        assertThat(AimiSmbModelStore.delete(dir)).isTrue()
+
+        assertThat(weights.exists()).isFalse()
+        assertThat(File(dir, weights.name + ".bak").exists()).isFalse()
+        // With no model in memory, refine hands the rule-based dose back untouched.
+        val predictedSmb = 0.62f
+        assertThat(
+            AimiSmbTrainer.refine(
+                predictedSmb = predictedSmb,
+                features = FloatArray(SmbRefinementFeatureSchema.INPUT_SIZE) { 0f },
+            )
+        ).isEqualTo(predictedSmb)
+    }
+
+    @Test
+    fun deleting_an_absent_weight_file_reports_success(@TempDir dir: File) {
+        assertThat(AimiSmbModelStore.delete(dir)).isTrue()
+    }
+}

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/DetermineBasalAIMI2.kt
@@ -68,6 +68,8 @@ import app.aaps.plugins.aps.openAPSAIMI.model.DecisionResult
 import app.aaps.plugins.aps.openAPSAIMI.ml.AimiSmbTrainer
 import app.aaps.plugins.aps.openAPSAIMI.ml.SmbRefinementFeatureSchema
 import app.aaps.plugins.aps.openAPSAIMI.ml.SmbTrainingRowBuffer
+import app.aaps.plugins.aps.openAPSAIMI.ml.TrainingCsvHeader
+import app.aaps.plugins.aps.openAPSAIMI.ml.ensureCurrent
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorJsonlExport
 import app.aaps.plugins.aps.openAPSAIMI.advisor.auditor.AuditorVerdict
 import app.aaps.plugins.aps.openAPSAIMI.smb.MaxSmbLadder
@@ -13201,12 +13203,9 @@ class DetermineBasalaimiSMB2 @Inject constructor(
         val eventMemory = lastPatientState?.eventMemory ?: PatientEventMemory.EMPTY
         val decisionConflictFlags = physioAdapter.getLastDecisionTrace()?.decisionConflictFlags?.joinToString("|").orEmpty()
 
-        val headerRow =
-            "dateStr, ${SmbRefinementFeatureSchema.csvFeatureNames.joinToString(", ")}, " +
-                "${SmbRefinementFeatureSchema.familyAuditFeatureNames.joinToString(", ")}, " +
-                "${SmbRefinementFeatureSchema.optionalTrainingAuditFeatureNames.joinToString(", ")}, " +
-                "predictedSMB, smbGiven, dynamicPeak, adjustedDia, " +
-                "${SmbTrainingRowBuffer.ADDED_COLUMN_NAMES.joinToString(", ")}\n"
+        // One source of truth for the column order: the writer and the trainer read the same list.
+        // Building the header here by hand is what let the file on disk drift away from the rows.
+        val headerRow = SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n"
         val valuesToRecord = "$dateStr," +
             "$bg,$iob,$cob,$delta,$shortAvgDelta,$longAvgDelta," +
             "$tdd7DaysPerHour,$tdd2DaysPerHour,$tddPerHour,$tdd24HrsPerHour," +
@@ -13297,36 +13296,32 @@ class DetermineBasalaimiSMB2 @Inject constructor(
             file.createNewFile()
             file.appendText(headerRow)
         } else {
-            upgradeCsvHeaderIfColumnsWereAppended(file, headerRow)
+            ensureCsvHeaderIsCurrent(file, headerRow)
         }
         file.appendText(valuesRow + "\n")
     }
 
     /**
-     * Rewrites the first line of an existing CSV when new columns were appended to the header.
+     * Makes sure an existing CSV carries the header the writer builds today.
      *
-     * The header is only written when the file is created, so a file that already exists keeps its
-     * old header for ever. New rows would then carry cells that no reader can name, and both
-     * [app.aaps.plugins.aps.openAPSAIMI.ml.AimiSmbTrainer] and the offline analysis look columns up
-     * by name. The rewrite happens only when the stored header is the start of the wanted one, so a
-     * file with another shape is never touched. Old rows keep their shorter row on purpose: a cell
-     * that is not there reads as absent, never as zero.
+     * The rewrite itself, and why it is safe to replace the first line whatever its old shape, live in
+     * [app.aaps.plugins.aps.openAPSAIMI.ml.TrainingCsvHeader]. Here we only add the two things that
+     * belong to the running app: the file is checked once per path per app start, and any failure is
+     * logged and swallowed, because a header that could not be fixed must never stop a row from being
+     * written.
      *
-     * The file is read once per path per app start; after that the path is remembered and skipped.
-     * File I/O stays in androidMain on the existing writer — not a second store, not commonMain.
+     * ⚠️ ASYNC IMPACT: File I/O on the tick writer thread (same as the previous prefix-only upgrade).
+     * The path is remembered after the first check so later ticks do not re-read the whole CSV.
      */
-    private fun upgradeCsvHeaderIfColumnsWereAppended(file: File, headerRow: String) {
+    private fun ensureCsvHeaderIsCurrent(file: File, headerRow: String) {
         if (!csvHeaderCheckedPaths.add(file.absolutePath)) return
         runCatching {
-            val wanted = headerRow.trimEnd('\n')
-            val lines = file.readLines(Charsets.UTF_8)
-            val stored = lines.firstOrNull()?.trimEnd('\r') ?: return@runCatching
-            if (stored == wanted) return@runCatching
-            if (!wanted.startsWith("$stored,")) return@runCatching
-            file.writeText((listOf(wanted) + lines.drop(1)).joinToString("\n") + "\n", Charsets.UTF_8)
-            aapsLogger.info(LTag.APS, "CSV header extended in place for ${file.name}")
+            val outcome = TrainingCsvHeader.ensureCurrent(file, headerRow)
+            if (outcome == TrainingCsvHeader.Outcome.REPLACED) {
+                aapsLogger.info(LTag.APS, "CSV header replaced in place for ${file.name}")
+            }
         }.onFailure { error ->
-            aapsLogger.warn(LTag.APS, "CSV header upgrade skipped for ${file.name}: ${error.message}")
+            aapsLogger.warn(LTag.APS, "CSV header refresh skipped for ${file.name}: ${error.message}")
         }
     }
 

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbModelStore.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbModelStore.kt
@@ -19,4 +19,23 @@ internal object AimiSmbModelStore {
 
     fun load(dir: File, expectedInputSize: Int): AimiNeuralNetwork? =
         AimiNeuralModelStore.load(modelFile(dir), expectedInputSize)
+
+    /**
+     * Removes the stored SMB weights from [dir].
+     *
+     * Used when the weights are known to have been trained on the wrong column, so the engine falls
+     * back to the rule-based dose until a training run on a readable corpus publishes new weights.
+     * Deleting from here keeps the filename in one place; callers never build the path themselves.
+     *
+     * Study adaptation vs `6c0c0285ff`: the reference deleted only the target file. This store's
+     * [load] goes through [AimiNeuralModelStore.load], which would otherwise resurrect the same
+     * weights from the `.bak`. Delegating to [AimiNeuralModelStore.delete] removes target + siblings
+     * so the discard actually clears the model the next [load] would see.
+     *
+     * Returns `true` when no weight file is left behind, whether it was deleted now or already gone.
+     *
+     * ⚠️ ASYNC IMPACT: File I/O. Called from the trainer's IO coroutine after the corpus guard
+     * refuses the CSV; not on the `refine()` hot path.
+     */
+    fun delete(dir: File): Boolean = AimiNeuralModelStore.delete(modelFile(dir))
 }

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbTrainer.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbTrainer.kt
@@ -12,12 +12,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.math.abs
-import kotlin.math.exp
 import kotlin.math.min
-import kotlin.math.sqrt
 
 /**
  * AimiSmbTrainer — Singleton managing the ML model lifecycle for SMB refinement.
@@ -83,6 +81,9 @@ object AimiSmbTrainer {
     // Training rate limit
     private val lastTrainMs   = AtomicLong(0L)
     private val rowsAtLastTrain = AtomicLong(0L)
+
+    /** Set once the weights trained on an unreadable corpus have been thrown away. */
+    private val staleModelDiscarded = AtomicBoolean(false)
 
     // ---- Public API ----------------------------------------------------------
 
@@ -182,31 +183,15 @@ object AimiSmbTrainer {
         }
 
         val headers = allLines.firstOrNull()?.split(",")?.map { it.trim() } ?: return
-        val targetName = "smbGiven"
-        val targetIndex    = headers.indexOf(targetName)
-
-        if (targetIndex == -1) {
-            Log.w(TAG, "CSV missing required columns — skip training")
+        val headerCheck = AimiSmbCorpus.checkCorpusHeader(headers)
+        if (!headerCheck.valid) {
+            Log.e(TAG, "SMB corpus refused — no training. ${headerCheck.reason}")
+            discardModelTrainedOnUnreadableCorpus(dir)
             return
         }
-
-        val inputs  = mutableListOf<FloatArray>()
-        val targets = mutableListOf<DoubleArray>()
-
-        for (line in dataLines) {
-            val cols = line.split(",").map { it.trim() }
-            if (cols.size <= targetIndex) continue
-
-            val raw = SmbRefinementFeatureSchema.parseTrainingFeatures(headers, cols) ?: continue
-            if (!SmbRefinementFeatureSchema.shouldUseCsvRowForTraining(headers, cols, raw)) continue
-
-            // Approximate trendIndicator for offline training
-            val trendIndicator = computeTrendIndicator(raw)
-            val enhanced = raw.copyOf(raw.size + 1).also { it[raw.size] = trendIndicator }
-
-            targets.add(doubleArrayOf(cols[targetIndex].toDoubleOrNull() ?: continue))
-            inputs.add(enhanced)
-        }
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(headers, dataLines) ?: return
+        val inputs = corpus.inputs
+        val targets = corpus.targets
 
         if (inputs.size < 10) {
             Log.w(TAG, "Insufficient training samples (${inputs.size}) — skip")
@@ -251,19 +236,32 @@ object AimiSmbTrainer {
 
     // ---- Helpers -------------------------------------------------------------
 
-    private fun computeTrendIndicator(raw: FloatArray): Float {
-        // raw: [bg, iob, cob, delta, shortAvgDelta, longAvgDelta, ...]
-        val bg           = raw.getOrElse(0) { 120f }.toDouble()
-        val iob          = raw.getOrElse(1) { 0f }.toDouble()
-        val delta        = raw.getOrElse(3) { 0f }
-        val shortAvgDelta = raw.getOrElse(4) { 0f }
-        val longAvgDelta  = raw.getOrElse(5) { 0f }
-        val combinedDelta = (delta + shortAvgDelta + longAvgDelta) / 3f
-        val stressScore   = if (bg > 150) 40.0 else 0.0
-        val metabolicLoad = iob * 5.0
-        val baseTrend = (combinedDelta * 5.0f) + (stressScore * 0.1).toFloat() - (metabolicLoad * 0.5).toFloat()
-        val sig = (1f / (1f + exp(-baseTrend.toDouble()))).toFloat()
-        return 0.5f + sig * 0.7f
+    /**
+     * Throws away the stored SMB weights, once, after the corpus guard refused the file.
+     *
+     * The weights on disk were fitted against whatever column the stale header pointed at, so they
+     * answer in the wrong unit and `refine` keeps using them until a training run succeeds. Clearing
+     * [modelRef] and deleting the weight file sends `refine` back to returning `predictedSmb`
+     * unchanged, which is already what it does when no model is loaded.
+     *
+     * It runs at most once per app start: a corpus that stays unreadable must not turn into a delete
+     * on every tick.
+     *
+     * ⚠️ ASYNC IMPACT: runs on the existing `Dispatchers.IO` training coroutine (same as `trainNow`).
+     * `modelRef.set(null)` is visible to the hot-path `refine()`; the File delete is IO-only.
+     * `loadModel` is also fire-and-forget on that dispatcher — same pre-existing race as a training
+     * publish vs a plugin-start load.
+     */
+    private fun discardModelTrainedOnUnreadableCorpus(dir: File) {
+        if (!staleModelDiscarded.compareAndSet(false, true)) return
+        modelRef.set(null)
+        val removed = AimiSmbModelStore.delete(dir)
+        Log.w(
+            TAG,
+            "SMB weights discarded: they were trained on an unreadable corpus. " +
+                "Weight file removed=$removed. refine() now returns the rule-based dose until a " +
+                "training run on a readable corpus publishes new weights.",
+        )
     }
 
     internal fun correctionClamp(

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCsvHeaderFile.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCsvHeaderFile.kt
@@ -1,0 +1,25 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import java.io.File
+
+/**
+ * File half of [TrainingCsvHeader]: rewrite the first line of a CSV on disk.
+ *
+ * Lives in androidMain because the SMB training writer still uses `java.io.File` (P0.7 left File
+ * I/O on the tick). The rewrite rule itself is [TrainingCsvHeader.apply] in commonMain.
+ *
+ * Any I/O problem is thrown to the caller, which is expected to log it and carry on: a header that
+ * could not be fixed must never stop a row from being written.
+ */
+internal fun TrainingCsvHeader.ensureCurrent(file: File, headerLine: String): TrainingCsvHeader.Outcome {
+    val applied = if (!file.exists()) {
+        file.parentFile?.mkdirs()
+        TrainingCsvHeader.apply(null, headerLine)
+    } else {
+        TrainingCsvHeader.apply(file.readLines(Charsets.UTF_8), headerLine)
+    }
+    if (applied.outcome != TrainingCsvHeader.Outcome.ALREADY_CURRENT) {
+        file.writeText(applied.lines.joinToString("\n") + "\n", Charsets.UTF_8)
+    }
+    return applied.outcome
+}

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpus.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpus.kt
@@ -1,0 +1,112 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import kotlin.math.exp
+
+/**
+ * File-free SMB corpus reading: header guard and row → training sample.
+ *
+ * Extracted from `AimiSmbTrainer` (`origin/dev_OAPSAIMI` @ `6c0c0285ff`) so the contract can live
+ * in commonMain and be locked by commonTest (`kotlin.test`). The Android trainer still owns
+ * persistence, coroutines, and `refine()`. Formulas are copied as they were; none are invented.
+ */
+internal object AimiSmbCorpus {
+
+    /** The rows the trainer accepted, in the shape the training pipeline expects. */
+    data class TrainingCorpus(
+        val inputs: List<FloatArray>,
+        val targets: List<DoubleArray>,
+    )
+
+    /** Verdict on a stored header: whether the trainer may read the file, and why not when it may not. */
+    data class HeaderCheck(val valid: Boolean, val reason: String)
+
+    /**
+     * Checks a stored CSV header against [SmbRefinementFeatureSchema.trainingCsvColumnNames].
+     *
+     * The trainer looks its label up by name, so a header that lists fewer columns than the rows carry
+     * silently returns the index of another column. That is what happened in production: a 13 name
+     * header put `smbGiven` at index 12, where a real row holds `endogenousGlucoseDrive`, a score
+     * bounded by 1. The model then learned a hormonal score while believing it learned insulin units.
+     *
+     * The header is accepted only when `smbGiven` sits exactly where the schema puts it, and when every
+     * name up to and including it matches the schema. Columns after the label are not checked here:
+     * they are read by name with a bounds-safe lookup, so an older, shorter header stays usable.
+     */
+    fun checkCorpusHeader(headers: List<String>): HeaderCheck {
+        val expected = SmbRefinementFeatureSchema.trainingCsvColumnNames
+        val expectedTargetIndex = SmbRefinementFeatureSchema.targetColumnIndex
+        val foundTargetIndex = headers.indexOf(SmbRefinementFeatureSchema.TARGET_COLUMN_NAME)
+
+        if (foundTargetIndex != expectedTargetIndex) {
+            return HeaderCheck(
+                valid = false,
+                reason = "'${SmbRefinementFeatureSchema.TARGET_COLUMN_NAME}' expected at index " +
+                    "$expectedTargetIndex, found at index $foundTargetIndex " +
+                    "(stored header has ${headers.size} columns, schema has ${expected.size})",
+            )
+        }
+
+        for (index in 0..expectedTargetIndex) {
+            val stored = headers.getOrNull(index)
+            if (stored != expected[index]) {
+                return HeaderCheck(
+                    valid = false,
+                    reason = "column $index is '$stored', schema expects '${expected[index]}'",
+                )
+            }
+        }
+
+        return HeaderCheck(valid = true, reason = "")
+    }
+
+    /**
+     * Turns the stored header and data lines into a training corpus, or returns `null` when the
+     * corpus cannot be read safely.
+     *
+     * A row shorter than the header is kept: the schemas are nested, so an older row holds its cells
+     * under the right names and the columns it lacks read as absent. A row longer than the header is
+     * dropped, because it cannot be lined up with any column: the production file holds one such row,
+     * 65 fields wide, made of two writes that got interleaved.
+     */
+    fun buildTrainingCorpus(headers: List<String>, dataLines: List<String>): TrainingCorpus? {
+        val headerCheck = checkCorpusHeader(headers)
+        if (!headerCheck.valid) return null
+        val targetIndex = SmbRefinementFeatureSchema.targetColumnIndex
+
+        val inputs = mutableListOf<FloatArray>()
+        val targets = mutableListOf<DoubleArray>()
+
+        for (line in dataLines) {
+            val cols = line.split(",").map { it.trim() }
+            if (cols.size <= targetIndex) continue
+            if (cols.size > headers.size) continue
+
+            val raw = SmbRefinementFeatureSchema.parseTrainingFeatures(headers, cols) ?: continue
+            if (!SmbRefinementFeatureSchema.shouldUseCsvRowForTraining(headers, cols, raw)) continue
+
+            // Approximate trendIndicator for offline training (copied from AimiSmbTrainer).
+            val trendIndicator = computeTrendIndicator(raw)
+            val enhanced = raw.copyOf(raw.size + 1).also { it[raw.size] = trendIndicator }
+
+            targets.add(doubleArrayOf(cols[targetIndex].toDoubleOrNull() ?: continue))
+            inputs.add(enhanced)
+        }
+
+        return TrainingCorpus(inputs = inputs, targets = targets)
+    }
+
+    private fun computeTrendIndicator(raw: FloatArray): Float {
+        // raw: [bg, iob, cob, delta, shortAvgDelta, longAvgDelta, ...]
+        val bg           = raw.getOrElse(0) { 120f }.toDouble()
+        val iob          = raw.getOrElse(1) { 0f }.toDouble()
+        val delta        = raw.getOrElse(3) { 0f }
+        val shortAvgDelta = raw.getOrElse(4) { 0f }
+        val longAvgDelta  = raw.getOrElse(5) { 0f }
+        val combinedDelta = (delta + shortAvgDelta + longAvgDelta) / 3f
+        val stressScore   = if (bg > 150) 40.0 else 0.0
+        val metabolicLoad = iob * 5.0
+        val baseTrend = (combinedDelta * 5.0f) + (stressScore * 0.1).toFloat() - (metabolicLoad * 0.5).toFloat()
+        val sig = (1f / (1f + exp(-baseTrend.toDouble()))).toFloat()
+        return 0.5f + sig * 0.7f
+    }
+}

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbRefinementFeatureSchema.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbRefinementFeatureSchema.kt
@@ -71,6 +71,43 @@ internal object SmbRefinementFeatureSchema {
 
     val csvFeatureNames: List<String> = requiredTrainingFeatureNames + latentFeatureNames + modeFeatureNames + causalFeatureNames
 
+    /** Name of the column the SMB model is trained on: the dose that was really delivered. */
+    const val TARGET_COLUMN_NAME = "smbGiven"
+
+    /** Separator used between column names in the `oapsaimiML2_records.csv` header line. */
+    private const val HEADER_SEPARATOR = ", "
+
+    /**
+     * The ordered column names of `oapsaimiML2_records.csv`, as the writer lays them out.
+     *
+     * This is the single source of truth for the corpus shape. The writer builds its header line from
+     * [trainingCsvHeaderLine], and the trainer checks a stored header against this same list
+     * before it reads a single row. They used to be two separate lists, and they drifted: the file on
+     * disk kept a 13 name header while rows were written with 33, 38 and then 39 fields, so a lookup
+     * by name returned the index of another column.
+     *
+     * The trailing block comes from [SmbTrainingRowBuffer.ADDED_COLUMN_NAMES]. The buffer owns those
+     * names because it is the code that renders them, and the reference points this way to keep one
+     * direction only: the buffer never reads the schema back.
+     */
+    val trainingCsvColumnNames: List<String> = buildList {
+        add("dateStr")
+        addAll(csvFeatureNames)
+        addAll(familyAuditFeatureNames)
+        addAll(optionalTrainingAuditFeatureNames)
+        add("predictedSMB")
+        add(TARGET_COLUMN_NAME)
+        add("dynamicPeak")
+        add("adjustedDia")
+        addAll(SmbTrainingRowBuffer.ADDED_COLUMN_NAMES)
+    }
+
+    /** Index at which [TARGET_COLUMN_NAME] must sit in a header the trainer is willing to read. */
+    val targetColumnIndex: Int = trainingCsvColumnNames.indexOf(TARGET_COLUMN_NAME)
+
+    /** The header line of `oapsaimiML2_records.csv`, without the trailing line break. */
+    fun trainingCsvHeaderLine(): String = trainingCsvColumnNames.joinToString(HEADER_SEPARATOR)
+
     fun buildRuntimeFeatures(
         baseFeatures: FloatArray,
         trendIndicator: Float,

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCsvHeader.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCsvHeader.kt
@@ -1,0 +1,62 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+/**
+ * Keeps the first line of a training CSV equal to the header the writer builds today.
+ *
+ * The header used to be written only when the file was created, so a file that already existed kept
+ * its first header for ever. That is how `oapsaimiML2_records.csv` ended up with a 13 name header
+ * above rows of 33, 38 and then 39 fields: every reader that looks a column up by name then gets the
+ * index of another column, and the SMB model was trained on `endogenousGlucoseDrive` instead of
+ * `smbGiven`.
+ *
+ * The first line is replaced whenever it differs, with no condition on its old shape. This mirrors
+ * `BasalNeuralLearner.ensureCsvSchema`, which has done the same on the basal corpus from the start;
+ * the basal header never drifted, the SMB one did. It is safe because the SMB schemas are nested:
+ * new columns are only ever appended at the end, so each older header is an exact prefix of the newer
+ * one. An older, shorter data row therefore keeps every cell under the right name, and the columns it
+ * does not have are read as absent, never as zero. Data rows are never rewritten, moved or deleted.
+ *
+ * The rewrite rule itself is File-free so it can live in commonMain and be locked by commonTest.
+ * The File wrapper is `TrainingCsvHeader.ensureCurrent` in androidMain, which is what the tick
+ * writer calls.
+ */
+internal object TrainingCsvHeader {
+
+    /** What [apply] / [ensureCurrent] did to the header. */
+    enum class Outcome {
+        /** The file did not exist, or was empty, and now holds only the header. */
+        CREATED,
+
+        /** The first line was already the wanted header. */
+        ALREADY_CURRENT,
+
+        /** The first line was replaced; every data row was kept as it was. */
+        REPLACED,
+    }
+
+    /** Result of applying [headerLine] to the lines already stored (or to a missing file). */
+    data class Applied(
+        val outcome: Outcome,
+        val lines: List<String>,
+    )
+
+    /**
+     * Makes the first of [existingLines] equal to [headerLine], keeping every data row untouched.
+     *
+     * [existingLines] is `null` when the file does not exist. [headerLine] is taken without its
+     * line break. This is the File-free half of the reference `TrainingCsvHeader.ensureCurrent`.
+     */
+    fun apply(existingLines: List<String>?, headerLine: String): Applied {
+        val wanted = headerLine.trimEnd('\n')
+        if (existingLines == null || existingLines.isEmpty()) {
+            return Applied(outcome = Outcome.CREATED, lines = listOf(wanted))
+        }
+        if (existingLines.first().trimEnd('\r') == wanted) {
+            return Applied(outcome = Outcome.ALREADY_CURRENT, lines = existingLines)
+        }
+        return Applied(
+            outcome = Outcome.REPLACED,
+            lines = listOf(wanted) + existingLines.drop(1),
+        )
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpusGuardTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/AimiSmbCorpusGuardTest.kt
@@ -1,0 +1,220 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Proof and locks for the `oapsaimiML2_records.csv` corpus contract.
+ *
+ * The header of that file used to be written only when the file was created, so a device that started
+ * the file early kept a 13 name header while rows grew to 33, then 38, then 39 fields. The trainer
+ * looks its label up by name, so `indexOf("smbGiven")` returned 12, and column 12 of a real row is
+ * `endogenousGlucoseDrive`: a hormonal score bounded by 1, learned as if it were insulin units.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `6c0c0285ff`. Study source set: header names, the
+ * corpus guard, and the header-rewrite rule are commonMain with no File I/O, so the tests live in
+ * `commonTest` (`kotlin.test`) — same layout as [SmbTrainingRowBufferTest]. The File wrapper
+ * ([TrainingCsvHeader.ensureCurrent]) and [AimiSmbModelStore.delete] stay in androidMain; their
+ * contracts are locked here on the pure functions, plus a host test for the File/store path.
+ *
+ * These are locks on the training-correctness contract. One of them is dose-facing: discarding a
+ * model trained on an unreadable corpus makes `refine()` return the rule-based dose until a clean
+ * training run publishes new weights.
+ */
+class AimiSmbCorpusGuardTest {
+
+    /** The header measured on a production file: 13 names above rows of 33, 38 and 39 fields. */
+    private val staleProductionHeader: List<String> = listOf(
+        "dateStr",
+        "bg",
+        "iob",
+        "cob",
+        "delta",
+        "shortAvgDelta",
+        "longAvgDelta",
+        "tdd7DaysPerHour",
+        "tdd2DaysPerHour",
+        "tddPerHour",
+        "tdd24HrsPerHour",
+        "predictedSMB",
+        "smbGiven",
+    )
+
+    /** The header the writer builds today, as a list of names. */
+    private val currentHeader: List<String> = SmbRefinementFeatureSchema.trainingCsvColumnNames
+
+    /** One row of the current 39 column shape. Index 12 is `endogenousGlucoseDrive`, index 30 is the dose. */
+    private fun currentShapeRow(smbGiven: String = "0.0000", bg: String = "152"): String = listOf(
+        "09/07/2026 12:30",
+        bg, "1.2", "9.0", "3.5", "2.9", "1.7", "0.8", "0.7", "0.9", "1.0",
+        "0.4100", "0.9293", "0.9100", "0.6400",
+        "0.9000", "0.1800", "0.8400",
+        "0.8300", "0.1200", "0.7900",
+        "2", "4", "3", "1", "3",
+        "0.20", "0.10", "",
+        "0.15", smbGiven, "55", "7.0",
+        "0.1500", "0.0000", "governed", "harmonia", "148.0", "0.2000",
+    ).joinToString(",")
+
+    /** The same tick as it was written before the origin and outcome columns existed: 33 fields. */
+    private fun legacyShapeRow(smbGiven: String = "0.3000"): String =
+        currentShapeRow(smbGiven = smbGiven).split(",").take(33).joinToString(",")
+
+    // ---- FIX 1: one source of truth for the header ---------------------------
+
+    @Test
+    fun `header line is unchanged character for character`() {
+        val expected = "dateStr, bg, iob, cob, delta, shortAvgDelta, longAvgDelta, tdd7DaysPerHour, " +
+            "tdd2DaysPerHour, tddPerHour, tdd24HrsPerHour, mealProb, endogenousGlucoseDrive, " +
+            "circadianSiFactor, transientResistanceProb, patientModeMealBias, " +
+            "patientModeProtectionBias, contextIntentConfidence, causalMealConfidence, " +
+            "causalProtectiveConfidence, causalLearningQuality, familyProtectionLevel, " +
+            "familyMealLevel, familyStabilityLevel, familyPhysioLevel, familyAutonomyLevel, " +
+            "eventMemoryPostHyperExhaustionScore, eventMemoryCorrectionFragilityScore, " +
+            "decisionConflictFlags, predictedSMB, smbGiven, dynamicPeak, adjustedDia, smbModelU, " +
+            "smbFloorU, smbBindingStage, smbOriginOwner, bgRealisedAfter, smbMpcRequestedU"
+
+        assertEquals(expected, SmbRefinementFeatureSchema.trainingCsvHeaderLine())
+        assertEquals(39, currentHeader.size)
+        assertEquals(30, SmbRefinementFeatureSchema.targetColumnIndex)
+    }
+
+    @Test
+    fun `every older smb schema is an exact prefix of the current one`() {
+        // This is why the header may be replaced in place whatever its old shape: an older, shorter row
+        // keeps every cell under the right name. The stale 13 name header is not a schema at all — it
+        // never matched any row — which is why a prefix-only rewrite could never repair it.
+        val schema33 = currentHeader.take(33)
+        val schema38 = currentHeader.take(38)
+
+        assertEquals(schema33, currentHeader.subList(0, 33))
+        assertEquals(schema38, currentHeader.subList(0, 38))
+        assertNotEquals(staleProductionHeader, currentHeader.take(staleProductionHeader.size))
+    }
+
+    // ---- FIX 2: the trainer refuses a corpus it cannot read ------------------
+
+    @Test
+    fun `trainer refuses a corpus whose stored header puts smbGiven at the wrong index`() {
+        val row = currentShapeRow()
+        assertEquals(39, row.split(",").size)
+        // What the stale header makes the trainer believe, and what the row really holds there.
+        assertEquals(12, staleProductionHeader.indexOf("smbGiven"))
+        assertEquals("0.9293", row.split(",")[12])
+        assertEquals("0.0000", row.split(",")[30])
+
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(staleProductionHeader, listOf(row))
+
+        // The label the trainer would learn from. Before the guard it was 0.9293, the hormonal score.
+        assertNull(corpus?.targets?.singleOrNull()?.singleOrNull())
+        assertNull(corpus)
+    }
+
+    @Test
+    fun `header check names the expected and the found index`() {
+        val check = AimiSmbCorpus.checkCorpusHeader(staleProductionHeader)
+
+        assertFalse(check.valid)
+        assertTrue("expected at index 30" in check.reason)
+        assertTrue("found at index 12" in check.reason)
+    }
+
+    @Test
+    fun `a healthy corpus passes the guard and is read normally`() {
+        val check = AimiSmbCorpus.checkCorpusHeader(currentHeader)
+        assertTrue(check.valid)
+
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(currentHeader, listOf(currentShapeRow(smbGiven = "0.4500")))
+
+        assertNotNull(corpus)
+        assertEquals(0.45, corpus.targets.single().single(), 1e-9)
+        assertEquals(SmbRefinementFeatureSchema.INPUT_SIZE, corpus.inputs.single().size)
+    }
+
+    @Test
+    fun `a row wider than the header is dropped and the others are kept`() {
+        // Two writes that got interleaved: the production file holds exactly one such row, 65 fields wide.
+        val interleavedRow = currentShapeRow(smbGiven = "9.9999") + "," + currentShapeRow().split(",").take(26).joinToString(",")
+        assertEquals(65, interleavedRow.split(",").size)
+
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(
+            currentHeader,
+            listOf(currentShapeRow(smbGiven = "0.4500"), interleavedRow, legacyShapeRow(smbGiven = "0.3000")),
+        )
+
+        assertNotNull(corpus)
+        assertEquals(listOf(0.45, 0.30), corpus.targets.map { it.single() })
+    }
+
+    @Test
+    fun `a row shorter than the header is kept because the schemas are nested`() {
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(currentHeader, listOf(legacyShapeRow(smbGiven = "0.2500")))
+
+        assertNotNull(corpus)
+        assertEquals(0.25, corpus.targets.single().single(), 1e-9)
+    }
+
+    // ---- FIX 3: the header is made current whatever its old shape ------------
+
+    @Test
+    fun `a stale header is replaced in place and every data row is kept`() {
+        val dataRows = listOf(legacyShapeRow(), currentShapeRow())
+        val existing = listOf(staleProductionHeader.joinToString(", ")) + dataRows
+
+        val applied = TrainingCsvHeader.apply(existing, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertEquals(TrainingCsvHeader.Outcome.REPLACED, applied.outcome)
+        assertEquals(SmbRefinementFeatureSchema.trainingCsvHeaderLine(), applied.lines.first())
+        assertEquals(dataRows, applied.lines.drop(1))
+    }
+
+    @Test
+    fun `a current header is left alone`() {
+        val existing = listOf(SmbRefinementFeatureSchema.trainingCsvHeaderLine(), currentShapeRow())
+
+        val applied = TrainingCsvHeader.apply(existing, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertEquals(TrainingCsvHeader.Outcome.ALREADY_CURRENT, applied.outcome)
+        assertEquals(existing, applied.lines)
+    }
+
+    @Test
+    fun `a missing file is created with the current header`() {
+        val applied = TrainingCsvHeader.apply(null, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+
+        assertEquals(TrainingCsvHeader.Outcome.CREATED, applied.outcome)
+        assertEquals(listOf(SmbRefinementFeatureSchema.trainingCsvHeaderLine()), applied.lines)
+    }
+
+    @Test
+    fun `a replaced header makes every real row width readable again`() {
+        val dataRows = listOf(legacyShapeRow(smbGiven = "0.1000"), currentShapeRow(smbGiven = "0.2000"))
+        val existing = listOf(staleProductionHeader.joinToString(", ")) + dataRows
+
+        val applied = TrainingCsvHeader.apply(existing, SmbRefinementFeatureSchema.trainingCsvHeaderLine() + "\n")
+        val headers = applied.lines.first().split(",").map { it.trim() }
+        val corpus = AimiSmbCorpus.buildTrainingCorpus(headers, applied.lines.drop(1))
+
+        assertNotNull(corpus)
+        assertEquals(listOf(0.10, 0.20), corpus.targets.map { it.single() })
+    }
+
+    // ---- FIX 4 (common half): refine with no model is the rule-based dose ----
+
+    @Test
+    fun `an unreadable corpus does not produce a training label from the column next to smbGiven`() {
+        // Dose-facing documentation lock: the stale 13-name header would have trained on
+        // endogenousGlucoseDrive (index 12). After discard, refine() has no model and returns
+        // predictedSmb unchanged — the rule-based dose. This test holds the training-side half:
+        // the guard refuses that corpus so those weights are never published again.
+        val check = AimiSmbCorpus.checkCorpusHeader(staleProductionHeader)
+        assertFalse(check.valid)
+        assertEquals(30, SmbRefinementFeatureSchema.targetColumnIndex)
+        assertEquals(12, staleProductionHeader.indexOf(SmbRefinementFeatureSchema.TARGET_COLUMN_NAME))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P1.1 only**. Port de `origin/dev_OAPSAIMI` @ `6c0c0285ff` (`fix(aimi): train the SMB head on smbGiven, not on the column next to it`) sur la branche d’étude KMP.

### Ancres
- **Study base** = `kmp-aimi-migration-study` tip `70823d0d327bf778c872e7b80a5ea6843184b645` (post P0.12 — barrier replay harness)
- **Référence** = `origin/dev_OAPSAIMI` `6c0c0285ff802f778f0a9a04e2bdb39dcd28f0e5`
- **Hors périmètre** : P1.2 DescentRedoseGuard `fe96b64f12`, viewer Flutter, advisor ZIP, dashboard ; pas de remplacement wholesale de `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`

### Problème
Le CSV device portait un header de 13 noms au-dessus de lignes à 33 / 38 / 39 champs. `AimiSmbTrainer` résolvait le label avec `headers.indexOf("smbGiven")` → index 12, où une vraie ligne tient `endogenousGlucoseDrive` (score hormonal borné à 1). La tête apprenait ce score comme des unités d’insuline. Le garde-fou `cols.size <= targetIndex` ne déclenchait jamais (39 > 12). Le rewrite P0.7 était **préfixe seulement**, donc ce header 13 noms n’était jamais réparé.

### Ce qui change
- **Une source de vérité** : `SmbRefinementFeatureSchema.trainingCsvHeaderLine()` / `trainingCsvColumnNames` / `targetColumnIndex` (`smbGiven` à l’index 30). Writer et validateur lisent la même liste.
- **Garde de corpus** (`AimiSmbCorpus` en commonMain) : refuse d’entraîner si `smbGiven` n’est pas à l’index attendu. Lignes plus courtes que le header **conservées** (schémas emboîtés) ; lignes plus larges **jetées**.
- **Header réécrit** dès qu’il diffère (`TrainingCsvHeader.apply` / `ensureCurrent`), quel que soit l’ancien shape — plus seulement s’il est un préfixe. Aucune ligne de données touchée.
- **Discard** : `AimiSmbModelStore.delete` + `modelRef.set(null)` une fois par démarrage si le corpus est illisible.

### Note dose-facing (`refine()`)
**Oui, le chemin de dose peut changer**, et c’est le seul geste côté pompe de ce lot. Si un modèle a été publié depuis un corpus illisible, il est jeté : `refine()` n’a plus de réseau en mémoire et **renvoie `predictedSmb` inchangé** (dose règle) jusqu’à un entraînement propre. Rien n’est supprimé si le header est déjà valide. Adaptation study : delete passe par `AimiNeuralModelStore.delete` (cible + `.bak` / `.tmp`) pour que `load()` ne ressuscite pas les poids via le backup.

⚠️ **ASYNC IMPACT** : discard et rewrite fichier tournent sur le chemin IO existant (`Dispatchers.IO` pour le trainer ; writer CSV du tick pour le header). `refine()` reste O(1) et lit `AtomicReference`. Pas de nouvelle coroutine, pas de changement de formule clinique.

### Hors périmètre
P1.2, viewer, advisor, dashboard, seuil `shouldUseCsvRowForTraining` / `causalLearningQuality` 0.52 (mesuré en ref, volontairement non touché).

## EN

Lot **P1.1 only**. Port of `origin/dev_OAPSAIMI` @ `6c0c0285ff` onto the KMP study branch.

### Anchors
- **Study base** = `kmp-aimi-migration-study` tip `70823d0d327bf778c872e7b80a5ea6843184b645` (post P0.12)
- **Reference** = `6c0c0285ff802f778f0a9a04e2bdb39dcd28f0e5`
- **Out of scope**: P1.2 DescentRedoseGuard `fe96b64f12`, Flutter viewer, advisor ZIP, dashboard; no wholesale replace of tick / plugin

### What changed
- Schema-owned CSV header so the writer and the trainer cannot drift (`smbGiven` at index 30).
- Corpus guard refuses a header that puts `smbGiven` at the wrong index (the production 13-name header put it at 12 = `endogenousGlucoseDrive`).
- Header is replaced in place whenever it differs (P0.7 was prefix-only and could not repair that 13-name header). Data rows are never rewritten.
- Unreadable-corpus weights are discarded once per app start.

### Dose-facing note
**`refine()` can change.** Discarding an unreadable model is the only dose-facing gesture: with no model loaded, `refine()` returns the rule-based `predictedSmb` until a clean training run publishes new weights. Valid headers are not deleted. Study adaptation: SMB `delete` also removes `.bak`/`.tmp` so the shared store cannot resurrect the bad weights.

⚠️ **ASYNC IMPACT**: File I/O on the existing trainer IO coroutine and the tick CSV writer. `modelRef.set(null)` is visible to hot-path `refine()`. No new formulas.

### Evidence (fresh, this agent)
- `:plugins:aps:compileAndroidMain` + `:plugins:aps:compileKotlinIosSimulatorArm64` — **BUILD SUCCESSFUL in 2m 40s**
- `:plugins:aps:jvmTest` `AimiSmbCorpusGuardTest` — **12/12**, 0 fail
- `:plugins:aps:jvmTest` `SmbTrainingRowBufferTest` — **11/11**, 0 fail
- `:plugins:aps:testAndroidHostTest` `AimiSmbCorpusFileTest` — **5/5**, 0 fail (File `ensureCurrent`, store `delete` + `.bak`, `refine()` identity)
- iOS **compile** only on this Linux VM (`compileKotlinIosSimulatorArm64`); Native iOS test execution not available here

### GitHub CI on this PR (not a P1.1 regression)
- **iOS compile steps green** (`Compile the Apple targets` + assert klibs). Failure is `:ios:shell:iosSimulatorArm64Test` Gradle variant ambiguity (`:plugins:dexcom_oneplus` / `libkeks` / `libre3` debug vs release when `appshell` is pulled in). Same red on P0.8–P0.12 on `kmp-aimi-migration-study`. This job does **not** run `:plugins:aps:iosSimulatorArm64Test`.
- **claude-review**: `Invalid OIDC token` (action auth). Same on P0.12 #88. Not caused by this lot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dbb9305-694f-4efa-bebf-648f5b1f7d6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dbb9305-694f-4efa-bebf-648f5b1f7d6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

