### PR TITLE
docs(kmp): ancre P2.2 PR #96 vs 02c906 support ZIP

### DIFF
--- a/_docs/kmp/P2.2-ANCHOR.md
+++ b/_docs/kmp/P2.2-ANCHOR.md
@@ -1,0 +1,209 @@
+# Ancre P2.2 — PR #96 vs `origin/dev_OAPSAIMI` @ `02c90656b1`
+
+**Verdict : `GO_WITH_CAVEATS`**
+
+Relu le **2026-09-11** sur le code (study / head / source), pas sur le texte du PR. Aucun changement clinique dans cette ancre. Lot **outils / observation** : ZIP support Advisor.
+
+| Rôle | SHA | Branche / objet |
+|---|---|---|
+| HEAD P2.2 | `5c20e9650b047443447a5bf12655b81f931f503f` | PR **#96** `cursor/p22-advisor-support-zip-670a` |
+| Base #96 (post-P2.1) | `3029f0779acef5283ec39db504ceb6532b07c197` | `kmp-aimi-migration-study` après merge **#94** |
+| Source ZIP / profil actif | `02c90656b183e65d08bc803fe86f9d982dd462a9` | `origin/dev_OAPSAIMI` — *feat(aimi): put the training corpus and the running profile in the support package* |
+| Parent source (ZIP pré-corpus) | `db21308e6c00c6b6a2bf0f2485dd351296a2bf50` | Activity = rapport + JSONL 24 h **sans** CSV **sans** `[ACTIVE PROFILE]` |
+| Tip `origin/dev_OAPSAIMI` au jour de l’ancre | `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc` | **hors lot** (DescentRedoseGuard, etc.) |
+| Dump staging (parké) | `_docs/kmp/staging/openAPSAIMI-android-wip/` | `AimiDiagnosticsManager` **sans** `[ACTIVE PROFILE]` ; Activity **sans** `addCsvTail` — état **pré-`02c906`** |
+
+P0.8 (#80) avait **différé** `02c90656b1` (Activity / DiagnosticsManager absents des source sets). P2.2 le porte, **sans** déparker l’Activity View.
+
+PR : https://github.com/MTR93600/OpenApsAIMI/pull/96
+
+---
+
+## 1. Contenu réel de PR #96
+
+- **1 commit** : `5c20e9650b` — *P2.2 — Advisor support ZIP corpus + active profile (02c906)*
+- **13 fichiers**, **+817 / −0** (GitHub et `git diff --numstat` identiques)
+- Parent du commit = `3029f0779a` (aucun autre commit study)
+- Merge-base `kmp-aimi-migration-study`…head = `3029f0779a`
+
+Sur la ref, `02c90656b1` ne touche que **3 fichiers** `src/main` / `src/test` (+218 / −4). L’étude n’avait pas ces types dans les source sets : le lot est **additif**, d’où +817 / −0.
+
+| Fichier study | Statut |
+|---|---|
+| `plugins/aps/src/androidMain/.../OpenAPSAIMIPlugin.kt` | modifié (+23) — **une** entrée prefs Compose |
+| `androidMain/.../advisor/compose/AimiSupportPackageScreen.kt` | ajouté |
+| `androidMain/.../advisor/diag/AimiDiagnosticsManager.kt` | ajouté (unpark dump + greffe `02c906`) |
+| `androidMain/.../advisor/diag/AimiSupportPackageExporter.kt` | ajouté (ZIP Activity extrait) |
+| `androidMain/res/values/aimi_strings.xml` | modifié (+6) |
+| `androidMain/res/values/strings.xml` | modifié (+2) — titres `ApsIntentKey` |
+| `commonMain/.../keys/ApsIntentKey.kt` | modifié (+7) — `AimiSupportPackage` |
+| `commonMain/.../advisor/diag/AimiDiagnosticsActiveProfile.kt` | ajouté |
+| `commonMain/.../advisor/diag/AimiSupportCsvTail.kt` | ajouté |
+| `commonMain/.../advisor/diag/AimiSupportDecisionLogFilter.kt` | ajouté |
+| `commonTest/.../AimiDiagnosticsActiveProfileTest.kt` | ajouté (3 locks) |
+| `commonTest/.../AimiSupportCsvTailTest.kt` | ajouté (5) |
+| `commonTest/.../AimiSupportDecisionLogFilterTest.kt` | ajouté (3) |
+
+**Non touchés** (`git diff --name-only 3029f0779a..5c20e9650b` vide sur ces chemins) :
+
+- `DetermineBasalAIMI2.kt`
+- `AimiProfileAdvisorActivity.kt` (reste dump staging)
+- Garmin (`plugins/sync/.../garmin/**`, icônes Garmin)
+- dashboard home / Control Center wholesale
+- `LoopHubImpl.kt`
+- `AimiDiagnosticsPrefExportPolicy.kt` (déjà `commonMain` study)
+- meal camera / leftovers dump
+
+---
+
+## 2. Tableau items P2.2
+
+| # | Item | Statut | Fidélité vs `02c90656b1` | Preuve |
+|---|---|---|---|---|
+| 1 | ZIP = `Diagnostic_Report.txt` + `AIMI_Decisions_Last24h.jsonl` + queue `oapsaimiML2_records.csv` | **Appliqué** | Mêmes 3 entrées, même ordre | Ref `generateAndShareReport` (Activity) ; study `AimiSupportPackageExporter.build` |
+| 2 | `[ACTIVE PROFILE]` via `ProfileFunction.getProfile()` / `getProfileName()` | **Appliqué** | Mêmes accessors (`getIsfsMgdlValues`, `getIcsValues`, `getBasalValues`, `getSingleTargetsMgdl`), mg/dL per U | Ref `appendActiveProfile` ; study `AimiDiagnosticsActiveProfile` ; `EffectiveProfile : Profile` (même interface que la ref) |
+| 3 | Profil absent **énoncé**, pas omis | **Appliqué** | Texte identique `Not available when the report was built.` | Test ref + study |
+| 4 | Préambule `LocalProfile_*` = éditeur, pas la boucle | **Appliqué** | Deux lignes identiques ; `[ACTIVE PROFILE]` **avant** `[AIMI PREFERENCES]` | Test ref + study |
+| 5 | Queue CSV : en-tête + **3000** dernières lignes, **comptées** pas datées | **Appliqué** | `lines.first()` + `drop(1).takeLast(3000)` | Ref `addCsvTail` / `MAX_CSV_ROWS_IN_PACKAGE` ; study `AimiSupportCsvTail` |
+| 6 | JSONL 24 h : heuristic `"timestamp":` sans parse JSON complet ; ligne sans ts **jetée** | **Appliqué** | `indexOf("\"timestamp\":")` + 12 + digits + `>= cutoff` | Ref Activity ; study `AimiSupportDecisionLogFilter.keep` |
+| 7 | `AimiDiagnosticsManager` unparké | **Appliqué** | Hash expert, `verifyCode`, dump prefs + secrets, `[SYSTEM]` / `[NIGHTSCOUT]` / `[VITAL STATS]` | Dump staging **sans** profil actif ; head = dump **+** greffe `02c906` |
+| 8 | Activity View `AimiProfileAdvisorActivity` | **Parkée** | Non copiée (Hilt / View / 2300+ L) | Présente seulement `_docs/kmp/staging/.../AimiProfileAdvisorActivity.kt` sur study **et** head |
+| 9 | UI étude = Compose + Metro / prefs | **Adapté** | Pas Hilt. `ApsIntentKey.AimiSupportPackage.withCompose` | Plugin `dev.zacsweers.metro.Inject` ; constructeur exporter **manuel** dans le lambda Compose |
+| 10 | Zéro dose | **Tenu** | Pas de tick / DB2 / ancre dose | `DetermineBasalAIMI2` absent du diff ; plugin = **un** `add(…withCompose)` après Control Center |
+
+---
+
+## 3. Fidélité ZIP / diagnostic (corpus + profil)
+
+### 3.1 Contenu du paquet
+
+Ref `02c906` `generateAndShareReport` et study `AimiSupportPackageExporter.build` :
+
+1. `Diagnostic_Report.txt` si le rapport n’est pas vide
+2. `AIMI_Decisions_Last24h.jsonl` si `T3cRuntimeHistoryReader.aimiDecisionsJsonlFile()` existe et est lisible (entrée ZIP même si 0 ligne gardée — **identique**)
+3. `oapsaimiML2_records.csv` : skip silencieux si fichier manquant / illisible / vide
+
+Cutoff 24 h : ref `System.currentTimeMillis()` ; study `aimiWallClockMs()` (`Clock.System.now().toEpochMilliseconds()`). Même horloge murale, couture PORTING (interdit `System.currentTimeMillis()` en commonMain).
+
+Nom ZIP : `AIMI_Support_Package_<epoch>.zip` dans `cacheDir`. Share : `ACTION_SEND` `application/zip`, subject `aimi_diag_subject`, texte `AIMI Support Package attached (ZIP).` — **identique**. Study ajoute `FLAG_ACTIVITY_NEW_TASK` parce que le `Context` plugin n’est pas l’Activity (nécessaire).
+
+### 3.2 Rapport texte
+
+`generateReport(userMessage, activeProfile, activeProfileName)` :
+
+- `[USER TICKET]` / `[SYSTEM]` / `[NIGHTSCOUT]` (URL `@` → `***SECRET***@`) : mêmes chaînes
+- puis `[ACTIVE PROFILE]` + préambule éditeur
+- dump SharedPreferences `*_preferences`, clés `aimi|aps|smb|max|basal|target|profile|opt_`, exclusion password/token/secret + `AimiDiagnosticsPrefExportPolicy` (**déjà** `commonMain` study, **non** modifié par #96)
+- `[VITAL STATS]` placeholder V2 — **identique** à la ref (pas de DB)
+
+Format des blocs profil :
+
+- Ref : `String.format(Locale.US, "%02d:%02d %.2f", …)`
+- Study : `padStart(2,'0')` + `aimiFmt2` (`NumberFormat.DECIMAL_2` / `SEPARATOR_DOT`)
+
+Locks `02c906` reproduits : `00:00 120.00, 11:00 50.00` / `7.00` / `0.50` / `115.00`. `DECIMAL_2.format(1.0)` = `"1.00"` (tests `NumberFormatParityTest`). Pas de `Locale` appareil.
+
+### 3.3 Tests
+
+Ref `src/test` : JUnit + Truth + mockk Android, 3 tests sur `generateReport()`.
+
+Study `commonTest` + `kotlin.test` :
+
+- 3 tests **mêmes assertions** (virgule du nom Native retirée : `stated not left out` — pattern P0.8)
+- + 5 CSV + 3 JSONL (la ref n’avait **pas** ces tests ; extraits pour KMP)
+
+Cette ancre a relancé sur `5c20e9650b` :
+
+```
+./gradlew --no-daemon :plugins:aps:jvmTest --tests 'app.aaps.plugins.aps.openAPSAIMI.advisor.diag.*'
+```
+
+**BUILD SUCCESSFUL**, XML : `AimiDiagnosticsActiveProfileTest` 3, `AimiSupportCsvTailTest` 5, `AimiSupportDecisionLogFilterTest` 3 — **11 tests, 0 failure, 0 error**.
+
+---
+
+## 4. Zéro dose
+
+| Chemin | Constat @ `5c20e9650b` vs `3029f0779a` |
+|---|---|
+| `DetermineBasalAIMI2.kt` | **0** ligne |
+| `invoke` / formule / ancre ISF / SMB | non touchés |
+| `OpenAPSAIMIPlugin` | uniquement imports + `add(ApsIntentKey.AimiSupportPackage.withCompose(…))` dans l’écran prefs. `@MetroIntKey(250)` inchangé |
+| DB / PersistenceLayer / tick | non touchés |
+| `SmbTrainingRowBuffer` | non touché (le ZIP **lit** le CSV déjà écrit) |
+
+⚠️ ASYNC IMPACT **du lot étudié** : I/O ZIP (`Dispatchers.IO` dans l’écran Compose). **Hors** chemin de dose. Cette ancre n’ajoute aucune coroutine.
+
+---
+
+## 5. Adaptations KMP vs divergences sémantiques
+
+| Sujet | Adaptation KMP | Divergence sémantique du **paquet** ? |
+|---|---|---|
+| Activity View Hilt vs Compose prefs | Activity **parkée**. `AimiSupportPackageScreen` + exporter, `withCompose` (même patron que Control Center) | Non. Flux expert-code → ticket → ZIP identique |
+| Metro | Plugin déjà `@Inject` Metro. Exporter **sans** Hilt / `javax.inject` | Non |
+| `aimiFmt2` / `aimiWallClockMs` | Interdits `String.format` / `currentTimeMillis` en commonMain | Non (locks + horloge murale) |
+| Heuristique JSONL extraite | `keep()` sans `try/catch` par ligne ; `toLongOrNull` ne jette pas | Non pour le JSONL attendu |
+| Tests commonTest | Pas de mock Android de `generateReport()` complet | Non. Locks profil = ref. Extra CSV/JSONL |
+| `FLAG_ACTIVITY_NEW_TASK` | Context application | UX share seulement |
+| Dump staging Activity | Reste pré-`02c906` (pas de CSV / pas de profil) | **Voulu.** Dump ≠ source live. Ne pas recoller |
+
+**Aucune divergence sémantique** sur les 3 fichiers du ZIP ni sur `[ACTIVE PROFILE]`.
+
+---
+
+## 6. Hors-scope respecté
+
+| Interdit P2.2 | Constat |
+|---|---|
+| P2.3 dashboard home wholesale | Control Center / Hormonitor **non** retouchés |
+| P2.4 Garmin | Aucun fichier `garmin` |
+| P2.5 tests bulk | Seulement `advisor.diag.*` (11) |
+| P2.1 viewer | Déjà mergé `#94` ; `tools/aimi_viewer` hors diff |
+| P2.7 meal camera / leftovers dump | Activity meal **parkée** |
+| Replace plugin / tick | Non |
+| Hilt / `@IntKey(225)` | Non |
+| Recoller dump Activity | Non |
+
+---
+
+## 7. Caveats vs blockers
+
+### Blockers
+
+Aucun. Pas de change de dose, pas d’écart de formule, hors-scope tenu, contenu ZIP fidèle à `02c906`.
+
+### Caveats (suivre, ne bloquent pas le merge P2.2)
+
+1. **Coquille UI Compose, pas l’Activity 2300 L.** Le dump Activity reste pré-`02c906`. C’est le contrat étude (pas Hilt). Ne pas traiter le dump comme source live.
+2. **CI GitHub #96** — `ios` fail (variants Gradle `:plugins:libre3` / `:plugins:libkeks`, **préexistant**) + `claude-review` fail (OIDC 401). Même forme que P0.8 / P0.9. **Ne juge pas** ce diff.
+3. **Cette ancre n’a pas relancé** `compileAndroidMain` / `compileKotlinIosArm64`. Preuve fraîche = `jvmTest` diag **11/11** + `compileKotlinJvm` (chemin `jvmTest`). Les compiles Android+iOS restent l’annonce du PR.
+4. **`[VITAL STATS]` reste le placeholder V2** — identique à `02c906`. Pas un oubli.
+5. **Share `NEW_TASK`** — delta vs Activity ; nécessaire hors Activity.
+
+---
+
+## 8. Checklist preuves
+
+- [x] PR #96 : 1 commit `5c20e9650b`, 13 fichiers, +817/−0, base `3029f0779a`
+- [x] Source `02c90656b1` : 3 fichiers Activity + DiagnosticsManager + test profil
+- [x] Dump staging DiagnosticsManager / Activity **sans** `[ACTIVE PROFILE]` / **sans** CSV 3000
+- [x] ZIP study = rapport + JSONL 24 h + `oapsaimiML2_records.csv` tail 3000
+- [x] `ProfileFunction.getProfile()` / `getProfileName()` ; `EffectiveProfile : Profile`
+- [x] Locks profil identiques (120/50, 7.00, 0.50, 115.00 ; profil manquant énoncé ; préambule éditeur)
+- [x] `DetermineBasalAIMI2` / Garmin / dashboard wholesale / meal camera **hors** diff
+- [x] Activity View absente des source sets ; Compose + Metro ; pas Hilt
+- [x] `jvmTest` diag @ `5c20e9650b` : 11/11
+- [x] CI GitHub rouge = préexistant (libre3/libkeks + OIDC), pas un verdict de ce lot
+
+---
+
+## 9. Recommandation
+
+| Action | Reco |
+|---|---|
+| **Merge #96** | **Oui** — outils only, fidèle à `02c90656b1` pour le **contenu** du ZIP, Activity parkée comme annoncé |
+| **Fix avant merge** | **Non** — pas de blocker clinique ni de trou ZIP |
+| **Suite** | P2.3 dashboard home (sans recoller l’Activity). Ne pas greffer Garmin / meal camera / tip `fe96b64f12` dans le même PR. Ne pas « corriger » le dump staging Activity (il n’est plus la source). |
+
+P0.8 avait différé `02c90656b1`. P2.2 le clôt côté **paquet support**. L’Activity View Advisor reste volontairement hors source sets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre **P2.2** (doc-only). Relecture du code de [PR #96](https://github.com/MTR93600/OpenApsAIMI/pull/96) vs source `origin/dev_OAPSAIMI` @ `02c90656b1`.

**Verdict : `GO_WITH_CAVEATS`** — merge #96 recommandé, pas de fix clinique.

| Rôle | SHA |
|---|---|
| HEAD #96 | `5c20e9650b047443447a5bf12655b81f931f503f` |
| Base study (post-P2.1) | `3029f0779acef5283ec39db504ceb6532b07c197` |
| Source ZIP / profil | `02c90656b183e65d08bc803fe86f9d982dd462a9` |

Preuves dans `_docs/kmp/P2.2-ANCHOR.md` :

- ZIP = `Diagnostic_Report.txt` (`[ACTIVE PROFILE]` via `ProfileFunction`) + JSONL 24 h + `oapsaimiML2_records.csv` (header + 3000, comptage)
- Activity View **parkée** ; Compose + Metro
- **Zéro dose** (`DetermineBasalAIMI2` hors diff)
- `jvmTest` diag @ head : **11/11** (relancé par cette ancre)
- Hors-scope : dashboard / Garmin / meal camera / seams

Aucun changement clinique.

## EN

P2.2 anchor (docs only). Verdict **GO_WITH_CAVEATS**: merge #96, no clinical fix. ZIP contents faithful to `02c90656b1`; View Activity stays parked; zero dose path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f72b9e3-6076-43c9-82e5-87057be83cac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f72b9e3-6076-43c9-82e5-87057be83cac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

