### PR TITLE
P2.2 — Advisor support ZIP corpus + active profile (02c906)

### DIFF
--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/OpenAPSAIMIPlugin.kt
@@ -144,6 +144,9 @@ import androidx.core.net.toUri
 import kotlin.math.abs
 import kotlin.math.exp
 import app.aaps.plugins.aps.openAPSAIMI.advisor.AimiAdvisorService
+import app.aaps.plugins.aps.openAPSAIMI.advisor.compose.AimiSupportPackageScreen
+import app.aaps.plugins.aps.openAPSAIMI.advisor.diag.AimiDiagnosticsManager
+import app.aaps.plugins.aps.openAPSAIMI.advisor.diag.AimiSupportPackageExporter
 import app.aaps.plugins.aps.openAPSAIMI.compose.AimiControlCenterScreen
 import app.aaps.plugins.aps.openAPSAIMI.compose.AimiPkpdSettingsScreen
 import app.aaps.plugins.aps.openAPSAIMI.tpo.TpoOrchestrator
@@ -1831,6 +1834,26 @@ open class OpenAPSAIMIPlugin  @Inject constructor(
                         preferences = preferences,
                         tpoOrchestrator = tpoOrchestrator,
                         onBack = onBack,
+                    )
+                },
+            ),
+        )
+        add(
+            ApsIntentKey.AimiSupportPackage.withCompose(
+                ComposeScreenContent { onBack ->
+                    val exporter = AimiSupportPackageExporter(
+                        context = context,
+                        preferences = preferences,
+                        logger = aapsLogger,
+                        storageHelper = storageHelper,
+                        profileFunction = profileFunction,
+                        rh = rh,
+                    )
+                    AimiSupportPackageScreen(
+                        onBack = onBack,
+                        verifyCode = { code -> AimiDiagnosticsManager.verifyCode(code) },
+                        buildPackage = { issue -> exporter.build(issue) },
+                        sharePackage = { zip, issue -> exporter.share(zip, issue) },
                     )
                 },
             ),

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/compose/AimiSupportPackageScreen.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/compose/AimiSupportPackageScreen.kt
@@ -1,0 +1,162 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import app.aaps.core.ui.compose.AapsSpacing
+import app.aaps.core.ui.compose.AapsTopAppBar
+import app.aaps.core.ui.compose.preference.ProvidePreferenceTheme
+import app.aaps.plugins.aps.R
+import app.aaps.plugins.aps.openAPSAIMI.advisor.diag.AimiSupportPackageExporter
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Study Compose stand-in for parked `AimiProfileAdvisorActivity` support-ZIP flow.
+ *
+ * Expert-code gate, optional ticket text, then a ZIP with the diagnostic report
+ * (`[ACTIVE PROFILE]`), last-24h decision log, and `oapsaimiML2_records.csv` tail.
+ * View Activity pattern is wrong for this KMP tree (Compose preferences, no Hilt).
+ */
+@Composable
+fun AimiSupportPackageScreen(
+    onBack: () -> Unit,
+    verifyCode: (String) -> Boolean,
+    buildPackage: suspend (issue: String) -> AimiSupportPackageExporter.Result,
+    sharePackage: (zipFile: File, issue: String) -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    var code by rememberSaveable { mutableStateOf("") }
+    var unlocked by rememberSaveable { mutableStateOf(false) }
+    var issue by rememberSaveable { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+    val generatingMessage = stringResource(R.string.aimi_diag_generating)
+    val invalidMessage = stringResource(R.string.aimi_adv_support_invalid)
+    val emptyMessage = stringResource(R.string.aimi_diag_empty)
+    val errorPrefix = stringResource(R.string.aimi_adv_error_gen)
+
+    fun onVerify() {
+        if (verifyCode(code)) {
+            unlocked = true
+        } else {
+            unlocked = false
+            scope.launch { snackbarHostState.showSnackbar(invalidMessage) }
+        }
+    }
+
+    fun onGenerate() {
+        if (busy) return
+        busy = true
+        scope.launch {
+            snackbarHostState.showSnackbar(generatingMessage)
+            val result = withContext(Dispatchers.IO) { buildPackage(issue) }
+            busy = false
+            when (result) {
+                is AimiSupportPackageExporter.Result.Ready -> sharePackage(result.zipFile, issue)
+                AimiSupportPackageExporter.Result.Empty -> snackbarHostState.showSnackbar(emptyMessage)
+                is AimiSupportPackageExporter.Result.Failed ->
+                    snackbarHostState.showSnackbar("$errorPrefix: ${result.message ?: ""}")
+            }
+        }
+    }
+
+    ProvidePreferenceTheme {
+        Scaffold(
+            topBar = {
+                AapsTopAppBar(
+                    title = { Text(stringResource(R.string.aimi_adv_support_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(app.aaps.core.ui.R.string.back),
+                            )
+                        }
+                    },
+                )
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .padding(horizontal = AapsSpacing.large)
+                    .padding(bottom = AapsSpacing.xxLarge)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(AapsSpacing.medium),
+            ) {
+                Text(
+                    text = stringResource(R.string.aimi_adv_support_msg),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                OutlinedTextField(
+                    value = code,
+                    onValueChange = { code = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text(stringResource(R.string.aimi_adv_support_code_hint)) },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                )
+                Button(
+                    onClick = { onVerify() },
+                    enabled = !busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.aimi_adv_support_verify))
+                }
+                if (unlocked) {
+                    Text(
+                        text = stringResource(R.string.aimi_adv_issue_msg),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    OutlinedTextField(
+                        value = issue,
+                        onValueChange = { issue = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(stringResource(R.string.aimi_adv_issue_hint)) },
+                        minLines = 3,
+                    )
+                    Button(
+                        onClick = { onGenerate() },
+                        enabled = !busy,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(R.string.aimi_adv_generate_btn))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsManager.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsManager.kt
@@ -1,0 +1,149 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import android.content.Context
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.profile.Profile
+import app.aaps.core.keys.BooleanKey
+import app.aaps.core.keys.StringKey
+import app.aaps.core.keys.interfaces.Preferences
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Secure diagnostic engine for AIMI.
+ * Handles authentication (Premium Expert Code) and the "black box" support report.
+ *
+ * Unparked from `_docs/kmp/staging/openAPSAIMI-android-wip/advisor/diag/` and updated with
+ * `origin/dev_OAPSAIMI` @ `02c90656b1` ([ACTIVE PROFILE] via [ProfileFunction][app.aaps.core.interfaces.profile.ProfileFunction]).
+ *
+ * Observation / tools only. Not on the dose path.
+ */
+class AimiDiagnosticsManager(
+    private val context: Context,
+    private val preferences: Preferences,
+    private val logger: AAPSLogger
+) {
+
+    companion object {
+        // SHA-256 of "MTR-X-742-NEBULA" (Premium Expert Code)
+        private const val SUPPORT_HASH = "7bb66c320fbc2e1c0e851eec23a171dcbd07ece4854bec29535822b25839323d"
+
+        fun verifyCode(input: String): Boolean {
+            val inputClean = input.trim()
+            val hash = hashString(inputClean)
+            return constantTimeEquals(hash, SUPPORT_HASH)
+        }
+
+        private fun hashString(input: String): String {
+            return MessageDigest.getInstance("SHA-256")
+                .digest(input.toByteArray())
+                .fold("") { str, it -> str + "%02x".format(it) }
+        }
+
+        private fun constantTimeEquals(a: String, b: String): Boolean {
+            if (a.length != b.length) return false
+            var result = 0
+            for (i in a.indices) {
+                result = result or (a[i].code xor b[i].code)
+            }
+            return result == 0
+        }
+    }
+
+    /**
+     * Builds the support report.
+     *
+     * @param activeProfile the profile the loop is really running, from `ProfileFunction.getProfile()`.
+     *   Pass it whenever it can be read. Without it the report only shows the `LocalProfile_*`
+     *   preferences, which are the profile **editor's** content and can differ from what runs: on the
+     *   2026-09-06 package they read 70 / 30 mg/dL per U while the loop was running 120 / 50.
+     * @param activeProfileName name of that profile, when known.
+     */
+    fun generateReport(
+        userMessage: String,
+        activeProfile: Profile? = null,
+        activeProfileName: String? = null,
+    ): String {
+        val sb = StringBuilder()
+        val now = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+
+        sb.append("=========================================\n")
+        sb.append("   AIMI DIAGNOSTIC REPORT - $now\n")
+        sb.append("=========================================\n\n")
+
+        if (userMessage.isNotBlank()) {
+            sb.append("[USER TICKET]\n")
+            sb.append(userMessage).append("\n\n")
+        }
+
+        sb.append("[SYSTEM]\n")
+        var versionName = "Unknown"
+        var versionCode = 0L
+        try {
+            val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            versionName = pInfo.versionName ?: "Unknown"
+            versionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                pInfo.longVersionCode
+            } else {
+                @Suppress("DEPRECATION")
+                pInfo.versionCode.toLong()
+            }
+        } catch (e: Exception) {
+            logger.error(LTag.CORE, "Error getting version info", e)
+        }
+
+        sb.append("App Version: $versionName ($versionCode)\n")
+        sb.append("Android: ${android.os.Build.VERSION.RELEASE} (SDK ${android.os.Build.VERSION.SDK_INT})\n")
+        sb.append("Device: ${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}\n\n")
+
+        sb.append("[NIGHTSCOUT]\n")
+        val nsUrl = preferences.get(StringKey.NsClientUrl)
+        val safeUrl = if (nsUrl.contains("@")) {
+            val parts = nsUrl.split("@")
+            "***SECRET***@" + (if (parts.size > 1) parts[1] else "???")
+        } else {
+            nsUrl.ifBlank { "Not Set" }
+        }
+        sb.append("URL: $safeUrl\n")
+        val nsEnabled = preferences.get(BooleanKey.NsClientUploadData)
+        sb.append("Upload Enabled: $nsEnabled\n\n")
+
+        AimiDiagnosticsActiveProfile.writeSection(sb, activeProfile, activeProfileName)
+        AimiDiagnosticsActiveProfile.writePreferencesPreamble(sb)
+        val prefs = context.getSharedPreferences(context.packageName + "_preferences", Context.MODE_PRIVATE)
+        val allPrefs = prefs.all
+
+        val interestKeys = listOf("aimi", "aps", "smb", "max", "basal", "target", "profile", "opt_")
+
+        allPrefs.keys.sorted().forEach { key ->
+            val value = allPrefs[key]
+            var isInteresting = false
+            for (pattern in interestKeys) {
+                if (key.contains(pattern, ignoreCase = true)) {
+                    isInteresting = true
+                    break
+                }
+            }
+
+            if (key.contains("password", true) || key.contains("token", true) || key.contains("secret", true)) {
+                isInteresting = false
+            }
+            if (AimiDiagnosticsPrefExportPolicy.isSecretPreferenceKey(key)) {
+                isInteresting = false
+            }
+
+            if (isInteresting) {
+                sb.append(key).append(": ").append(AimiDiagnosticsPrefExportPolicy.formatExportValue(key, value)).append('\n')
+            }
+        }
+        sb.append("\n")
+
+        sb.append("[VITAL STATS]\n")
+        sb.append("(Stats deep analysis requires DB access - available in V2)\n")
+
+        return sb.toString()
+    }
+}

--- a/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportPackageExporter.kt
+++ b/plugins/aps/src/androidMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportPackageExporter.kt
@@ -1,0 +1,149 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import app.aaps.core.interfaces.logging.AAPSLogger
+import app.aaps.core.interfaces.logging.LTag
+import app.aaps.core.interfaces.profile.ProfileFunction
+import app.aaps.core.interfaces.resources.ResourceHelper
+import app.aaps.core.keys.interfaces.Preferences
+import app.aaps.plugins.aps.R
+import app.aaps.plugins.aps.openAPSAIMI.advisor.data.T3cRuntimeHistoryReader
+import app.aaps.plugins.aps.openAPSAIMI.aimiWallClockMs
+import app.aaps.plugins.aps.openAPSAIMI.utils.AimiStorageHelper
+import java.io.BufferedOutputStream
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FileReader
+import java.io.OutputStreamWriter
+import java.util.Date
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Builds and shares the AIMI Advisor support ZIP.
+ *
+ * Observation / tools only. File I/O on a background dispatcher. Not on the dose path.
+ *
+ * Package contents (from parked Advisor Activity + `origin/dev_OAPSAIMI` @ `02c90656b1`):
+ * 1. `Diagnostic_Report.txt` including `[ACTIVE PROFILE]` from [ProfileFunction]
+ * 2. `AIMI_Decisions_Last24h.jsonl` (last 24 hours, when the log can be read)
+ * 3. tail of `oapsaimiML2_records.csv` (header + last 3000 rows)
+ */
+class AimiSupportPackageExporter(
+    private val context: Context,
+    private val preferences: Preferences,
+    private val logger: AAPSLogger,
+    private val storageHelper: AimiStorageHelper,
+    private val profileFunction: ProfileFunction,
+    private val rh: ResourceHelper,
+) {
+
+    sealed class Result {
+        data class Ready(val zipFile: File) : Result()
+        data object Empty : Result()
+        data class Failed(val message: String?) : Result()
+    }
+
+    suspend fun build(issue: String): Result {
+        return try {
+            val diagManager = AimiDiagnosticsManager(context, preferences, logger)
+            val runningProfile = runCatching { profileFunction.getProfile() }.getOrNull()
+            val runningProfileName = runCatching { profileFunction.getProfileName() }.getOrNull()
+            val reportContent = diagManager.generateReport(
+                userMessage = issue,
+                activeProfile = runningProfile,
+                activeProfileName = runningProfileName,
+            )
+            val zipFileName = "AIMI_Support_Package_${aimiWallClockMs()}.zip"
+            val zipFile = File(context.cacheDir, zipFileName)
+
+            ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { out ->
+                if (reportContent.isNotEmpty()) {
+                    out.putNextEntry(ZipEntry("Diagnostic_Report.txt"))
+                    out.write(reportContent.toByteArray())
+                    out.closeEntry()
+                }
+                addDecisionLogLast24h(out)
+                addCsvTail(out, "oapsaimiML2_records.csv")
+            }
+
+            if (zipFile.exists() && zipFile.length() > 0) {
+                Result.Ready(zipFile)
+            } else {
+                Result.Empty
+            }
+        } catch (e: Exception) {
+            logger.error(LTag.APS, "AIMI_DIAG: Failed to generate/share report", e)
+            Result.Failed(e.message)
+        }
+    }
+
+    fun share(zipFile: File, issue: String) {
+        val authority = "${context.packageName}.fileprovider"
+        val uri = FileProvider.getUriForFile(context, authority, zipFile)
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/zip"
+            putExtra(Intent.EXTRA_SUBJECT, rh.gs(R.string.aimi_diag_subject, Date().toString()))
+            putExtra(Intent.EXTRA_TEXT, "AIMI Support Package attached (ZIP).\n\nDetails: $issue")
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        val chooser = Intent.createChooser(intent, rh.gs(R.string.aimi_diag_chooser))
+        chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(chooser)
+    }
+
+    /**
+     * Adds the tail of an AIMI CSV to the support package, header first.
+     *
+     * A missing or unreadable file is skipped in silence. The package is a best effort report, and
+     * failing to build it would leave the user with nothing to send.
+     */
+    private fun addCsvTail(out: ZipOutputStream, fileName: String) {
+        try {
+            val source = storageHelper.getAimiFile(fileName)
+            if (!source.exists() || !source.canRead()) {
+                logger.info(LTag.APS, "AIMI_DIAG: $fileName not found, not added to the package")
+                return
+            }
+            val lines = source.readLines(Charsets.UTF_8)
+            val tail = AimiSupportCsvTail.select(lines) ?: return
+            out.putNextEntry(ZipEntry(fileName))
+            out.write(AimiSupportCsvTail.toText(tail).toByteArray(Charsets.UTF_8))
+            out.closeEntry()
+            logger.info(
+                LTag.APS,
+                "AIMI_DIAG: added $fileName to the package (${tail.body.size} rows of ${lines.size - 1})"
+            )
+        } catch (e: Exception) {
+            logger.warn(LTag.APS, "AIMI_DIAG: could not add $fileName: ${e.message}")
+        }
+    }
+
+    private fun addDecisionLogLast24h(out: ZipOutputStream) {
+        val jsonFile = T3cRuntimeHistoryReader.aimiDecisionsJsonlFile()
+        if (!jsonFile.exists() || !jsonFile.canRead()) return
+        out.putNextEntry(ZipEntry("AIMI_Decisions_Last24h.jsonl"))
+        val cutoffTime = aimiWallClockMs() - (24 * 60 * 60 * 1000L)
+        val reader = BufferedReader(FileReader(jsonFile))
+        val writer = BufferedWriter(OutputStreamWriter(out))
+        try {
+            var line = reader.readLine()
+            while (line != null) {
+                if (AimiSupportDecisionLogFilter.keep(line, cutoffTime)) {
+                    writer.write(line)
+                    writer.newLine()
+                }
+                line = reader.readLine()
+            }
+            writer.flush()
+        } finally {
+            reader.close()
+        }
+        out.closeEntry()
+    }
+}

--- a/plugins/aps/src/androidMain/res/values/aimi_strings.xml
+++ b/plugins/aps/src/androidMain/res/values/aimi_strings.xml
@@ -471,6 +471,8 @@
 
 <string name="aimi_adv_support_invalid">⚠️ Invalid Code</string>
 
+<string name="aimi_adv_support_code_hint">Enter Expert Code</string>
+
 <string name="aimi_adv_issue_title">Describe Issue</string>
 
 <string name="aimi_adv_issue_msg">Briefly describe the problem so MTR can analyze the context.</string>
@@ -484,6 +486,10 @@
 <string name="aimi_diag_subject">AIMI Diagnostic Report - %1$s</string>
 
 <string name="aimi_diag_chooser">Send Diagnostic to MTR</string>
+
+<string name="aimi_diag_generating">Generating diagnostic report...</string>
+
+<string name="aimi_diag_empty">Failed to create support package (Empty)</string>
 
 <string name="oaps_aimi_enableMlTraining_title">Enable A.I. Training</string>
 

--- a/plugins/aps/src/androidMain/res/values/strings.xml
+++ b/plugins/aps/src/androidMain/res/values/strings.xml
@@ -117,6 +117,8 @@
     <!-- AIMI intent preferences (ApsIntentKey). Unique names so lot K aimi_strings.xml can keep freeze ids. -->
     <string name="pref_title_aimi_control_center">AIMI Control Center</string>
     <string name="pref_summary_aimi_control_center">See how AIMI interprets your current settings before simplifying them into behavior families.</string>
+    <string name="pref_title_aimi_support_package">AIMI support package</string>
+    <string name="pref_summary_aimi_support_package">Export a diagnostic ZIP with the training corpus tail and the running profile.</string>
     <string name="pref_title_aimi_sos_permissions">Grant SMS and location permissions</string>
     <string name="pref_summary_aimi_sos_permissions">Tap to authorize AAPS to send SOS SMS and access location for emergencies. Automatic phone calls are not used.</string>
     <string name="pref_title_aimi_hypo_risk_alarm_info">Hypo Risk</string>

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/keys/ApsIntentKey.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/keys/ApsIntentKey.kt
@@ -30,6 +30,13 @@ enum class ApsIntentKey(
         preferenceType = PreferenceType.CLICK,
     ),
 
+    AimiSupportPackage(
+        key = "aimi_support_package_compose",
+        title = ApsStrings.pref_title_aimi_support_package,
+        summary = ApsStrings.pref_summary_aimi_support_package,
+        preferenceType = PreferenceType.CLICK,
+    ),
+
     AimiSosPermissions(
         key = "aimi_sos_permissions_compose",
         title = ApsStrings.pref_title_aimi_sos_permissions,

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsActiveProfile.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsActiveProfile.kt
@@ -1,0 +1,94 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import app.aaps.core.data.model.GlucoseUnit
+import app.aaps.core.interfaces.profile.Profile
+import app.aaps.plugins.aps.openAPSAIMI.aimiFmt2
+
+/**
+ * The `[ACTIVE PROFILE]` section of the AIMI support report.
+ *
+ * Behaviour from `origin/dev_OAPSAIMI` @ `02c90656b1`. Printed from the same accessors the loop
+ * reads (`ProfileFunction.getProfile()`), in mg/dL per U, so a support package cannot confuse the
+ * profile editor's `LocalProfile_*` keys with what actually ran.
+ *
+ * A null profile is stated as such instead of being left out: an absent section would read as
+ * "no profile problem", which is the mistake this section exists to stop.
+ */
+internal object AimiDiagnosticsActiveProfile {
+
+    data class Blocks(
+        val name: String?,
+        val units: GlucoseUnit,
+        val percentage: Int,
+        val timeshift: Int,
+        val isf: List<Profile.ProfileValue>,
+        val ic: List<Profile.ProfileValue>,
+        val basal: List<Profile.ProfileValue>,
+        val target: List<Profile.ProfileValue>,
+    ) {
+        companion object {
+            fun from(profile: Profile, name: String?): Blocks =
+                Blocks(
+                    name = name,
+                    units = profile.units,
+                    percentage = profile.percentage,
+                    timeshift = profile.timeshift,
+                    isf = profile.getIsfsMgdlValues().toList(),
+                    ic = profile.getIcsValues().toList(),
+                    basal = profile.getBasalValues().toList(),
+                    target = profile.getSingleTargetsMgdl().toList(),
+                )
+        }
+    }
+
+    fun writeSection(sb: StringBuilder, profile: Profile?, name: String?) {
+        writeSection(sb, profile?.let { Blocks.from(it, name) })
+    }
+
+    fun writeSection(sb: StringBuilder, blocks: Blocks?) {
+        sb.append("[ACTIVE PROFILE]\n")
+        appendBody(sb, blocks)
+        sb.append('\n')
+    }
+
+    fun writePreferencesPreamble(sb: StringBuilder) {
+        sb.append("[AIMI PREFERENCES]\n")
+        sb.append("Note: the LocalProfile_* keys below are the profile editor's content.\n")
+        sb.append("They are not always what the loop runs. See [ACTIVE PROFILE] above.\n")
+    }
+
+    fun appendBody(sb: StringBuilder, blocks: Blocks?) {
+        if (blocks == null) {
+            sb.append("Not available when the report was built.\n")
+            return
+        }
+        sb.append("Name: ").append(blocks.name ?: "unknown").append('\n')
+        sb.append("Display units: ").append(blocks.units).append('\n')
+        sb.append("Percentage: ").append(blocks.percentage).append("%\n")
+        sb.append("Timeshift: ").append(blocks.timeshift).append(" h\n")
+        appendBlocks(sb, "ISF (mg/dL per U)", blocks.isf)
+        appendBlocks(sb, "IC (g per U)", blocks.ic)
+        appendBlocks(sb, "Basal (U/h)", blocks.basal)
+        appendBlocks(sb, "Target (mg/dL)", blocks.target)
+    }
+
+    /** One line per quantity: every block as `hh:mm value`, in the profile's own order. */
+    fun appendBlocks(sb: StringBuilder, label: String, values: List<Profile.ProfileValue>) {
+        sb.append(label).append(": ")
+        if (values.isEmpty()) {
+            sb.append("none\n")
+            return
+        }
+        values.forEachIndexed { index, block ->
+            if (index > 0) sb.append(", ")
+            val hours = block.timeAsSeconds / 3600
+            val minutes = (block.timeAsSeconds % 3600) / 60
+            sb.append(hours.toString().padStart(2, '0'))
+                .append(':')
+                .append(minutes.toString().padStart(2, '0'))
+                .append(' ')
+                .append(aimiFmt2(block.value))
+        }
+        sb.append('\n')
+    }
+}

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportCsvTail.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportCsvTail.kt
@@ -1,0 +1,42 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+/**
+ * Tail of an AIMI CSV for the support package: header first, then the newest rows.
+ *
+ * Behaviour from `origin/dev_OAPSAIMI` @ `02c90656b1` (`addCsvTail`). The tail, not the whole
+ * file: the corpus grows for ever and a support package must stay small enough to send.
+ * [MAX_CSV_ROWS_IN_PACKAGE] rows are about two days at the one minute loop rate.
+ *
+ * Rows are counted, not dated. The date column is written with the user's locale format, so
+ * parsing it back to filter on time would break on some devices; counting lines cannot.
+ */
+internal object AimiSupportCsvTail {
+
+    /**
+     * How many CSV rows the support package carries, newest last.
+     *
+     * About two days at the one minute loop rate, which matches the 24 hour window the decision
+     * log uses, with room for the delay `SmbTrainingRowBuffer` adds before a row is written.
+     */
+    const val MAX_CSV_ROWS_IN_PACKAGE = 3000
+
+    data class Selected(
+        val header: String,
+        val body: List<String>,
+    )
+
+    fun select(lines: List<String>): Selected? {
+        if (lines.isEmpty()) return null
+        return Selected(
+            header = lines.first(),
+            body = lines.drop(1).takeLast(MAX_CSV_ROWS_IN_PACKAGE),
+        )
+    }
+
+    fun toText(tail: Selected): String {
+        val sb = StringBuilder()
+        sb.append(tail.header).append('\n')
+        tail.body.forEach { row -> sb.append(row).append('\n') }
+        return sb.toString()
+    }
+}

--- a/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportDecisionLogFilter.kt
+++ b/plugins/aps/src/commonMain/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportDecisionLogFilter.kt
@@ -1,0 +1,24 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+/**
+ * Last-24h filter for `AIMI_Decisions.jsonl` lines in the support ZIP.
+ *
+ * Same fast heuristic as parked `AimiProfileAdvisorActivity.generateAndShareReport`:
+ * look for `"timestamp":123456789` without parsing the whole JSON line.
+ * Lines with no timestamp are dropped (cleaner log).
+ */
+internal object AimiSupportDecisionLogFilter {
+
+    fun keep(line: String, cutoffTimeMs: Long): Boolean {
+        val tsIdx = line.indexOf("\"timestamp\":")
+        if (tsIdx == -1) return false
+        val start = tsIdx + 12
+        var end = start
+        while (end < line.length && line[end].isDigit()) {
+            end++
+        }
+        if (end <= start) return false
+        val ts = line.substring(start, end).toLongOrNull() ?: return false
+        return ts >= cutoffTimeMs
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsActiveProfileTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiDiagnosticsActiveProfileTest.kt
@@ -1,0 +1,73 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import app.aaps.core.data.model.GlucoseUnit
+import app.aaps.core.interfaces.profile.Profile
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The report must show the profile the loop runs, not only the profile editor's preferences.
+ *
+ * On the 2026-09-06 support package the `LocalProfile_isf_0` preference read 70 / 30 mg/dL per U
+ * while the engine was running 120 / 50. The report carried only the preference, so the profile
+ * looked wrong when it was right. An analysis was written on that wrong reading.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `02c90656b1` (`AimiDiagnosticsActiveProfileTest`).
+ * Study source set: the [ACTIVE PROFILE] section is commonMain with no Android, so the tests live
+ * in `commonTest` (`kotlin.test`) — same layout as [app.aaps.plugins.aps.openAPSAIMI.ml.SmbTrainingRowBufferTest].
+ * Assertions are the same locks as the Truth/JUnit reference.
+ */
+class AimiDiagnosticsActiveProfileTest {
+
+    private fun runningBlocks(): AimiDiagnosticsActiveProfile.Blocks =
+        AimiDiagnosticsActiveProfile.Blocks(
+            name = "AIMI running",
+            units = GlucoseUnit.MGDL,
+            percentage = 100,
+            timeshift = 0,
+            isf = listOf(
+                Profile.ProfileValue(0, 120.0),
+                Profile.ProfileValue(11 * 3600, 50.0),
+            ),
+            ic = listOf(Profile.ProfileValue(0, 7.0)),
+            basal = listOf(Profile.ProfileValue(0, 0.5)),
+            target = listOf(Profile.ProfileValue(0, 115.0)),
+        )
+
+    private fun report(blocks: AimiDiagnosticsActiveProfile.Blocks?): String {
+        val sb = StringBuilder()
+        AimiDiagnosticsActiveProfile.writeSection(sb, blocks)
+        AimiDiagnosticsActiveProfile.writePreferencesPreamble(sb)
+        return sb.toString()
+    }
+
+    @Test
+    fun `the running profile is printed block by block`() {
+        val text = report(runningBlocks())
+
+        assertTrue("[ACTIVE PROFILE]" in text)
+        assertTrue("Name: AIMI running" in text)
+        assertTrue("ISF (mg/dL per U): 00:00 120.00, 11:00 50.00" in text)
+        assertTrue("IC (g per U): 00:00 7.00" in text)
+        assertTrue("Basal (U/h): 00:00 0.50" in text)
+        assertTrue("Target (mg/dL): 00:00 115.00" in text)
+    }
+
+    /** A missing profile must be stated. An absent section would read as "nothing to report". */
+    @Test
+    fun `a missing profile is stated not left out`() {
+        val text = report(null)
+
+        assertTrue("[ACTIVE PROFILE]" in text)
+        assertTrue("Not available when the report was built." in text)
+    }
+
+    /** The trap that produced the wrong reading: the editor keys must carry a warning. */
+    @Test
+    fun `the preference dump warns that the editor keys may differ`() {
+        val text = report(runningBlocks())
+
+        assertTrue("the LocalProfile_* keys below are the profile editor's content" in text)
+        assertTrue(text.indexOf("[ACTIVE PROFILE]") < text.indexOf("[AIMI PREFERENCES]"))
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportCsvTailTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportCsvTailTest.kt
@@ -1,0 +1,58 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The support package carries the header and the last 3000 rows of `oapsaimiML2_records.csv`.
+ *
+ * Behaviour from `origin/dev_OAPSAIMI` @ `02c90656b1` (`addCsvTail` in the Advisor Activity).
+ * Rows are counted, not dated: the date column is written in the device locale, so parsing it
+ * back would break on some devices.
+ *
+ * The selector is commonMain with no File I/O, so the tests live in `commonTest` (`kotlin.test`).
+ */
+class AimiSupportCsvTailTest {
+
+    @Test
+    fun `an empty file is skipped`() {
+        assertNull(AimiSupportCsvTail.select(emptyList()))
+    }
+
+    @Test
+    fun `header only is kept with an empty body`() {
+        val tail = AimiSupportCsvTail.select(listOf("dateStr,smbGiven"))
+        assertEquals("dateStr,smbGiven", tail?.header)
+        assertEquals(emptyList(), tail?.body)
+    }
+
+    @Test
+    fun `a short file keeps every body row newest last`() {
+        val tail = AimiSupportCsvTail.select(
+            listOf("hdr", "r1", "r2", "r3"),
+        )
+        assertEquals("hdr", tail?.header)
+        assertEquals(listOf("r1", "r2", "r3"), tail?.body)
+    }
+
+    @Test
+    fun `a long file keeps the header and the last 3000 body rows`() {
+        val header = "dateStr,smbGiven"
+        val body = (1..4000).map { "row$it" }
+        val tail = AimiSupportCsvTail.select(listOf(header) + body)
+        assertEquals(header, tail?.header)
+        assertEquals(AimiSupportCsvTail.MAX_CSV_ROWS_IN_PACKAGE, tail?.body?.size)
+        assertEquals("row1001", tail?.body?.first())
+        assertEquals("row4000", tail?.body?.last())
+    }
+
+    @Test
+    fun `the zip entry is header then body each on its own line`() {
+        val tail = AimiSupportCsvTail.Selected(
+            header = "hdr",
+            body = listOf("a", "b"),
+        )
+        assertEquals("hdr\na\nb\n", AimiSupportCsvTail.toText(tail))
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportDecisionLogFilterTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/advisor/diag/AimiSupportDecisionLogFilterTest.kt
@@ -1,0 +1,28 @@
+package app.aaps.plugins.aps.openAPSAIMI.advisor.diag
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Last-24h decision-log filter used by the support ZIP.
+ * Same heuristic as parked `AimiProfileAdvisorActivity` (not invented).
+ */
+class AimiSupportDecisionLogFilterTest {
+
+    @Test
+    fun `a line at or after the cutoff is kept`() {
+        assertTrue(AimiSupportDecisionLogFilter.keep("""{"timestamp":1000,"x":1}""", 1000L))
+        assertTrue(AimiSupportDecisionLogFilter.keep("""{"timestamp":1001}""", 1000L))
+    }
+
+    @Test
+    fun `a line before the cutoff is dropped`() {
+        assertFalse(AimiSupportDecisionLogFilter.keep("""{"timestamp":999}""", 1000L))
+    }
+
+    @Test
+    fun `a line without a timestamp is dropped`() {
+        assertFalse(AimiSupportDecisionLogFilter.keep("""{"bg":120}""", 1000L))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P2.2 only**. Port de `02c90656b1` (feat(aimi): put the training corpus and the running profile in the support package) sur la branche d’étude KMP.

### Ancres
- **Study base** = `kmp-aimi-migration-study` tip **`3029f0779acef5283ec39db504ceb6532b07c197`** (post P2.1)
- **Référence** = `origin/dev_OAPSAIMI` **`02c90656b1`** — feat(aimi): put the training corpus and the running profile in the support package
- Contexte tip ref : `fe96b64f12`

### Unpark vs nouveau port
- **Unparked** (dump `_docs/kmp/staging` ≠ source live) : `AimiDiagnosticsManager` (rapport black-box + code expert). Le dump n’avait **pas** `[ACTIVE PROFILE]` ni la queue CSV — c’était l’état pré-`02c906`.
- **Porté depuis `02c90656b1`** : section `[ACTIVE PROFILE]` via `ProfileFunction` (ISF/IC/basal/cible en mg/dL per U) ; queue `oapsaimiML2_records.csv` (en-tête + 3000 dernières lignes, comptage pas date).
- **Adapté étude / Milos (pas Hilt)** : l’Activity View `AimiProfileAdvisorActivity` reste **parked**. Équivalent Compose `AimiSupportPackageScreen` + `AimiSupportPackageExporter`, Metro / prefs existantes (`ApsIntentKey` + `withCompose`), pas de Dagger.

### Ce qui change
- ZIP support : `Diagnostic_Report.txt` (avec `[ACTIVE PROFILE]`) + `AIMI_Decisions_Last24h.jsonl` (déjà dans l’Activity parked) + queue `oapsaimiML2_records.csv`.
- Tests `commonTest` / `kotlin.test` : `AimiDiagnosticsActiveProfileTest` (locks de la ref), `AimiSupportCsvTailTest`, `AimiSupportDecisionLogFilterTest`.
- Câblage chirurgical dans `OpenAPSAIMIPlugin` (une entrée prefs). **Aucun** replace wholesale du plugin / `DetermineBasalAIMI2`.

### Hors périmètre
- P2.3 dashboard home
- P2.4 Garmin
- P2.5 tests bulk
- P2.1 viewer (déjà mergé)
- P2.7 meal camera / leftovers dump
- Flutter viewer

### Impact dose
**Zéro.** Observation / outils uniquement. Pas de formule inventée. Pas de Hilt. `DetermineBasalAIMI2` non modifié.

### ⚠️ ASYNC IMPACT
I/O fichier pour le ZIP (`Dispatchers.IO` : lecture CSV/JSONL, écriture ZIP, share). Hors chemin de dose.

### Evidence (fresh, this agent)
- `:plugins:aps:compileAndroidMain` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:compileKotlinIosArm64` — **BUILD SUCCESSFUL** EXIT=0 (commonMain touché)
- `:plugins:aps:jvmTest --tests 'app.aaps.plugins.aps.openAPSAIMI.advisor.diag.*'` — **11 tests, 0 failures** (`AimiDiagnosticsActiveProfileTest` 3, `AimiSupportCsvTailTest` 5, `AimiSupportDecisionLogFilterTest` 3)

## EN

Lot **P2.2 only**. Port of `02c90656b1` onto the KMP study branch.

### Anchors
- **Study base** = `kmp-aimi-migration-study` tip **`3029f0779acef5283ec39db504ceb6532b07c197`** (post P2.1)
- **Reference** = `origin/dev_OAPSAIMI` **`02c90656b1`**
- Ref tip context: `fe96b64f12`

### Unpark vs newly ported
- **Unparked** from `_docs/kmp/staging` (staging dump ≠ live source set): `AimiDiagnosticsManager`. Dump had no `[ACTIVE PROFILE]` and no CSV tail (pre-`02c906`).
- **Newly ported from `02c90656b1`**: `[ACTIVE PROFILE]` via `ProfileFunction`; `oapsaimiML2_records.csv` tail (header + last 3000 rows, counted not dated).
- **Study/Milos UI**: parked View `AimiProfileAdvisorActivity` is **not** copied. Compose `AimiSupportPackageScreen` + exporter, Metro / existing prefs, no Hilt.

### What changed
Support ZIP = diagnostic report (with running profile) + last-24h decision log + training-corpus tail. Surgical plugin wiring only.

### Out of scope
P2.3 home dashboard, P2.4 Garmin, P2.5 bulk tests, P2.1 viewer, P2.7 meal camera, Flutter viewer changes, dose path.

### Dose impact
**None.** Tools/observation only. No invented formulas. No Hilt. `DetermineBasalAIMI2` untouched.

### ⚠️ ASYNC IMPACT
File I/O for the ZIP (`Dispatchers.IO`). Not on the dose path.

### Evidence (fresh, this agent)
- `:plugins:aps:compileAndroidMain` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:compileKotlinIosArm64` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:jvmTest --tests 'app.aaps.plugins.aps.openAPSAIMI.advisor.diag.*'` — **11 tests, 0 failures**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c112ffbe-42eb-4f63-9caa-74aa6fcd670a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c112ffbe-42eb-4f63-9caa-74aa6fcd670a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

