### PR TITLE
docs(kmp): ancre P1.1 GO_WITH_CAVEATS — PR #90 (6c0c)

### DIFF
--- a/_docs/kmp/P1.1-ANCHOR.md
+++ b/_docs/kmp/P1.1-ANCHOR.md
@@ -1,0 +1,177 @@
+# Ancre P1.1 — SMB train on `smbGiven`
+
+> Date d’ancre : 2026-09-11  
+> Lot : **P1.1 only** — PR [#90](https://github.com/MTR93600/OpenApsAIMI/pull/90)  
+> **Verdict : GO_WITH_CAVEATS**  
+> Aucun changement clinique dans ce document. Relecture du code, pas d’invention.
+
+## SHA
+
+| Rôle | SHA | Preuve |
+|---|---|---|
+| Study base (base de PR #90) | `70823d0d327bf778c872e7b80a5ea6843184b645` | `kmp-aimi-migration-study` tip post P0.12 (#88) — `P0.12 — Barrier replay harness (79588)` |
+| PR #90 head | `67a34bdbadd141ee4f4d9c8bd7817283438ec771` | unique commit du PR |
+| Référence `dev_OAPSAIMI` | `6c0c0285ff802f778f0a9a04e2bdb39dcd28f0e5` | `fix(aimi): train the SMB head on smbGiven, not on the column next to it` |
+| Branche PR | `cursor/p11-smb-train-smb-given-7d6d` | 1 commit, +645/−64, **9 fichiers** (annoncé et mesuré) |
+
+## Verdict
+
+**GO_WITH_CAVEATS** — merger PR #90 sur `kmp-aimi-migration-study`.
+
+Le contrat clinique de `6c0c0285ff` est porté : header schema-owned, `smbGiven` à l’index **30**, garde de corpus, discard d’un modèle illisible → `refine()` rend la dose règle. Ce n’est **pas** un lot dose-neutre. Le caractère **ML mixed** est une caveat acceptée, pas un blocker. Aucune divergence sémantique inattendue sur le chemin ML. Hors-scope respecté.
+
+Ne pas classer **GO** (le discard est dose-facing, annoncé). Ne pas classer **NO_GO** (fidélité vs ref tenue ; l’adaptation `.bak` est plus stricte, pas plus faible).
+
+---
+
+## 1. Contenu réel de PR #90
+
+Mesuré `git diff --stat 70823d0d327bf778c872e7b80a5ea6843184b645 67a34bdbadd141ee4f4d9c8bd7817283438ec771` :
+
+```
+9 files changed, 645 insertions(+), 64 deletions(-)
+```
+
+Commit unique :
+
+```
+67a34bdbad P1.1 — train the SMB head on smbGiven, not on the column next to it
+```
+
+| Fichier | Statut | Rôle |
+|---|---|---|
+| `plugins/aps/src/commonMain/.../ml/SmbRefinementFeatureSchema.kt` | modified | `TARGET_COLUMN_NAME` / `trainingCsvColumnNames` / `targetColumnIndex` / `trainingCsvHeaderLine()` |
+| `plugins/aps/src/commonMain/.../ml/AimiSmbCorpus.kt` | added | garde + `buildTrainingCorpus` + `computeTrendIndicator` (File-free) |
+| `plugins/aps/src/commonMain/.../ml/TrainingCsvHeader.kt` | added | règle de rewrite (`apply`), File-free |
+| `plugins/aps/src/androidMain/.../ml/TrainingCsvHeaderFile.kt` | added | wrapper `java.io.File` → `ensureCurrent` |
+| `plugins/aps/src/androidMain/.../ml/AimiSmbTrainer.kt` | modified | appelle la garde, discard once-per-start |
+| `plugins/aps/src/androidMain/.../ml/AimiSmbModelStore.kt` | modified | `delete(dir)` |
+| `plugins/aps/src/androidMain/.../DetermineBasalAIMI2.kt` | modified | header writer + rewrite (CSV **uniquement**) |
+| `plugins/aps/src/commonTest/.../ml/AimiSmbCorpusGuardTest.kt` | added | 12 locks commonMain |
+| `plugins/aps/src/androidHostTest/.../ml/AimiSmbCorpusFileTest.kt` | added | 5 locks File / store / `refine()` identité |
+
+`DetermineBasalAIMI2.kt` : **uniquement** le writer CSV (`headerRow` + `ensureCsvHeaderIsCurrent`). L’appel `AimiSmbTrainer.refine(...)` (l.15496 du tree d’étude) **n’est pas dans le diff**.
+
+Réf `6c0c0285ff` : 6 fichiers, +479/−48, même geste, corpus inline dans `AimiSmbTrainer` (pas d’objet `AimiSmbCorpus`).
+
+---
+
+## 2. Tableau items + preuves
+
+| # | Item | Statut | Preuve SHA |
+|---|---|---|---|
+| 1 | Header schema-owned, une liste | **Aligné** | `67a34bdb` `SmbRefinementFeatureSchema.trainingCsvColumnNames` = `dateStr` + `csvFeatureNames` + family + optional + `predictedSMB` + `smbGiven` + `dynamicPeak` + `adjustedDia` + `SmbTrainingRowBuffer.ADDED_COLUMN_NAMES`. Writer tick : `trainingCsvHeaderLine() + "\n"`. Identique à `6c0c0285ff` (seule diff : un mot de KDoc, `AimiSmbTrainer` → « the trainer »). |
+| 2 | `smbGiven` @ col **30** | **Aligné** | Comptage des listes : 39 colonnes ; index 30 = `smbGiven` ; index 12 = `endogenousGlucoseDrive`. Test `header line is unchanged character for character` locke `targetColumnIndex == 30` et la ligne 39 noms. Header prod 13 noms : `indexOf("smbGiven") == 12`. |
+| 3 | Garde corpus | **Aligné** | `AimiSmbCorpus.checkCorpusHeader` (`67a34bdb`) **byte-identique** à `AimiSmbTrainer.checkCorpusHeader` (`6c0c0285ff`) : refuse si `smbGiven` n’est pas à `targetColumnIndex` ; vérifie les noms `0..expectedTargetIndex`. |
+| 4 | Lignes courtes gardées / larges jetées | **Aligné** | `cols.size <= targetIndex` → skip ; `cols.size > headers.size` → skip ; sinon parse + `shouldUseCsvRowForTraining`. Formule `computeTrendIndicator` identique (sigmoid 0.5 + sig·0.7). |
+| 5 | Rewrite header, toute forme | **Aligné** | `TrainingCsvHeader.apply` remplace la 1re ligne dès qu’elle diffère ; **aucune ligne de données touchée**. P0.7 prefix-only (`wanted.startsWith("$stored,")`) retiré du tick. Wrapper File : même I/O que la ref (`mkdirs` si absent, pas d’écriture si `ALREADY_CURRENT`). |
+| 6 | Discard modèle illisible → dose règle | **Aligné (intent)** | `discardModelTrainedOnUnreadableCorpus` : `staleModelDiscarded.compareAndSet(false,true)` ; `modelRef.set(null)` ; `AimiSmbModelStore.delete(dir)`. Corps de fonction identique à la ref. `refine()` **byte-identique** : `modelRef.get() ?: return predictedSmb`. |
+| 7 | `refine()` callers / formule | **Inchangé hors discard** | Call site tick non modifié. Clamp `min(0.05U, 25%)` inchangé. Circuit breaker inchangé. |
+| 8 | Seuil `shouldUseCsvRowForTraining` / `causalLearningQuality` 0.52 | **Non touché (volontaire)** | `shouldUseForTraining` / `shouldUseCsvRowForTraining` / `parseTrainingFeatures` **IDENTICAL** ref vs PR. `learningQuality >= 0.52f && protectiveConfidence < 0.86f` intact. |
+| 9 | Hors-scope P1.2 / Advisor / UI | **Respecté** | Diff 9 fichiers, tous `openAPSAIMI/ml/` + writer CSV du tick. Pas de `DescentRedoseGuard`, pas d’Advisor, pas d’UI, pas de remplacement wholesale plugin/tick. |
+| 10 | Adaptation delete `.bak` / `.tmp` | **Caveat (plus strict)** | Ref `AimiSmbModelStore.delete` : `file.delete()` sur la cible seule. Study : `AimiNeuralModelStore.delete` = cible + `.bak` + `.tmp`. Justifié : `load()` de ce tree ressuscite depuis `.bak`. Test host locke `.bak` absent. |
+
+---
+
+## 3. Fidélité clinique vs `6c0c0285ff`
+
+### Ce que la ref corrige (relu, pas inventé)
+
+CSV device : header **13 noms** au-dessus de lignes 33 / 38 / 39 champs. `headers.indexOf("smbGiven")` → 12, où une vraie ligne tient `endogenousGlucoseDrive` (score hormonal borné à 1). Garde `cols.size <= targetIndex` inerte (39 > 12). Rewrite P0.7 **préfixe seulement** : ce header 13 noms n’est pas un préfixe du header 39, donc jamais réparé.
+
+### Mapping ref → study
+
+| Symbole ref (`src/main`) | Symbole study | Égalité |
+|---|---|---|
+| `SmbRefinementFeatureSchema.trainingCsv*` | même objet `commonMain` | fonctions cliniques identiques |
+| `AimiSmbTrainer.checkCorpusHeader` | `AimiSmbCorpus.checkCorpusHeader` | identique |
+| `AimiSmbTrainer.buildTrainingCorpus` | `AimiSmbCorpus.buildTrainingCorpus` | identique (log `Log.e` retiré du build : déjà logué dans `trainNow`) |
+| `AimiSmbTrainer.computeTrendIndicator` | `AimiSmbCorpus.computeTrendIndicator` | identique |
+| `AimiSmbTrainer.refine` | même | identique |
+| `AimiSmbTrainer.discardModel…` | même | identique |
+| `TrainingCsvHeader.ensureCurrent(File)` | `apply` + `TrainingCsvHeaderFile.ensureCurrent` | même règle |
+| `DetermineBasalaimiSMB2` header writer | même | même substitution `trainingCsvHeaderLine()` |
+
+### Chemin dose-facing
+
+1. Tick appelle `maybeTrainAsync` (IO, existant) **puis** `refine` (O(1), `AtomicReference`).
+2. Si le CSV est illisible **et** que `trainNow` passe les gates 6 h / 200 lignes : garde refuse, discard once, `modelRef = null`.
+3. Le `refine()` **du même tick** peut encore voir l’ancien modèle (discard sur `Dispatchers.IO`). Les ticks suivants : pas de réseau → `predictedSmb` inchangé (dose règle).
+4. Header déjà valide : **rien n’est supprimé**.
+
+C’est le même geste que `6c0c0285ff`. ⚠️ **ASYNC IMPACT** : I/O trainer + writer CSV ; `modelRef.set(null)` visible du hot path. Pas de nouvelle coroutine, pas de nouvelle formule.
+
+---
+
+## 4. Adaptations KMP vs divergences sémantiques
+
+| Adaptation | Type | Dose-facing ? |
+|---|---|---|
+| Corpus + rewrite extraits en `commonMain` (File-free) ; tests `kotlin.test` | KMP | Non — mêmes formules |
+| Wrapper File `androidMain` (`TrainingCsvHeaderFile`) | KMP | Non — même rewrite |
+| Tests File/store en `androidHostTest` (Truth/JUnit) | KMP | Non |
+| `AimiSmbModelStore.delete` → `AimiNeuralModelStore.delete` (cible + `.bak` + `.tmp`) | Study vs ref | **Oui, plus complet** : empêche `load()` de ressusciter les poids via `.bak`. Intent discard respecté, pas une sous-délétion |
+| KDoc ⚠️ ASYNC IMPACT | Doc | Non |
+
+Pas de divergence sémantique **inattendue**. La seule différence dose-facing vs ref va dans le sens du discard (plus étanche).
+
+---
+
+## 5. Caveats vs blockers
+
+### Caveats (acceptées — ne bloquent pas le merge)
+
+1. **ML mixed / dose-facing (le lot)** — un modèle publié sur corpus illisible est jeté ; `refine()` retombe sur la dose règle jusqu’à un train propre. Annoncé dans `6c0c0285ff` et dans le body PR #90. Ce n’est pas un P0 observation-only.
+2. **Fenêtre avant discard** — `trainNow` ne lit la garde **après** `MIN_NEW_ROWS_TO_RETRAIN = 200` et le rate-limit 6 h. `loadModel` au start peut donc servir un mauvais modèle jusqu’au premier `trainNow` éligible. Identique à la ref.
+3. **Course `loadModel` vs discard** — les deux sont fire-and-forget sur `Dispatchers.IO`. Documenté dans le KDoc study ; même race préexistante qu’un publish vs load. L’adaptation `.bak` réduit la résurrection **disque**, pas la course mémoire.
+4. **Filtre 0.52 devient vivant** — une fois le header réparé, `shouldUseCsvRowForTraining` n’est plus inerte (les noms causal/family existent). Seuil **non modifié** (note mesurée de la ref : ~631/2999 lignes). À ne pas retoucher dans un lot suivant sans corpus lisible.
+5. **CI iOS job rouge, héritée** — `iosSimulatorArm64Test` via `:ios:shell` : variants ambigus `:plugins:dexcom_oneplus` / `libkeks` / `libre3`. Confirmé sur les runs PR #90 (`34570347072`, `34570327171`). Même classe d’échec que P0.8–P0.12. Ce job **ne** lance **pas** `:plugins:aps:iosSimulatorArm64Test`. `claude-review` : OIDC invalide (même #88).
+6. **Host File tests non rejoués dans cette ancre** — pas d’`ANDROID_HOME` sur le pod d’ancre. Les 5 tests `AimiSmbCorpusFileTest` sont lus ; exécution = preuve de l’agent PR #90, pas de cette ancre.
+
+### Blockers
+
+**Aucun.** Pas de divergence de label, pas de formule inventée, pas de fuite hors-scope.
+
+---
+
+## 6. Checklist preuves
+
+| Preuve | Résultat | Qui |
+|---|---|---|
+| Diff PR vs base = 9 fichiers, +645/−64, 1 commit `67a34bdb` | OK | ancre, `git diff --stat` |
+| Head / base / ref SHA ci-dessus | OK | `git rev-parse` + `git cat-file` |
+| `smbGiven` index 30, col 12 = `endogenousGlucoseDrive`, header 39 noms | OK | comptage listes + test lock |
+| `checkCorpusHeader` / `buildTrainingCorpus` / `computeTrendIndicator` / `refine` identiques à `6c0c0285ff` | OK | diff symboles |
+| `shouldUseCsvRowForTraining` + `0.52f` non touchés | OK | diff fonctions IDENTICAL |
+| Hors-scope : pas DescentRedose / Advisor / UI dans le diff | OK | `git diff --name-only` |
+| `:plugins:aps:jvmTest` `AimiSmbCorpusGuardTest` | **12/12**, 0 fail, 0 err, 0 skip | ancre, 2026-09-11, HEAD `67a34bdb` — XML `plugins/aps/build/test-results/jvmTest/TEST-…AimiSmbCorpusGuardTest.xml` |
+| `:plugins:aps:jvmTest` `SmbTrainingRowBufferTest` (fichier **hors** PR, lock P0.7) | **11/11**, 0 fail | ancre, même run, `BUILD SUCCESSFUL in 1m 26s` |
+| `:plugins:aps:testAndroidHostTest` `AimiSmbCorpusFileTest` | **5/5** déclaré PR #90 ; **non rejoué** ici (SDK Android absent) | agent PR + relecture |
+| `compileAndroidMain` + `compileKotlinIosSimulatorArm64` | déclaré PR #90 BUILD SUCCESSFUL in 2m 40s ; **non rejoué** ici | agent PR |
+| CI GitHub iOS rouge = variants appshell, pas régression P1.1 | OK | logs `dexcom_oneplus` / `libkeks` / `libre3` |
+
+---
+
+## 7. Reco (merge / fix / suite)
+
+1. **Merge** PR #90 sur `kmp-aimi-migration-study`. Ne pas attendre le job iOS `:ios:shell` (dette study, pas P1.1).
+2. **Pas de fix clinique** demandé. Ne pas « corriger » le seuil 0.52 dans la foulée. Ne pas élargir au tick/plugin.
+3. **Suite** : P1.2 DescentRedoseGuard `fe96b64f12` **lot séparé**. Ne pas tirer viewer / advisor ZIP / dashboard.
+4. **Opérationnel post-merge** : traiter comme ML mixed — un device au header 13 noms passera en dose règle dès le discard, puis réapprendra sur `smbGiven` @ 30 après rewrite + train propre. Surveiller que `load()` ne ramène pas de poids (couvert par delete + `.bak` sur ce tree).
+5. **Cette ancre** : doc-only ; ne pas rebase `dev_OAPSAIMI` dans le lot.
+
+---
+
+## 8. Hors-scope (rappel)
+
+- P1.2 `DescentRedoseGuard` `fe96b64f12`
+- Viewer Flutter, advisor ZIP, dashboard
+- Remplacement wholesale `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`
+- Seuil `shouldUseCsvRowForTraining` / `causalLearningQuality` 0.52
+- Harnais barrier P0.12 (déjà mergé #88)
+
+---
+
+## 9. ⚠️ ASYNC IMPACT (flag ML)
+
+Discard + rewrite fichier : chemin IO existant (`Dispatchers.IO` trainer ; writer CSV du tick). `refine()` reste O(1) et lit `AtomicReference`. `modelRef.set(null)` est visible du hot path. Pas de nouvelle coroutine. Pas de changement de formule clinique. Course `loadModel` vs discard = préexistante, identique à `6c0c0285ff`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre **P1.1** pour [PR #90](https://github.com/MTR93600/OpenApsAIMI/pull/90). Doc-only (`_docs/kmp/P1.1-ANCHOR.md`). **Aucun changement clinique.**

### Verdict : **GO_WITH_CAVEATS**

Merger PR #90. Le contrat `6c0c0285ff` est tenu (`smbGiven` schema-owned @ col 30, garde corpus, discard modèle illisible → `refine()` dose règle). Le caractère **ML mixed** est une caveat, pas un blocker. Pas de divergence sémantique inattendue. Hors-scope (P1.2 / Advisor / UI) respecté.

### SHA

| Rôle | SHA |
|---|---|
| Study base | `70823d0d327bf778c872e7b80a5ea6843184b645` |
| PR #90 head | `67a34bdbadd141ee4f4d9c8bd7817283438ec771` |
| Ref `dev_OAPSAIMI` | `6c0c0285ff802f778f0a9a04e2bdb39dcd28f0e5` |

### Reco

1. Merge PR #90 (ne pas bloquer sur le job iOS `:ios:shell`, dette study héritée).
2. Pas de fix clinique. Ne pas toucher le seuil `causalLearningQuality` 0.52.
3. Suite = P1.2 DescentRedoseGuard `fe96b64f12`, lot séparé.

Preuves relues dans le fichier d’ancre (12+11 jvmTest rejoués ici sur `67a34bdb` ; host File 5/5 non rejoués — pas d’Android SDK sur ce pod).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02349297-7edc-4847-82a3-921f794787b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02349297-7edc-4847-82a3-921f794787b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

