### PR TITLE
docs(kmp): ancre P1.2 GO_WITH_CAVEATS — PR #92 (fe96)

### DIFF
--- a/_docs/kmp/P1.2-ANCHOR.md
+++ b/_docs/kmp/P1.2-ANCHOR.md
@@ -1,0 +1,182 @@
+# Ancre P1.2 — DescentRedoseGuard (`fe96`)
+
+> Date d’ancre : 2026-09-11  
+> Lot : **P1.2 only** — PR [#92](https://github.com/MTR93600/OpenApsAIMI/pull/92)  
+> **Verdict : GO_WITH_CAVEATS**  
+> Aucun changement clinique dans ce document. Relecture du code, pas d’invention.
+
+## SHA
+
+| Rôle | SHA | Preuve |
+|---|---|---|
+| Study base (base de PR #92) | `55f832d2eb3eddc132fd91b8c9a11f8b4cb2ce6f` | `kmp-aimi-migration-study` tip post P1.1 (#90) — `P1.1 — SMB train on smbGiven (6c0c)` |
+| PR #92 head | `addc772738c26b154fa06f24d3d57f20e7868a73` | unique commit du PR |
+| Référence `origin/dev_OAPSAIMI` | `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc` | `feat: add DescentRedoseGuard to prevent bolus re-dosing during descents` |
+| Branche PR | `cursor/p12-descent-redose-guard-1ca8` | 1 commit, **+775 / 6 fichiers** (annoncé et mesuré) |
+
+## Verdict
+
+**GO_WITH_CAVEATS** — merger PR #92 sur `kmp-aimi-migration-study`.
+
+Le contrat clinique de `fe96b64f12` est porté : cinq conditions verrouillées, export `baseline_state` **toujours**, dose bolus **seulement** si `OApsAIMIDescentRedoseGuard` est on, défaut **false** = ombre. Canal basal / TBR intact. Hors-scope respecté. Aucune divergence sémantique inattendue.
+
+Ne pas classer **GO** : le lot est **mixed** (ombre par défaut, chemin dose réel derrière l’opt-in). C’est une caveat acceptée, pas un blocker. Ne pas classer **NO_GO** : fidélité vs ref tenue ; le défaut ne dose pas.
+
+---
+
+## 1. Contenu réel de PR #92
+
+Mesuré `git diff --stat 55f832d2eb3eddc132fd91b8c9a11f8b4cb2ce6f addc772738c26b154fa06f24d3d57f20e7868a73` :
+
+```
+6 files changed, 775 insertions(+)
+```
+
+Commit unique :
+
+```
+addc772738 P1.2 — DescentRedoseGuard to prevent bolus re-dosing during descents (fe96)
+```
+
+| Fichier | Statut | Rôle |
+|---|---|---|
+| `plugins/aps/src/commonMain/.../smb/DescentRedoseGuard.kt` | added (285) | objet pur ; `evaluate` + `shouldWithhold` |
+| `plugins/aps/src/commonTest/.../smb/DescentRedoseGuardTest.kt` | added (400) | 23 locks `kotlin.test` (mêmes noms que la ref) |
+| `plugins/aps/src/androidMain/.../DetermineBasalAIMI2.kt` | modified (+69) | champs export + `evaluateDescentRedoseGuard` + câblage sortie SMB |
+| `plugins/aps/src/androidMain/.../OpenAPSAIMIPlugin.kt` | modified (+1) | ligne pref écran Autodrive compose |
+| `core/keys/src/commonMain/.../BooleanKey.kt` | modified (+18) | `OApsAIMIDescentRedoseGuard`, `defaultValue = false` |
+| `core/keys/src/androidMain/res/values/strings.xml` | modified (+2) | title + summary (texte identique à la ref) |
+
+Réf `fe96b64f12` : **les mêmes 6 chemins**, layout Android `src/main` / `src/test` au lieu de `commonMain` / `commonTest` / `androidMain`. Pas d’autre fichier.
+
+Lecteurs des symboles sur `addc772738` : uniquement ces 6 fichiers. Rien d’autre ne lit `descent_redose_guard_*` ni `DescentRedoseGuard`.
+
+---
+
+## 2. Tableau items + preuves
+
+| # | Item | Statut | Preuve SHA |
+|---|---|---|---|
+| 1 | Logique `DescentRedoseGuard` (5 conditions, seuils, tokens) | **Aligné** | `addc772738` vs `fe96b64f12` : `WINDOW_MINUTES=120`, `PEAK_MIN_MGDL=180`, `PEAK_AGE_MINUTES=30`, `DROP_MGDL=25`, `IOB_MIN_U=6`, `REBOUND_MGDL=25`, `MAX_GAP_MINUTES=10`. `when` identique (`<` sur a–d, `>` sur e). Pic = dernier max du plateau. `usableWindow` coupe au premier trou > 10 min. `shouldWithhold = block && armed && !isExplicitUserAction && proposedUnits > 0.0` **byte-identique**. |
+| 2 | Export always (`baseline_state`) | **Aligné** | Tick : `evaluateDescentRedoseGuard()` **avant** `shouldWithhold`. Écrit `descent_redose_guard_would_block`, `_reason`, et `_withheld_u` **si** `verdict.block` (même si pref off). JSON : trois `base.put(...)` après `autodrive_gate_*`. Identique à `fe96b64f12` (seul `AimiJson.NULL` vs `org.json.JSONObject.NULL` = pattern study préexistant). |
+| 3 | Dose seulement si pref on | **Aligné** | `armed = preferences.get(BooleanKey.OApsAIMIDescentRedoseGuard)`. Pref off → `shouldWithhold` false → **aucun** write `finalUnits` / console / `rT.reason`. Tests `with the key off…` / `with the key on…` lockent le couple. |
+| 4 | Défaut ombre (`false`) | **Aligné** | `BooleanKey.OApsAIMIDescentRedoseGuard(key = "key_aimi_descent_redose_guard", defaultValue = false)`. Pas de `dependency`. Identique à `fe96b64f12`. |
+| 5 | Canal bolus seulement | **Aligné** | Diff tick : uniquement `finalUnits = 0.0` dans le `if (shouldWithhold)`. Aucun `rate` / TBR / basal. Placement : après effort SMB, avant charge SlowCarbMeal — même site que la ref. |
+| 6 | Filtre lectures (bucketed) | **Aligné** | `evaluateDescentRedoseGuard()` : `getBucketedDataTableCopy()`, skip `value <= 39 \|\| filledGap`, `Reading(timestamp, recalculated)`, `nowMs = dateUtil.now()`, `iobU = this.iob.toDouble()`. Corps identique à `fe96b64f12`. |
+| 7 | Action utilisateur jamais retenue | **Aligné** | `!isExplicitUserAction` dans `shouldWithhold`. Test `a user-initiated bolus is never withheld even with the key on`. |
+| 8 | Hors-scope Advisor / UI / P2 | **Respecté** | Diff 6 fichiers. Pas de viewer Flutter, advisor ZIP, dashboard AIMI home, Garmin re-grid. Plugin : **+1 ligne** dans `aimiComposeAutodriveSubScreen()` (même écran que la ref). Pas de remplacement wholesale tick/plugin. |
+| 9 | Tests 23/23, mêmes cas | **Aligné** | 23 `@Test`, **mêmes noms** que `fe96b64f12`. Assertions Truth → `kotlin.test`. Épisodes 08/09 et 09/09, un cas par condition, armement shadow vs dose. Rejoué ici (voir checklist). |
+
+---
+
+## 3. Fidélité clinique vs `fe96b64f12`
+
+### Ce que la ref fait (relu, pas inventé)
+
+Garde d’**épisode**, pas un test instantané « BG chute ». Cinq conditions simultanées :
+
+1. **(a)** pic ≥ 180 mg/dL dans 120 min  
+2. **(b)** âge du pic ≥ 30 min  
+3. **(c)** chute depuis le pic ≥ 25 mg/dL  
+4. **(d)** IOB ≥ 6 U (`iobU < 6.0` échoue ; **6.0 pile bloque** — locké par `exactly on each threshold`)  
+5. **(e)** rebond depuis le trough ≤ 25 mg/dL (`rebound > 25` = nouvelle montée)
+
+Mesure (`evaluate`) séparée de l’actuation (`shouldWithhold`). Export même quand la pref est off. Bolus auto seulement ; basal intact.
+
+### Mapping ref → study
+
+| Symbole ref (`src/main`) | Symbole study | Égalité |
+|---|---|---|
+| `object DescentRedoseGuard` | `internal object` `commonMain` | formules / seuils / tokens identiques |
+| `String.format(Locale.US, …)` | `aimiFmt0` / `aimiFmt1` / `aimiFmt2` | **raison texte seulement** (voir caveat 3) |
+| `evaluate` / `usableWindow` / `empty` / `shouldWithhold` | mêmes | identiques hors format |
+| `BooleanKey.OApsAIMIDescentRedoseGuard` `defaultValue=false` | `commonMain` + `KeysStrings` | clé + défaut identiques |
+| strings title/summary | `androidMain` `strings.xml` | texte **identique** |
+| `evaluateDescentRedoseGuard` + câblage sortie SMB | `androidMain` tick | identique |
+| `aimiComposeAutodriveSubScreen` +1 key | même | identique |
+| tests Truth/JUnit `src/test` | `commonTest` `kotlin.test` | 23/23 mêmes noms, mêmes chiffres 08/09 et 09/09 |
+
+### Chemin dose-facing
+
+1. Tick atteint la sortie SMB universelle (après effort).  
+2. `evaluate()` **toujours** (copie bucketed déjà utilisée par `minBgInLastMinutes`).  
+3. Export `baseline_state` **toujours**. `_withheld_u` = `finalUnits` **proposés** si `block`, même en ombre (mesure « would withhold », identique à la ref).  
+4. `shouldWithhold` : si pref **off** → no-op dose. Si pref **on** + block + pas d’action user + `finalUnits > 0` → `finalUnits = 0.0`.  
+5. Basal / TBR non lus par ce bloc.
+
+⚠️ **ASYNC IMPACT** : `evaluate()` synchrone sur le thread du tick APS. Pas de nouvelle coroutine, pas de Flow, pas de changement d’interface ML. Pref off : `finalUnits` non écrit.
+
+---
+
+## 4. Adaptations KMP vs divergences sémantiques
+
+| Adaptation | Type | Dose-facing ? |
+|---|---|---|
+| `commonMain` `internal object` (sibling `MaxSmbLadder`) ; pas de Metro `@Inject` | KMP | Non |
+| `aimiFmt*` au lieu de `String.format(Locale.US)` | KMP | **Non sur la décision** ; chaîne `reason` seulement |
+| tests `commonTest` / `kotlin.test` | KMP | Non — mêmes locks |
+| `BooleanKey` `title`/`summary` = `KeysStrings` (généré depuis XML) ; `PreferencesImpl` itère `BooleanKey.entries` | KMP | Non — pas de Hilt |
+| JSON `AimiJson.NULL` | pattern study déjà là | Non — même sémantique null |
+| Câblage tick / plugin restent `androidMain` | study (tick parked) | Non au-delà du geste ref |
+
+Pas de divergence sémantique **inattendue**. La séparation mesure / actuation est celle de `fe96b64f12`.
+
+---
+
+## 5. Caveats vs blockers
+
+### Caveats (acceptées — ne bloquent pas le merge)
+
+1. **Lot mixed (ombre vs dose)** — défaut **false** = observation. Si un opérateur arme `OApsAIMIDescentRedoseGuard`, le bolus auto peut passer à 0 U quand les cinq conditions tiennent. Annoncé dans `fe96b64f12` et le body PR #92. Ce n’est **pas** un P0 observation-only, et ce n’est **pas** un lot qui dose sans opt-in.
+2. **`_withheld_u` en ombre** — le champ est rempli dès que `verdict.block`, même si la dose n’est pas coupée. Nom « withheld » = *would withhold*. Identique à la ref. Compter l’export comme mesure, pas comme preuve d’actuation.
+3. **Arrondi `reason` `age=`** — `aimiFmt0` = `NumberFormat.INTEGER` (**HALF_EVEN**). Ref `%.0f` Locale.US = **HALF_UP**. N’entre pas dans le `when` (doubles bruts). Écart possible seulement sur la chaîne d’export pour un âge pile `n.5`. Les épisodes lockés (57 / 63 / 98 / 30.0) sont identiques (`peak=232.5`, `iob=13.81`).
+4. **CI iOS job rouge, héritée** — `:ios:shell` `iosSimulatorArm64Test` : variants ambigus `:plugins:dexcom_oneplus` / `libkeks` / `libre3`. Runs PR #92 `34573791035`, `34573763713`. Même classe que P0.8–P1.1. Ce job **ne** lance **pas** `:plugins:aps:iosSimulatorArm64Test`. `claude-review` : OIDC invalide (`34573791042`).
+5. **Tick consumer encore `androidMain`** — le garde est `commonMain` ; le câblage vit dans `DetermineBasalAIMI2` parked, comme les lots P0. Pas une extraction wholesale.
+6. **Compile Android+iOS** — déclaré PR #92 (`compileAndroidMain` + `compileKotlinIosSimulatorArm64` BUILD SUCCESSFUL). **Non rejoué** dans cette ancre. Preuve d’ancre = `jvmTest` 23/23 (ci-dessous).
+
+### Blockers
+
+**Aucun.** Pas de divergence de seuils, pas de dose sans opt-in, pas de fuite hors-scope, pas de canal basal touché.
+
+---
+
+## 6. Checklist preuves
+
+| Preuve | Résultat | Qui |
+|---|---|---|
+| Diff PR vs base = 6 fichiers, +775, 1 commit `addc772738` | OK | ancre, `git diff --stat` |
+| Head / base / ref SHA ci-dessus | OK | `git cat-file` + `git log -1` |
+| `evaluate` / `shouldWithhold` / seuils / tokens identiques à `fe96b64f12` hors `aimiFmt` | OK | `diff` symboles + strip commentaires |
+| Pref `key_aimi_descent_redose_guard` `defaultValue=false` | OK | `BooleanKey` ref et PR |
+| Export always + withhold derrière pref + `finalUnits` only | OK | hunk tick ref vs PR |
+| Hors-scope : pas Advisor / Flutter / dashboard / Garmin / P2 dans le diff | OK | `git diff --name-only` + `git grep` symboles |
+| 23 noms de tests identiques à la ref | OK | parse `` fun `…` `` |
+| `:plugins:aps:jvmTest` `DescentRedoseGuardTest` | **23/23**, 0 fail, 0 err, 0 skip | ancre, 2026-09-11, HEAD `addc772738` — XML `plugins/aps/build/test-results/jvmTest/TEST-…DescentRedoseGuardTest.xml` ; `BUILD SUCCESSFUL in 2m 50s` |
+| `compileAndroidMain` + `compileKotlinIosSimulatorArm64` | déclaré PR #92 BUILD SUCCESSFUL in 1m 2s / 58s ; **non rejoué** ici | agent PR |
+| CI GitHub iOS rouge = variants appshell, pas régression P1.2 | OK | logs `dexcom_oneplus` / `libkeks` / `libre3` |
+
+---
+
+## 7. Reco (merge / fix / suite)
+
+1. **Merge** PR #92 sur `kmp-aimi-migration-study`. Ne pas attendre le job iOS `:ios:shell` (dette study, pas P1.2).
+2. **Pas de fix clinique** demandé. Ne pas élargir les seuils. Ne pas toucher le canal basal. Ne pas inverser le défaut.
+3. **Opérationnel post-merge** : traiter comme **ombre par défaut**. Armer `OApsAIMIDescentRedoseGuard` seulement après lecture des champs export (`would_block` / `reason` / `withheld_u`). Compter `_withheld_u` en ombre comme *would*, pas *did*.
+4. **Suite** : lots suivants **séparés**. Ne pas tirer viewer / advisor ZIP / dashboard / Garmin. Ne pas extraire le tick wholesale dans le même lot.
+5. **Cette ancre** : doc-only ; ne pas rebase `dev_OAPSAIMI` dans le lot.
+
+---
+
+## 8. Hors-scope (rappel)
+
+- Viewer Flutter, advisor ZIP, dashboard AIMI home, Garmin re-grid
+- Remplacement wholesale `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`
+- Canal basal / TBR
+- Élargissement des cinq seuils
+- P1.1 SMB train (`6c0c`, déjà mergé #90)
+
+---
+
+## 9. ⚠️ ASYNC IMPACT (flag)
+
+`evaluate()` est synchrone sur le thread du tick APS, même copie bucketed que `minBgInLastMinutes`. Pas de nouvelle coroutine. Pref off : pas d’écriture `finalUnits`. Identique à `fe96b64f12`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre **P1.2 only**. Relecture de [PR #92](https://github.com/MTR93600/OpenApsAIMI/pull/92) contre `origin/dev_OAPSAIMI` @ `fe96b64f12`. **Aucun changement clinique.**

### SHA
- Study base = `kmp-aimi-migration-study` `55f832d2eb3eddc132fd91b8c9a11f8b4cb2ce6f`
- PR #92 head = `addc772738c26b154fa06f24d3d57f20e7868a73` (+775, 6 fichiers, 1 commit)
- Référence = `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc`

### Verdict : **GO_WITH_CAVEATS**

Fidélité clinique tenue : cinq conditions, export `baseline_state` toujours, dose bolus seulement si `OApsAIMIDescentRedoseGuard` (défaut **false** = ombre). Canal basal intact. Hors-scope respecté.

Ne pas classer GO (lot mixed : chemin dose réel derrière l’opt-in). Ne pas classer NO_GO (défaut n’arme pas ; pas de divergence sémantique inattendue).

### Reco
1. Merger PR #92. Ne pas attendre le job iOS `:ios:shell` (dette study, variants `dexcom_oneplus` / `libkeks` / `libre3`).
2. Pas de fix clinique. Ne pas inverser le défaut. Ne pas élargir les seuils.
3. Post-merge : ombre par défaut ; armer seulement après lecture de l’export. `_withheld_u` en ombre = *would*, pas *did*.

Preuve ancre : `:plugins:aps:jvmTest` `DescentRedoseGuardTest` **23/23** sur `addc772738` (`BUILD SUCCESSFUL in 2m 50s`).

Doc : `_docs/kmp/P1.2-ANCHOR.md`

## EN

P1.2 anchor vs `fe96b64f12`. **GO_WITH_CAVEATS**. Mixed lot: export always, bolus withhold only when the pref is on (default false = shadow). No clinical code in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc1eec2-f6a5-4a97-9062-2c37d30e4280?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc1eec2-f6a5-4a97-9062-2c37d30e4280&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

