### PR TITLE
docs(kmp): ancre P2.1 GO — PR #94 (aimi_viewer)

### DIFF
--- a/_docs/kmp/P2.1-ANCHOR.md
+++ b/_docs/kmp/P2.1-ANCHOR.md
@@ -1,0 +1,185 @@
+# Ancre P2.1 — AIMI Flutter viewer (`tools/aimi_viewer`)
+
+> Date d’ancre : 2026-09-11  
+> Lot : **P2.1 only** — PR [#94](https://github.com/MTR93600/OpenApsAIMI/pull/94)  
+> **Verdict : GO**  
+> Aucun changement clinique dans ce document. Relecture du code et des arbres git, pas d’invention.
+
+## SHA
+
+| Rôle | SHA | Preuve |
+|---|---|---|
+| Study base (base de PR #94) | `181ba03b3f897a7350073e50c207aa144e447465` | `kmp-aimi-migration-study` tip post P1.2 (#92) — `P1.2 — DescentRedoseGuard (fe96)` |
+| PR #94 head | `75a94317e0a6be967ecee6218178ad9113a09888` | unique commit du PR ; parent = study base |
+| Référence `origin/dev_OAPSAIMI` | `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc` | tip ref ; `feat: add DescentRedoseGuard…` |
+| Commit source viewer (timeline) | `81b401a7f9a2048fb176e1b3148cb883a5e196a9` | dernier commit qui touche `tools/aimi_viewer/` sur la ref ; **n’est pas** un ancêtre de #94 |
+| Arbre `tools/aimi_viewer/` | `f4dc4009bd7104fc10869cde9a34570a4e21acf1` | **identique** HEAD #94 ≡ `fe96b64f12` ≡ `81b401a7f9` |
+| Branche PR | `cursor/p21-aimi-flutter-viewer-b8a1` | 1 commit, **+5394 / 36 fichiers** (annoncé et mesuré) |
+
+## Verdict
+
+**GO** — merger PR #94 sur `kmp-aimi-migration-study`.
+
+Lot **outils / observation**, **zéro dose**. Port de l’**arbre entier** `tools/aimi_viewer/` en copie blob-identique de `fe96b64f12`. Aucun câblage tick APS, Metro, plugin clinique, Autodrive, SMB, prefs AAPS. Hors-scope Advisor / dashboard wholesale / Garmin respecté.
+
+Ne pas classer **GO_WITH_CAVEATS** : ce verdict est réservé aux lots mixed dose/ombre (P1.1 / P1.2). Ici il n’y a pas de chemin dose, pas d’adaptation KMP, pas de drift sémantique. `flutter test` non rejoué est une **caveat d’environnement** (SDK absent), pas un caveat produit — même classe que P0.12 « Gradle non relancé » qui est resté GO.
+
+Ne pas classer **NO_GO** : l’arbre n’est pas un cherry-pick incomplet de `81b401a7f9` (4 fichiers). Les 36 blobs matchent la ref.
+
+---
+
+## 1. Contenu réel de PR #94
+
+Mesuré `git diff --stat 181ba03b3f897a7350073e50c207aa144e447465 75a94317e0a6be967ecee6218178ad9113a09888` :
+
+```
+36 files changed, 5394 insertions(+)
+```
+
+Commit unique :
+
+```
+75a94317e0 P2.1 — AIMI Flutter viewer (tools/aimi_viewer)
+```
+
+Parent = `181ba03b3f`. Diff hors `tools/aimi_viewer/` : **vide**.
+
+Base GitHub = `kmp-aimi-migration-study` @ `181ba03b3f`. Head GitHub = `75a94317e0`. Reviews / issue comments : aucun au moment de l’ancre.
+
+Sur la study base, `tools/aimi_viewer/` = **0** fichier. Sur la ref et sur #94 = **36**.
+
+| Groupe | Fichiers | Rôle |
+|---|---|---|
+| Flutter app | `lib/main.dart`, `lib/src/{analysis_period,dashboard_controller,export_parser,label_catalog,models,storage_bridge}.dart` | UI + parseurs lecture seule |
+| Tests Dart | `test/{analysis_period,export_parser,label_catalog}_test.dart` | 15 `test()` (4+8+3) |
+| Hôte Android | `android/app/.../MainActivity.kt`, `DecisionWindowIndex.kt` | pont SAF **lecture seule** ; `applicationId = app.aaps.aimi_viewer` |
+| Manifestes / Gradle Flutter | `android/**` (manifests, gradle, icônes, styles) | APK autonome ; **pas** un module `settings.gradle` racine |
+| Meta | `pubspec.yaml` `0.2.0+2`, `pubspec.lock`, `README.md`, `.gitignore`, `.metadata`, `analysis_options.yaml` | package tools |
+
+`dashboard_controller.dart` est le contrôleur **interne** du viewer Flutter. Ce n’est **pas** le lot P2.3 (remplacement Overview / AIMI home).
+
+Le Kotlin sous `tools/aimi_viewer/android/` n’est **pas** `plugins/aps`. Package `app.aaps.aimi_viewer`, APK séparé.
+
+---
+
+## 2. Tableau items + preuves
+
+| # | Item | Statut | Preuve SHA |
+|---|---|---|---|
+| 1 | Arbre entier `tools/aimi_viewer/` (pas cherry-pick seul) | **Aligné** | Tree `f4dc4009bd7104fc10869cde9a34570a4e21acf1` identique HEAD ≡ `fe96b64f12` ≡ `81b401a7f9`. 36/36 chemins. `git diff --raw 75a94317e0 fe96b64f12 -- tools/aimi_viewer` vide. Historique ref : `b0035ab085` (31 fichiers) → `71e36f2697` (36) → `81b401a7f9` (36, 4 fichiers touchés). Cherry-pick de `81b401a7f9` seul sur une study vide n’aurait donné que 4 fichiers. |
+| 2 | Parité blobs 36/36 | **Aligné** | Comparaison `git ls-tree -r` HEAD vs REF : `identical=36 mismatch=0 only_head=0 only_ref=0`. Modes `100644` identiques. |
+| 3 | Diff hors tools vide | **Aligné** | `git diff --name-only 181ba03b3f 75a94317e0 \| grep -v '^tools/aimi_viewer/'` → vide. `comm` des listes de chemins : uniquement les 36 ajouts. |
+| 4 | Zéro dose — `plugins/aps` / tick / Metro / prefs AAPS | **Aligné** | Tree `plugins/aps` `c97fa0b790f96707e68a65656364be6a925c613e` BASE ≡ HEAD. Tree `app` `badf9e6f…`, `core` `6d992388…`, `core/keys` `a5c54cc4…`, `plugins` `a76c0460…` identiques. Blobs : `DetermineBasalAIMI2.kt` `1a3c3ec5de5b3eb4c9853e5d847b5f35500be911`, `OpenAPSAIMIPlugin.kt` `07e157d0993d60997ebf383038762c709530f098`, `BooleanKey.kt` `7c40baa81bc8e81d2434480ac8ba3594b670c1ce`, `AutodriveEngine.kt` `f727f13c7a346a1a604f4297e20b9d3c870cf2b3`. `settings.gradle` racine `0f8ebc2933…` BASE ≡ HEAD ; **aucun** `include` `aimi_viewer`. |
+| 5 | Viewer = lecture seule (SAF / cache privé) | **Aligné** | `MainActivity` : `FLAG_GRANT_READ_URI_PERMISSION` seulement (pas `WRITE`). `takePersistableUriPermission(..., FLAG_GRANT_READ_URI_PERMISSION)`. `openFileDescriptor(..., "r")` aux deux sites (l.286, l.313). Prefs locales `SharedPreferences("aimi_viewer_storage")` — clés `tree_uri` / `hormone_tracking_preference`. Aucune clé `BooleanKey` / `key_aimi_*`. Écritures = cache privé de l’APK, pas les originaux AAPS. README : « Aucun fichier d’AAPS n’est créé, déplacé, renommé ou modifié. » |
+| 6 | Pas de réseau prod / pas de pompe | **Aligné** | Manifeste **main** : aucune `uses-permission`. INTERNET seulement dans `debug/` et `profile/` (boilerplate Flutter hot-reload, identique ref). `pubspec.yaml` : dépendance unique `flutter` (pas http/dio). `applicationId = app.aaps.aimi_viewer`. |
+| 7 | Tests présents (non exécutés ici) | **Présents / non rejoués** | `analysis_period_test.dart` (4), `export_parser_test.dart` (8), `label_catalog_test.dart` (3) = 15 `test()`. Blobs identiques à la ref. `flutter` / `dart` absents de cette VM. |
+| 8 | Hors-scope P2.2 / P2.3 / P2.4 | **Respecté** | Aucun chemin `advisor`, `garmin`, `overview`, ZIP Advisor. `GarminBooleanKey.kt` blob `a0dc31e216…` inchangé. Pas de fichier hors `tools/aimi_viewer/`. |
+
+---
+
+## 3. Fidélité vs `fe96b64f12`
+
+### Ce que la ref contient (relu, pas inventé)
+
+Package Flutter **0.2.0+2**, SDK Dart `>=3.7.0 <4.0.0`. Application locale qui visualise les exports `Documents/AAPS` :
+
+- `AIMI_Decisions.jsonl` (préféré, index jour) ; `AIMI_Decisions_Last24h.jsonl` en repli
+- `oapsaimi_pkpd_records.csv`
+- streams Hormonitor (events, daily outcomes, QA/shadow/blackbox en métadonnées)
+
+Pont Android : `MethodChannel("app.aaps.aimiviewer/storage")`. Index incrémental `DecisionWindowIndex` (offsets d’octets). Staging vers le stockage **privé** de l’app. Isolate Dart pour le parse.
+
+Historique sur la ref (le tip `fe96b64f12` **contient** déjà l’arbre post-timeline) :
+
+1. `b0035ab085` — viewer standalone (31 fichiers)
+2. `71e36f2697` — vues d’analyse historique (36 fichiers)
+3. `81b401a7f9` — onglet timeline (même arbre 36 fichiers, 4 fichiers modifiés)
+
+`81b401a7f9` est ancêtre de `fe96b64f12` (**oui**). Il n’est **pas** ancêtre de `75a94317e0` : #94 est une copie d’arbre, pas un merge de l’historique viewer. Le contenu landé est néanmoins l’arbre **complet** du tip ref.
+
+### Mapping ref → study
+
+| Symbole ref | Symbole #94 | Égalité |
+|---|---|---|
+| Tree `tools/aimi_viewer/` | même chemin | **byte-identique** `f4dc4009` |
+| 36 blobs + modes | 36 blobs + modes | **36/36 IDENT** |
+| Hôte `MainActivity` / `DecisionWindowIndex` | mêmes fichiers | blobs `914144bd3aa7` / `69475b43183a` |
+| `pubspec.yaml` 0.2.0+2 | même | blob `e3fc0e8bf98e` |
+| 15 tests Dart | mêmes | blobs `fde9b345` / `5999d5aa` / `ec5da523` |
+
+**Aucune adaptation KMP.** Pas de `commonMain`, pas de Metro, pas de rewrite. Copie d’arbre.
+
+### Chemin dose-facing
+
+**Aucun.** Le viewer n’est pas un module Gradle de l’APK AAPS. Il ne lit pas `BooleanKey`. Il n’appelle pas `DetermineBasalAIMI2`. Il n’écrit pas sur la pompe. Les libellés `SMB` / `SMB_DELIVERY` dans `label_catalog.dart` sont des **traductions d’exports** déjà écrits, pas des commandes.
+
+⚠️ **ASYNC IMPACT** : **aucun** sur le tick APS / coroutines Metro / engines ML. Le viewer a son propre `Executors.newSingleThreadExecutor()` (I/O SAF) et `compute(...)` Dart (parse). Isolé dans l’APK `app.aaps.aimi_viewer`.
+
+---
+
+## 4. Caveats vs blockers
+
+### Caveats (acceptées — ne bloquent pas le merge)
+
+1. **`flutter test` non rejoué** — `flutter` / `dart` introuvables sur cette VM (et sur l’agent PR #94). Vérification = parité d’arbre + présence des 15 tests. À rejouer sur une machine Flutter **3.47+** : `cd tools/aimi_viewer && flutter pub get && flutter test`. Ce n’est pas un doute sur le contenu (blobs = ref).
+2. **CI GitHub #94** — `mergeable_state: unstable` ; check `claude-review` **failure** (job `103195112601`, run `34578099693`) — même classe OIDC que P0.8–P1.2. 0 status commit. Ne juge pas ce diff.
+3. **INTERNET debug/profile** — `uses-permission INTERNET` dans les manifests debug et profile uniquement (hot-reload Flutter). Manifeste **main** : zéro permission réseau. Identique à `fe96b64f12`.
+4. **Prefs locales vs prefs AAPS** — `SharedPreferences("aimi_viewer_storage")` dans l’APK viewer. Préférence d’affichage cycle `unspecified` / `notApplicable` / `enabledInAaps` : **affichage**, pas d’écriture dans AAPS. À ne pas confondre avec `BooleanKey`.
+5. **Signing release = debug** — `signingConfig = signingConfigs.getByName("debug")` dans `android/app/build.gradle.kts`. Identique ref. Limite de distribution, pas de dose.
+6. **Nom `dashboard_controller.dart`** — UI du viewer, pas P2.3. Ne pas lire ce fichier comme un remplacement Overview.
+
+### Blockers
+
+**Aucun.** Arbre complet. 36/36 blobs. Diff hors tools vide. Trees `plugins/aps` / `app` / `core` / `core/keys` / `plugins` identiques. Hors-scope tenu.
+
+---
+
+## 5. Checklist preuves
+
+| Preuve | Résultat | Qui |
+|---|---|---|
+| Diff PR vs base = 36 fichiers, +5394, 1 commit `75a94317e0` | OK | ancre, `git diff --stat` / `--shortstat` |
+| Parent HEAD = study base `181ba03b3f` | OK | `git rev-parse 75a94317e0^` |
+| Head / base / ref SHA ci-dessus | OK | `git cat-file` + `git fetch` `origin/dev_OAPSAIMI` / `cursor/p21-aimi-flutter-viewer-b8a1` |
+| Tree `tools/aimi_viewer/` HEAD ≡ REF ≡ `81b401a7f9` = `f4dc4009…` | OK | `git rev-parse <sha>:tools/aimi_viewer` |
+| 36/36 blobs IDENT, 0 only_head, 0 only_ref | OK | `git ls-tree -r` comparé fichier à fichier |
+| `git diff --raw HEAD REF -- tools/aimi_viewer` vide | OK | ancre |
+| Cherry-pick `81b401a7f9` seul = 4 fichiers ≠ arbre 36 | OK | `git show --name-only 81b401a7f9` |
+| Hors `tools/aimi_viewer/` : 0 chemin | OK | `git diff --name-only` + `comm` des trees |
+| `plugins/aps` / `app` / `core` / `core/keys` / `plugins` trees IDENT | OK | `git rev-parse` |
+| Tick / plugin / Autodrive / BooleanKey blobs IDENT | OK | table §2 item 4 |
+| `settings.gradle` racine sans `aimi_viewer` | OK | blob `0f8ebc2933` ; `rg aimi_viewer` vide |
+| SAF read-only : pas de `FLAG_GRANT_WRITE` ; `openFileDescriptor "r"` | OK | `git grep` sur HEAD |
+| Aucune clé AAPS / `BooleanKey` dans le viewer | OK | `git grep key_aimi\|BooleanKey` vide |
+| Manifeste main sans INTERNET | OK | `git show …/main/AndroidManifest.xml` |
+| Tests Dart présents 15 `test()` | OK | `git grep -c 'test('` |
+| `flutter test` | **non exécuté** (SDK absent) | ancre + agent PR #94 |
+| Hors-scope Advisor / Garmin / Overview | OK | `git diff --name-only` + blob `GarminBooleanKey` inchangé |
+| CI `claude-review` failure = OIDC, pas le diff | noté | check run `103195112601` |
+
+---
+
+## 6. Reco (merge / fix / suite)
+
+1. **Merge** PR #94 sur `kmp-aimi-migration-study`. Ne pas attendre `claude-review` ni un SDK Flutter sur l’agent.
+2. **Pas de fix clinique.** Ne pas câbler le viewer dans `settings.gradle` racine, le tick, Metro, ou les prefs AAPS.
+3. **Post-merge opérationnel** : outil d’observation local. Lancer hors AAPS : `cd tools/aimi_viewer && flutter pub get && flutter test && flutter run`. APK ≠ APK clinique.
+4. **Suite** : lots **séparés**. P2.2 Advisor ZIP, P2.3 Overview / AIMI home, P2.4 Garmin re-grid. Ne pas les tirer dans #94.
+5. **Cette ancre** : doc-only ; ne pas rebase `dev_OAPSAIMI` dans le lot.
+
+---
+
+## 7. Hors-scope (rappel)
+
+- Advisor ZIP (**P2.2**)
+- Remplacement wholesale Overview / dashboard AIMI home (**P2.3**)
+- Garmin re-grid (**P2.4**)
+- Chemin de dose clinique / tick `openAPSAIMI` / `DetermineBasalAIMI2` / Autodrive / SMB
+- Inclusion Gradle racine du module Flutter
+- P1.1 `smbGiven` / P1.2 `DescentRedoseGuard` (déjà sur la base `181ba03b3f`)
+
+---
+
+## 8. ⚠️ ASYNC IMPACT (flag)
+
+Aucun impact async sur les 3 engines ML ni sur le tick APS. Aucune coroutine / Flow / callback Metro ajouté ou modifié. L’I/O du viewer (`ioExecutor`, isolate Dart) vit dans un process APK distinct (`app.aaps.aimi_viewer`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre **P2.1 only**. Relecture de [PR #94](https://github.com/MTR93600/OpenApsAIMI/pull/94) contre `origin/dev_OAPSAIMI` @ `fe96b64f12`. **Aucun changement clinique.**

### SHA
- Study base = `kmp-aimi-migration-study` `181ba03b3f897a7350073e50c207aa144e447465`
- PR #94 head = `75a94317e0a6be967ecee6218178ad9113a09888` (+5394, 36 fichiers, 1 commit)
- Référence = `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc`
- Arbre `tools/aimi_viewer/` = `f4dc4009bd7104fc10869cde9a34570a4e21acf1` (HEAD ≡ ref ≡ `81b401a7f9`)

### Verdict : **GO**

Arbre entier, 36/36 blobs identiques. Diff hors `tools/aimi_viewer/` vide. Zéro dose (`plugins/aps` / tick / Metro / `BooleanKey` inchangés). Hors-scope P2.2 Advisor ZIP / P2.3 dashboard / P2.4 Garmin respecté.

Ne pas classer GO_WITH_CAVEATS (réservé aux lots mixed dose/ombre). Ne pas classer NO_GO (pas un cherry-pick incomplet de `81b401a7f9` seul — 4 fichiers).

`flutter test` non rejoué = caveat d’environnement (SDK absent), pas un blocker.

### Reco
1. Merger PR #94. Ne pas attendre `claude-review` ni un SDK Flutter sur l’agent.
2. Pas de fix clinique. Ne pas câbler le viewer dans `settings.gradle` racine ni le tick APS.
3. Suite : P2.2 / P2.3 / P2.4 en lots séparés.

Doc : `_docs/kmp/P2.1-ANCHOR.md`

## EN

P2.1 anchor vs `fe96b64f12`. **GO**. Whole-tree blob-identical `tools/aimi_viewer/` (36/36). Zero dose. Flutter tests not re-run on this VM (caveat, not a blocker). No clinical code in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65bcf9e9-cc53-44b5-bfcc-0c4fbf49eee6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65bcf9e9-cc53-44b5-bfcc-0c4fbf49eee6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

