### PR TITLE
P2.5.1 — AIMI pure tests package 1 (≤15)

### DIFF
--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/UamInputSchemaValidatorTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/UamInputSchemaValidatorTest.kt
@@ -1,0 +1,36 @@
+package app.aaps.plugins.aps.openAPSAIMI
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the UAM tensor input-count helper used when a batched shape `[1, 18]` must yield 18 features.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `fe96b64f12`
+ * (`plugins/aps/src/test/.../UamInputSchemaValidatorTest.kt`). Study source set:
+ * [UamInputSchemaValidator] is commonMain with no File/Android, so the tests live in
+ * `commonTest` (`kotlin.test`) — same layout as [AimiSmbCorpusGuardTest], not `androidHostTest`.
+ *
+ * Adaptations: `org.junit.jupiter` + Truth → `kotlin.test`; snake_case names → backticks without
+ * commas (Kotlin/Native). No production change.
+ */
+class UamInputSchemaValidatorTest {
+
+    @Test
+    fun `expected feature count uses last dimension for batched tensor shapes`() {
+        val expected = UamInputSchemaValidator.expectedFeatureCount(intArrayOf(1, 18))
+
+        assertEquals(18, expected)
+    }
+
+    @Test
+    fun `mismatch reason is explicit for runtime logs`() {
+        val reason = UamInputSchemaValidator.mismatchReason(expectedCount = 18, actualCount = 15)
+
+        assertTrue(
+            "expected 18 features, got 15" in reason,
+            "reason=$reason",
+        )
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbRefinementFeatureSchemaTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/SmbRefinementFeatureSchemaTest.kt
@@ -1,0 +1,256 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import app.aaps.plugins.aps.openAPSAIMI.patient.CausalStateId
+import app.aaps.plugins.aps.openAPSAIMI.patient.CausalStatePosterior
+import app.aaps.plugins.aps.openAPSAIMI.patient.PatientMode
+import app.aaps.plugins.aps.openAPSAIMI.patient.PatientModeOrchestrator
+import app.aaps.plugins.aps.openAPSAIMI.patient.PatientStrategyHint
+import app.aaps.plugins.aps.openAPSAIMI.physio.PhysioLatentState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+/**
+ * Locks the SMB-refinement feature schema: runtime vector layout, old-CSV fallback neutrals,
+ * family-audit columns ignored by the trainer parser, and the conflict/fragility training gate.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `fe96b64f12`
+ * (`plugins/aps/src/test/.../ml/SmbRefinementFeatureSchemaTest.kt`). Study source set:
+ * [SmbRefinementFeatureSchema] is commonMain with no File/Android, so the tests live in
+ * `commonTest` (`kotlin.test`) — same layout as [AimiSmbCorpusGuardTest] /
+ * [SmbTrainingRowBufferTest], not `androidHostTest`. Assertions are the same locks as the
+ * Truth/JUnit Jupiter reference corpus.
+ *
+ * Adaptations: `org.junit.jupiter` + Truth → `kotlin.test`; snake_case names → backticks without
+ * commas (Kotlin/Native). No production change.
+ */
+class SmbRefinementFeatureSchemaTest {
+
+    @Test
+    fun `build runtime features appends latent physio axes and trend indicator`() {
+        val features = SmbRefinementFeatureSchema.buildRuntimeFeatures(
+            baseFeatures = floatArrayOf(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f),
+            trendIndicator = 0.73f,
+            physioLatentState = PhysioLatentState(
+                mealProb = 0.41,
+                endogenousGlucoseDrive = 0.28,
+                circadianSiFactor = 0.91,
+                transientResistanceProb = 0.64,
+                postHypoReboundProb = 0.22,
+                sleepDebtScore = 0.15,
+                sensorConfidence = 0.94,
+                falseMealSuppression = false,
+                source = "test",
+            ),
+            patientModeDecision = PatientModeOrchestrator.Decision(
+                mode = PatientMode.FAST_MEAL,
+                confidence = 0.89,
+                strategyHint = PatientStrategyHint.SMB_PRIORITY,
+                mealBias = 0.90,
+                protectionBias = 0.18,
+                userIntentConfidence = 0.84,
+                reasonCodes = listOf("MEAL_FIRST_WAVE"),
+            ),
+            causalStatePosterior = CausalStatePosterior(
+                fastMealProb = 0.83,
+                prolongedMealProb = 0.18,
+                dawnEndogenousProb = 0.12,
+                postHypoRecoveryProb = 0.04,
+                stressResistanceProb = 0.10,
+                exerciseAfterburnProb = 0.06,
+                inflammatoryDriftProb = 0.08,
+                absorptionUncertainProb = 0.11,
+                dominant = CausalStateId.FAST_MEAL,
+                dominantConfidence = 0.83,
+                learningQuality = 0.79,
+            ),
+        )
+
+        assertEquals(SmbRefinementFeatureSchema.INPUT_SIZE, features.size)
+        assertEquals(
+            listOf(0.41f, 0.28f, 0.91f, 0.64f),
+            features.copyOfRange(10, 14).toList(),
+        )
+        assertEquals(
+            listOf(0.90f, 0.18f, 0.84f),
+            features.copyOfRange(14, 17).toList(),
+        )
+        assertEquals(
+            listOf(0.83f, 0.12f, 0.79f),
+            features.copyOfRange(17, 20).toList(),
+        )
+        assertEquals(0.73f, features.last())
+    }
+
+    @Test
+    fun `parse training features keeps backward compatibility for old csv rows`() {
+        val headers = listOf(
+            "dateStr",
+            "bg",
+            "iob",
+            "cob",
+            "delta",
+            "shortAvgDelta",
+            "longAvgDelta",
+            "tdd7DaysPerHour",
+            "tdd2DaysPerHour",
+            "tddPerHour",
+            "tdd24HrsPerHour",
+            "predictedSMB",
+            "smbGiven",
+        )
+        val cols = listOf(
+            "06/06/2026 08:00",
+            "152",
+            "1.2",
+            "9.0",
+            "3.5",
+            "2.9",
+            "1.7",
+            "0.8",
+            "0.7",
+            "0.9",
+            "1.0",
+            "0.4",
+            "0.35",
+        )
+
+        val parsed = assertNotNull(SmbRefinementFeatureSchema.parseTrainingFeatures(headers, cols))
+        assertEquals(SmbRefinementFeatureSchema.INPUT_SIZE - 1, parsed.size)
+        assertEquals(
+            listOf(0f, 0f, 1f, 0f, 0.45f, 0.22f, 0f, 0f, 0f, 1f),
+            parsed.copyOfRange(10, 20).toList(),
+        )
+    }
+
+    @Test
+    fun `parse training features ignores family audit columns`() {
+        val headers = listOf(
+            "dateStr",
+            "bg",
+            "iob",
+            "cob",
+            "delta",
+            "shortAvgDelta",
+            "longAvgDelta",
+            "tdd7DaysPerHour",
+            "tdd2DaysPerHour",
+            "tddPerHour",
+            "tdd24HrsPerHour",
+            "mealProb",
+            "endogenousGlucoseDrive",
+            "circadianSiFactor",
+            "transientResistanceProb",
+            "patientModeMealBias",
+            "patientModeProtectionBias",
+            "contextIntentConfidence",
+            "causalMealConfidence",
+            "causalProtectiveConfidence",
+            "causalLearningQuality",
+            "familyProtectionLevel",
+            "familyMealLevel",
+            "familyStabilityLevel",
+            "familyPhysioLevel",
+            "familyAutonomyLevel",
+            "predictedSMB",
+            "smbGiven",
+        )
+        val cols = listOf(
+            "06/11/2026 08:00",
+            "148",
+            "1.0",
+            "8.0",
+            "3.0",
+            "2.4",
+            "1.6",
+            "0.8",
+            "0.7",
+            "0.9",
+            "1.0",
+            "0.44",
+            "0.19",
+            "0.92",
+            "0.58",
+            "0.74",
+            "0.33",
+            "0.65",
+            "0.71",
+            "0.12",
+            "0.82",
+            "2",
+            "4",
+            "3",
+            "1",
+            "3",
+            "0.35",
+            "0.30",
+        )
+
+        val parsed = assertNotNull(SmbRefinementFeatureSchema.parseTrainingFeatures(headers, cols))
+        assertEquals(SmbRefinementFeatureSchema.INPUT_SIZE - 1, parsed.size)
+        assertEquals(
+            listOf(0.71f, 0.12f, 0.82f),
+            parsed.copyOfRange(17, 20).toList(),
+        )
+    }
+
+    @Test
+    fun `should use csv row for training rejects conflicted or fragile rows`() {
+        val headers = listOf(
+            "dateStr",
+            "bg",
+            "iob",
+            "cob",
+            "delta",
+            "shortAvgDelta",
+            "longAvgDelta",
+            "tdd7DaysPerHour",
+            "tdd2DaysPerHour",
+            "tddPerHour",
+            "tdd24HrsPerHour",
+            "mealProb",
+            "endogenousGlucoseDrive",
+            "circadianSiFactor",
+            "transientResistanceProb",
+            "patientModeMealBias",
+            "patientModeProtectionBias",
+            "contextIntentConfidence",
+            "causalMealConfidence",
+            "causalProtectiveConfidence",
+            "causalLearningQuality",
+            "eventMemoryPostHyperExhaustionScore",
+            "eventMemoryCorrectionFragilityScore",
+            "decisionConflictFlags",
+        )
+        val cols = listOf(
+            "06/11/2026 08:00",
+            "182",
+            "1.8",
+            "12.0",
+            "2.5",
+            "2.1",
+            "1.5",
+            "0.8",
+            "0.7",
+            "0.9",
+            "1.0",
+            "0.52",
+            "0.18",
+            "0.93",
+            "0.28",
+            "0.80",
+            "0.20",
+            "0.54",
+            "0.72",
+            "0.22",
+            "0.78",
+            "0.48",
+            "0.75",
+            "dual_delivery|dual_delivery_tbr_up",
+        )
+
+        val parsed = assertNotNull(SmbRefinementFeatureSchema.parseTrainingFeatures(headers, cols))
+        assertFalse(SmbRefinementFeatureSchema.shouldUseCsvRowForTraining(headers, cols, parsed))
+    }
+}

--- a/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCircuitBreakerTest.kt
+++ b/plugins/aps/src/commonTest/kotlin/app/aaps/plugins/aps/openAPSAIMI/ml/TrainingCircuitBreakerTest.kt
@@ -1,0 +1,58 @@
+package app.aaps.plugins.aps.openAPSAIMI.ml
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the on-device trainer circuit breaker: trip after N consecutive failures, cooldown, reset.
+ *
+ * Matching tests from `origin/dev_OAPSAIMI` @ `fe96b64f12`
+ * (`plugins/aps/src/test/.../ml/TrainingCircuitBreakerTest.kt`). Study source set:
+ * [TrainingCircuitBreaker] is commonMain (`AapsLock` + injectable clock), so the tests live in
+ * `commonTest` (`kotlin.test`) — same layout as [SmbTrainingRowBufferTest], not `androidHostTest`.
+ *
+ * Adaptations: `org.junit.jupiter` + Truth → `kotlin.test`. Clock injection is already on study
+ * (same as ref). No File, no Hilt, no production change.
+ */
+class TrainingCircuitBreakerTest {
+
+    @Test
+    fun `opens only after max consecutive failures and signals the trip once`() {
+        var now = 0L
+        val cb = TrainingCircuitBreaker(maxFailures = 3, cooldownMs = 1_000L, clock = { now })
+
+        assertFalse(cb.isOpen())
+        assertFalse(cb.recordFailure()) // 1
+        assertFalse(cb.recordFailure()) // 2
+        assertFalse(cb.isOpen())
+        assertTrue(cb.recordFailure())  // 3 → trips open
+        assertTrue(cb.isOpen())
+    }
+
+    @Test
+    fun `attempts are allowed again once the cooldown elapses`() {
+        var now = 0L
+        val cb = TrainingCircuitBreaker(maxFailures = 2, cooldownMs = 1_000L, clock = { now })
+
+        cb.recordFailure()
+        cb.recordFailure()
+        assertTrue(cb.isOpen())
+
+        now = 1_001L
+        assertFalse(cb.isOpen())
+    }
+
+    @Test
+    fun `reset clears the failure count`() {
+        var now = 0L
+        val cb = TrainingCircuitBreaker(maxFailures = 2, cooldownMs = 1_000L, clock = { now })
+
+        cb.recordFailure()
+        cb.recordFailure()
+        assertTrue(cb.isOpen())
+
+        cb.reset()
+        assertFalse(cb.isOpen())
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Lot **P2.5.1 only** — premier paquet de tests unitaires AIMI purs depuis `origin/dev_OAPSAIMI` vers la branche d’étude KMP. **Tests uniquement. Zéro changement du chemin de dose.**

### Ancres (revérifiées)
- **Study base** = `kmp-aimi-migration-study` tip **`c19eccfb14c691e76c6f2de2162938b0837800a3`** (post P2.2)
- **Référence** = `origin/dev_OAPSAIMI` tip **`fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc`**

| Inventaire | Fichiers `*Test.kt` | Méthodes `@Test` |
|---|---:|---:|
| Ref `plugins/aps/.../openAPSAIMI/` | 258 | 1451 |
| Study `commonTest` AIMI (avant ce PR) | 23 | 158 |
| Study `androidHostTest` AIMI (avant ce PR) | 16 | 56 |
| Manquants (basename, avant ce PR) | 230 | ~1255 |

L’inventaire « ~266 vs ~24+16 » collait aux **fichiers** (258 vs 23+16). Les comptes ci-dessus sont des méthodes `@Test` + fichiers, revérifiés sur les deux tips.

### Paquet porté (9 tests, ≤15)
**SMB schema / corpus restant + UAM input schema** — logique déjà en `commonMain`, aucun seam Android.

| Ref (`plugins/aps/src/test/...`) | Study | `@Test` | Statut |
|---|---|---:|---|
| `ml/SmbRefinementFeatureSchemaTest.kt` | `commonTest/.../ml/` | 4 | **porté** |
| `ml/TrainingCircuitBreakerTest.kt` | `commonTest/.../ml/` | 3 | **porté** |
| `UamInputSchemaValidatorTest.kt` | `commonTest/.../` | 2 | **porté** |

Complète le cluster déjà sur l’étude : `AimiSmbCorpusGuardTest`, `SmbTrainingRowBufferTest` (P1.1).

### Adaptations (pas de changement de production)
- JUnit Jupiter + Truth → `kotlin.test` (`commonTest`)
- Noms snake_case → backticks **sans virgule** (Kotlin/Native)
- Pas de `File` / `Locale.US` / Hilt / mockk — les trois suites sont pures
- `TrainingCircuitBreaker` : horloge injectable déjà présente sur l’étude (comme la ref)

### Hors périmètre
- P2.3 dashboard, P2.4 Garmin, P2.6 tick seams, P2.8 Metro source
- Flutter viewer, Advisor ZIP (P2.2, déjà mergé)
- Aucune édition production / dose / tick

### Impact dose
**Zéro.** Aucune formule inventée. `DetermineBasalAIMI2` / plugin / tick non touchés. Trois fichiers `commonTest` uniquement.

### ⚠️ ASYNC IMPACT
Aucun. `TrainingCircuitBreaker` utilise `AapsLock` déjà en production ; les tests injectent une horloge déterministe. Pas de coroutine dose.

### Follow-ups (ne pas implémenter ici)
Paquets suivants, chacun ≤15 tests, logique `commonMain` déjà présente :

1. **P2.5.2** — SMB policy math : `SmbQuantizer`, `SmbIntervalPolicy`, `MealHighIobPolicy`, `SmbMpcPiBlend` (15)
2. **P2.5.3** — Autodrive pur restant : `PhysiologicalStressMaskBuilder`, `MpcControllerCandidateGrid` (12)
3. **P2.5.4** — Shields : `ControlBarrierShieldDiagnostics` + `ControlBarrierShieldSafetySi` (11, mockk → fakes)
4. **P2.5.5** — Safety petits gates : `CompressionReboundGuard`, `HypoTools`, `HypoLgsBlockReason`, `InsulinStackingSignals`, `PostHypoAggressiveRiseExit` (~14)
5. **P2.5.6** — Safety SMB/basal : `SmbMaxLimits`, `BasalFirstPolicy`, `HighBgOverride`, `CorrectionAggressionGate` (split)
6. **P2.5.7** — Advisor parsers : meal JSON + oref reason/outcome
7. **P2.5.8** — Patient restant : Harmonia harmonizer/arbiter, PatientMode/State
8. **P2.5.9** — Physio pattern / thyroid / thermal
9. **P2.5.10+** — PKPD, recursive, release, risk, estimator Autodrive (mockk), ml File/Android, DetermineBasal scenarios

Reste après ce PR : **~227 fichiers / ~1255 `@Test`**. Garder ≤15 par PR.

### Evidence (fresh, this agent)
- `:plugins:aps:compileAndroidMain` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:compileKotlinIosArm64` — **BUILD SUCCESSFUL** EXIT=0 (commonTest touché)
- `:plugins:aps:jvmTest` (3 classes) — **9 tests, 0 failures, 0 errors, 0 skipped**
  - `SmbRefinementFeatureSchemaTest` 4
  - `TrainingCircuitBreakerTest` 3
  - `UamInputSchemaValidatorTest` 2
- Diff vs study : **3 fichiers `commonTest` only**, +350 lignes, zéro production

## EN

Lot **P2.5.1 only** — first package of pure AIMI unit tests from `origin/dev_OAPSAIMI` onto the KMP study branch. **Tests only. Zero clinical dose path change.**

### Anchors (re-verified)
- **Study base** = `kmp-aimi-migration-study` tip **`c19eccfb14c691e76c6f2de2162938b0837800a3`** (post P2.2)
- **Reference** = `origin/dev_OAPSAIMI` tip **`fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc`**

| Inventory | `*Test.kt` files | `@Test` methods |
|---|---:|---:|
| Ref `plugins/aps/.../openAPSAIMI/` | 258 | 1451 |
| Study `commonTest` AIMI (before this PR) | 23 | 158 |
| Study `androidHostTest` AIMI (before this PR) | 16 | 56 |
| Missing by basename (before this PR) | 230 | ~1255 |

The “~266 vs ~24+16” note matches **files** (258 vs 23+16). Counts above are re-verified `@Test` methods + files on both tips.

### Package ported (9 tests, ≤15)
**Remaining SMB schema/corpus + UAM input schema** — production already in `commonMain`, no Android-only seams.

| Ref | Study | `@Test` | Status |
|---|---|---:|---|
| `ml/SmbRefinementFeatureSchemaTest.kt` | `commonTest/.../ml/` | 4 | **ported** |
| `ml/TrainingCircuitBreakerTest.kt` | `commonTest/.../ml/` | 3 | **ported** |
| `UamInputSchemaValidatorTest.kt` | `commonTest/.../` | 2 | **ported** |

Completes the cluster already on study: `AimiSmbCorpusGuardTest`, `SmbTrainingRowBufferTest` (P1.1).

### Adaptations (no production change)
- JUnit Jupiter + Truth → `kotlin.test` (`commonTest`)
- snake_case names → backticks **without commas** (Kotlin/Native)
- No `File` / `Locale.US` / Hilt / mockk
- `TrainingCircuitBreaker` injectable clock already on study (same as ref)

### Out of scope
P2.3 dashboard, P2.4 Garmin, P2.6 tick seams, P2.8 Metro source, Flutter viewer, Advisor ZIP (P2.2, already merged), any production/dose/tick edit.

### Dose impact
**None.** No invented formulas. `DetermineBasalAIMI2` / plugin / tick untouched. Three `commonTest` files only.

### ⚠️ ASYNC IMPACT
None. Breaker uses existing production `AapsLock`; tests inject a deterministic clock. No dose coroutine.

### Follow-ups (not in this PR)
See FR list above (P2.5.2–P2.5.10+). Remainder after this PR: **~227 files / ~1255 `@Test`**. Keep ≤15 per PR.

### Evidence (fresh, this agent)
- `:plugins:aps:compileAndroidMain` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:compileKotlinIosArm64` — **BUILD SUCCESSFUL** EXIT=0
- `:plugins:aps:jvmTest` (3 classes) — **9 tests, 0 failures, 0 errors, 0 skipped**
  - `SmbRefinementFeatureSchemaTest` 4
  - `TrainingCircuitBreakerTest` 3
  - `UamInputSchemaValidatorTest` 2
- Diff vs study: **3 `commonTest` files only**, +350 lines, zero production

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6abd7b3-9c8c-4fe3-ae53-9d58672648c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6abd7b3-9c8c-4fe3-ae53-9d58672648c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

