### PR TITLE
docs(kmp): ancre P2.5.1 GO — PR #98 vs fe96b64f12

### DIFF
--- a/_docs/kmp/P2.5.1-ANCHOR.md
+++ b/_docs/kmp/P2.5.1-ANCHOR.md
@@ -1,0 +1,240 @@
+# Ancre P2.5.1 — AIMI pure tests package 1 (≤15)
+
+> Date d’ancre : 2026-09-11
+> Lot : **P2.5.1 only** — PR [#98](https://github.com/MTR93600/OpenApsAIMI/pull/98)
+> **Verdict : GO**
+> Aucun changement clinique dans ce document. Relecture du code, pas d’invention.
+
+## SHA
+
+| Rôle | SHA | Preuve |
+|---|---|---|
+| Study base (base de PR #98) | `c19eccfb14c691e76c6f2de2162938b0837800a3` | `kmp-aimi-migration-study` tip post P2.2 (#96) — `P2.2 — Advisor support ZIP corpus + active profile (02c906)` |
+| PR #98 head | `43cf1a4eb1ed4bce1b6d4ce019970ab338786361` | unique commit du PR ; parent = study base |
+| Référence `origin/dev_OAPSAIMI` | `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc` | tip ref au jour de l’ancre (`git rev-parse origin/dev_OAPSAIMI`) |
+| Branche PR | `cursor/p251-aimi-pure-tests-pkg1-48c5` | 1 commit, **+350 / −0**, **3 fichiers** `commonTest` only (annoncé et mesuré) |
+
+## Verdict
+
+**GO** — merger PR #98 sur `kmp-aimi-migration-study`.
+
+Lot **tests uniquement**. Zéro prod / zéro dose. Les 9 `@Test` de `SmbRefinementFeatureSchema` (4) + `TrainingCircuitBreaker` (3) + `UamInputSchemaValidator` (2) sont portés depuis `fe96b64f12` vers `commonTest` / `kotlin.test` avec les **mêmes locks**. Hors-scope P2.5.2 (SMB policy math, 15 tests) / Metro / Garmin respecté.
+
+Ne pas classer **GO_WITH_CAVEATS** : ce verdict est réservé aux lots mixed dose/ombre (P1.1 / P1.2) ou aux ports incomplets (Activity parkée P2.2). Ici il n’y a pas de chemin dose, pas de formule inventée, pas de drift sémantique. La CI GitHub `ios` rouge et `compileAndroidMain` non rejoués ici sont des **caveats d’environnement / dette study**, même classe que P2.1 « `flutter test` non rejoué » qui est resté GO.
+
+Ne pas classer **NO_GO** : les 9 méthodes `@Test` de la ref sont présentes ; aucune assertion clinique n’est relâchée.
+
+---
+
+## 1. Contenu réel de PR #98
+
+Mesuré `git diff --stat c19eccfb14c691e76c6f2de2162938b0837800a3 43cf1a4eb1ed4bce1b6d4ce019970ab338786361` :
+
+```
+3 files changed, 350 insertions(+)
+```
+
+Commit unique :
+
+```
+43cf1a4eb1 P2.5.1 — AIMI pure tests package 1 (SMB schema/corpus)
+```
+
+Parent = `c19eccfb14`. `git rev-parse 43cf1a4eb1^` = study base.
+
+| Fichier study | Statut | `@Test` |
+|---|---|---:|
+| `plugins/aps/src/commonTest/.../ml/SmbRefinementFeatureSchemaTest.kt` | ajouté (+256) | 4 |
+| `plugins/aps/src/commonTest/.../ml/TrainingCircuitBreakerTest.kt` | ajouté (+58) | 3 |
+| `plugins/aps/src/commonTest/.../UamInputSchemaValidatorTest.kt` | ajouté (+36) | 2 |
+
+**Non touchés** (`git diff --name-only` vide sur ces chemins) :
+
+- tout `commonMain` / `androidMain` / `src/main`
+- `DetermineBasalAIMI2.kt`
+- `OpenAPSAIMIPlugin.kt`
+- `SmbQuantizer` / `SmbIntervalPolicy` / `MealHighIobPolicy` / `SmbMpcPiBlend` (tests **et** prod)
+- Garmin (`plugins/sync/.../garmin/**`)
+- Metro / Hilt / dashboard
+
+Inventaire relu sur les deux tips (avant ce PR) :
+
+| Corpus | Fichiers `*Test.kt` | Méthodes `@Test` |
+|---|---:|---:|
+| Ref `plugins/aps/.../openAPSAIMI/` | 258 | 1451 |
+| Study `commonTest` AIMI | 23 | 158 |
+| Study `androidHostTest` AIMI | 16 | 56 |
+| Manquants par basename | **230** | 1237 (PR : ~1255) |
+
+Après #98 : **227** basenames manquants (230 − 3). Tests restants mesurés : 1451 − (158+9) − 56 = **1228**. Le « ~1255 » du body PR #98 recopie l’approx d’avant-PR — caveat de comptage, pas un trou de portage.
+
+---
+
+## 2. Tableau items + preuves
+
+| # | Item | Statut | Preuve SHA |
+|---|---|---|---|
+| 1 | 3 fichiers `commonTest` only, +350/−0, 1 commit | **Aligné** | `git diff --stat` / `--name-only` `c19eccfb14..43cf1a4eb1` ; GitHub `changed_files=3` `additions=350` |
+| 2 | `SmbRefinementFeatureSchemaTest` 4/4 | **Aligné** | Ref `plugins/aps/src/test/.../ml/SmbRefinementFeatureSchemaTest.kt` @ `fe96b64f12`. Head `commonTest/.../ml/SmbRefinementFeatureSchemaTest.kt` @ `43cf1a4eb1`. Mêmes 4 funs, mêmes fixtures, mêmes slices |
+| 3 | `TrainingCircuitBreakerTest` 3/3 | **Aligné** | Noms backtick **identiques** à la ref. `maxFailures=3` trip ; cooldown `now=1001` ; `reset()` |
+| 4 | `UamInputSchemaValidatorTest` 2/2 | **Aligné** | `expectedFeatureCount(intArrayOf(1, 18)) == 18` ; substring `"expected 18 features, got 15"` |
+| 5 | Zéro prod / dose | **Tenu** | 0 chemin `commonMain` / `androidMain`. Trees prod des 3 classes **hors** diff. `DetermineBasalAIMI2` absent |
+| 6 | JUnit/Truth → `kotlin.test` ; pas File/Hilt/mockk | **Aligné** | Imports `kotlin.test.{Test,assertEquals,assertTrue,assertFalse,assertNotNull}` seulement. `org.junit` / Truth / mockk / `java.io.File` / Hilt : uniquement dans le KDoc d’adaptation |
+| 7 | Noms Native sans virgule | **Aligné** | snake_case → backticks **espaces**, 0 virgule. Pattern P0.8 / P1.1 |
+| 8 | Hors-scope P2.5.2 SMB policy math | **Respecté** | Ref a 15 tests (`SmbQuantizer` 3 + `SmbIntervalPolicy` 4 + `MealHighIobPolicy` 3 + `SmbMpcPiBlend` 5) — **0** dans le diff |
+| 9 | Hors-scope Metro / Garmin | **Respecté** | `git diff --name-only` sans `garmin` / `metro` / `Metro` |
+| 10 | `jvmTest` 9/9 | **Relancé ici** | ancre @ `43cf1a4eb1` : BUILD SUCCESSFUL, XML 4+3+2, 0 fail / 0 err / 0 skip |
+
+---
+
+## 3. Fidélité vs `fe96b64f12` (9 tests)
+
+### 3.1 `SmbRefinementFeatureSchemaTest` (4)
+
+Prod study `commonMain` vs ref `src/main` : **KDoc only** (`the trainer` vs `` `AimiSmbTrainer` ``, héritage P1.1). APIs lockées identiques : `INPUT_SIZE`, `buildRuntimeFeatures`, `parseTrainingFeatures`, `shouldUseCsvRowForTraining`.
+
+| Ref (JUnit + Truth) | Study (`kotlin.test`) | Lock |
+|---|---|---|
+| `build_runtime_features_appends_latent_physio_axes_and_trend_indicator` | `` `build runtime features appends latent physio axes and trend indicator` `` | `features.size == INPUT_SIZE` ; `[10,14)=[0.41,0.28,0.91,0.64]` ; `[14,17)=[0.90,0.18,0.84]` ; `[17,20)=[0.83,0.12,0.79]` ; `last==0.73` |
+| `parse_training_features_keeps_backward_compatibility_for_old_csv_rows` | `` `parse training features keeps backward compatibility for old csv rows` `` | CSV 13 cols (sans latent/mode/causal) → non-null ; `size == INPUT_SIZE-1` ; `[10,20)` neutrals `[0,0,1,0,0.45,0.22,0,0,0,1]` |
+| `parse_training_features_ignores_family_audit_columns` | `` `parse training features ignores family audit columns` `` | family `2,4,3,1,3` ignorées ; `[17,20)==[0.71,0.12,0.82]` |
+| `should_use_csv_row_for_training_rejects_conflicted_or_fragile_rows` | `` `should use csv row for training rejects conflicted or fragile rows` `` | `decisionConflictFlags=dual_delivery\|dual_delivery_tbr_up` + fragility `0.75` → `shouldUseCsvRowForTraining == false` |
+
+Truth `containsExactly(…).inOrder()` ≡ `assertEquals(listOf(…), slice.toList())`. `isNotNull()` + `!!` ≡ `assertNotNull(...)` (retourne la valeur). Pas de tolérance float : Truth `isEqualTo` sans `isWithin` = égalité exacte, comme `assertEquals`.
+
+### 3.2 `TrainingCircuitBreakerTest` (3)
+
+Noms déjà en backticks sur la ref — **copie caractère pour caractère**.
+
+| Lock | Fixtures | Assertions |
+|---|---|---|
+| trip après N failures, `recordFailure()` true au trip | `maxFailures=3`, `cooldownMs=1000`, `clock={now}` | `isOpen` false ; 2× `recordFailure` false ; 3e true ; `isOpen` true |
+| cooldown écoulé → tentatives autorisées | `maxFailures=2` ; `now=1001` | open après 2 failures ; `isOpen` false après cooldown |
+| `reset` efface le compteur | idem | open → `reset()` → `isOpen` false |
+
+Prod study vs ref (**hors ce PR**, déjà sur `c19eccfb14`) : `AapsLock` + `aimiWallClockMs` vs `AtomicInteger`/`AtomicLong` + `System.currentTimeMillis`. Horloge **injectable des deux côtés**. Les 3 tests sont séquentiels / single-thread : même comportement observé. ⚠️ ASYNC IMPACT **du prod préexistant** : le breaker est thread-safe pour les trainers IO ; **ce PR n’ajoute aucune coroutine**.
+
+Note (ref **et** study, pas une divergence #98) : le KDoc prod dit « trip once » mais `recordFailure()` retourne `true` à **chaque** failure `≥ maxFailures`. Le test ne locke que le 3e appel. Identique `fe96b64f12`.
+
+### 3.3 `UamInputSchemaValidatorTest` (2)
+
+Prod study ≡ ref (diff vide).
+
+| Ref | Study | Lock |
+|---|---|---|
+| `expected_feature_count_uses_last_dimension_for_batched_tensor_shapes` | `` `expected feature count uses last dimension for batched tensor shapes` `` | shape `[1,18]` → 18 |
+| `mismatch_reason_is_explicit_for_runtime_logs` | `` `mismatch reason is explicit for runtime logs` `` | `mismatchReason(18,15)` contient `"expected 18 features, got 15"` |
+
+Truth `.contains(...)` ≡ `"..." in reason`. La chaîne prod est `"⚠ UAM input schema mismatch: expected …"` — le lock est la sous-chaîne, pas le préfixe emoji.
+
+### 3.4 Cluster déjà sur l’étude (non dans #98)
+
+`AimiSmbCorpusGuardTest` + `SmbTrainingRowBufferTest` (P1.1) restent hors diff. Ce paquet **complète** le cluster schema/corpus SMB + UAM input, sans les retoucher.
+
+---
+
+## 4. Zéro dose
+
+| Chemin | Constat @ `43cf1a4eb1` vs `c19eccfb14` |
+|---|---|
+| `DetermineBasalAIMI2.kt` | **0** ligne |
+| `OpenAPSAIMIPlugin` / tick / invoke / ISF / SMB formule | non touchés |
+| `SmbRefinementFeatureSchema.kt` / `TrainingCircuitBreaker.kt` / `UamInputSchemaValidator.kt` | **hors** diff (prod déjà `commonMain`) |
+| `androidMain` dose-facing | **0** fichier |
+| DB / PersistenceLayer | non touchés |
+
+Aucune formule inventée. Les tests **lisent** le schema / breaker / validateur déjà présents.
+
+⚠️ ASYNC IMPACT **de cette ancre / de ce PR** : **aucun**. Pas de nouvelle coroutine. Le breaker injecte une horloge déterministe.
+
+---
+
+## 5. Adaptations KMP vs divergences sémantiques
+
+| Sujet | Adaptation KMP | Divergence sémantique du **paquet** ? |
+|---|---|---|
+| JUnit Jupiter + Truth → `kotlin.test` | `commonTest` | Non — locks numériques / booléens / substrings identiques |
+| snake_case → backticks sans virgule | Kotlin/Native | Non — mêmes prédicats |
+| `assertNotNull` vs Truth `isNotNull`+`!!` | idiome kotlin.test | Non |
+| `listOf` + `assertEquals` vs `containsExactly.inOrder` | ordre conservé | Non |
+| `"…" in reason` vs Truth `contains` | substring | Non |
+| Source set `commonTest` (pas `androidHostTest`) | classes déjà `commonMain`, pas File/Android | Non — même layout que `AimiSmbCorpusGuardTest` |
+| `TrainingCircuitBreaker` `AapsLock` vs `Atomic*` | **préexistant** study, pas #98 | Non pour les 3 tests séquentiels |
+
+**Aucune divergence sémantique** sur les 9 locks.
+
+---
+
+## 6. Hors-scope respecté
+
+| Interdit P2.5.1 | Constat |
+|---|---|
+| P2.5.2 SMB policy math | `SmbQuantizerTest` (3) / `SmbIntervalPolicyTest` (4) / `MealHighIobPolicyTest` (3) / `SmbMpcPiBlendTest` (5) absents du diff. Prod `smb/` non touché |
+| P2.3 dashboard | Control Center / Hormonitor non retouchés |
+| P2.4 Garmin | Aucun fichier `garmin` |
+| P2.6 tick seams / P2.8 Metro source | Non |
+| Flutter viewer / Advisor ZIP | Déjà mergés #94 / #96 ; hors diff |
+| File / Hilt / mockk / `Locale.US` | Non utilisés dans les 3 fichiers |
+| Remplacement plugin / tick | Non |
+
+---
+
+## 7. Caveats vs blockers
+
+### Blockers
+
+**Aucun.** Pas de change de dose, pas d’écart de lock, hors-scope tenu, 9/9 relancés.
+
+### Caveats (suivre, ne bloquent pas le merge P2.5.1)
+
+1. **CI GitHub #98** — `ios` fail (variants Gradle `:plugins:libre3` / `:plugins:libkeks` / `:ios:shell`, **préexistant** : mêmes fails sur merges P0.9–P2.2, runs study `34583769060` etc.) + `claude-review` fail (OIDC 401, job `103214099774`). **Ne juge pas** ce diff. Même classe que P0.8 / P2.1 / P2.2.
+2. **Cette ancre n’a pas relancé** `compileAndroidMain` / `compileKotlinIosArm64`. Preuve fraîche = `jvmTest` 9/9 + `compileKotlinJvm` (chemin `jvmTest`, BUILD SUCCESSFUL in 3m 13s). `ANDROID_HOME` absent sur ce pod ; iOS native compile n’est pas disponible ici. Les compiles Android+iOS restent l’annonce du PR #98.
+3. **Comptage restant** — body PR : « ~227 fichiers / ~1255 `@Test` ». Mesure ancre : **227** basenames, **1228** `@Test` restants. Écart d’approx, pas de fichier oublié dans le paquet.
+4. **Breaker `AapsLock`** — adaptation study **déjà mergée**, pas introduite par #98. Tests identiques à la ref.
+5. **KDoc « trip once »** vs code (`true` à chaque failure ≥ N) — identique ref. Le test ne locke pas les appels 4+.
+
+---
+
+## 8. Checklist preuves
+
+| Preuve | Résultat | Qui |
+|---|---|---|
+| Diff PR vs base = 3 fichiers, +350/−0, 1 commit `43cf1a4eb1` | OK | ancre, `git diff --stat` |
+| Parent HEAD = study base `c19eccfb14` | OK | `git rev-parse 43cf1a4eb1^` |
+| Head / base / ref SHA ci-dessus | OK | `git rev-parse` + `git fetch` `origin/dev_OAPSAIMI` |
+| Ref tip = `fe96b64f12` | OK | `git rev-parse origin/dev_OAPSAIMI` |
+| 9 `@Test` ref = 9 `@Test` head (4+3+2) | OK | `rg -c '@Test'` |
+| Noms : snake_case → backticks, 0 virgule ; CB noms identiques | OK | extract funs |
+| Assertions / fixtures identiques (slices, neutrals, cooldown 1001, UAM 18/15) | OK | relecture côte à côte |
+| 0 chemin `commonMain` / `androidMain` / Garmin / Quantizer / Metro | OK | `git diff --name-only` |
+| Prod schema : KDoc only vs ref ; UAM prod IDENT ; breaker AapsLock préexistant | OK | `git diff <blob> <blob>` |
+| Inventaire 258/1451 ; 23/158 ; 16/56 ; missing basename 230→227 | OK | `git ls-tree` + basename set |
+| P2.5.2 15 tests présents **sur la ref**, absents du PR | OK | `rg -c '@Test'` sur les 4 fichiers smb |
+| `:plugins:aps:jvmTest` 3 classes @ `43cf1a4eb1` | **9/9**, 0 fail, 0 err, 0 skip | ancre, 2026-09-11 — XML `plugins/aps/build/test-results/jvmTest/TEST-…{SmbRefinementFeatureSchema,TrainingCircuitBreaker,UamInputSchemaValidator}Test.xml` |
+| `compileAndroidMain` / `compileKotlinIosArm64` | déclaré PR #98 BUILD SUCCESSFUL ; **non rejoué** ici | agent PR |
+| CI GitHub iOS rouge = variants appshell, pas régression P2.5.1 | OK | logs `libre3` debug/release ApiElements ; historique study |
+
+---
+
+## 9. Reco (merge / fix / suite)
+
+1. **Merge** PR #98 sur `kmp-aimi-migration-study`. Ne pas attendre le job iOS `:ios:shell` ni `claude-review` (dette study, pas P2.5.1).
+2. **Pas de fix clinique.** Ne pas toucher `SmbRefinementFeatureSchema` / breaker / UAM validator dans la foulée. Ne pas « corriger » le KDoc trip-once dans ce lot.
+3. **Suite** : **P2.5.2** SMB policy math — `SmbQuantizer` + `SmbIntervalPolicy` + `MealHighIobPolicy` + `SmbMpcPiBlend` (**15** tests, pile le plafond). Lot séparé. Ne pas tirer P2.5.3 Autodrive / shields / Garmin / Metro.
+4. **Cette ancre** : doc-only ; ne pas rebase `dev_OAPSAIMI` dans le lot.
+
+---
+
+## 10. Hors-scope (rappel)
+
+- P2.5.2 SMB policy math (15)
+- P2.5.3 Autodrive pur (`PhysiologicalStressMaskBuilder`, `MpcControllerCandidateGrid`)
+- P2.3 dashboard, P2.4 Garmin, P2.6 tick seams, P2.8 Metro source
+- File/Android host tests, mockk shields, DetermineBasal scenarios
+- Remplacement wholesale `DetermineBasalAIMI2` / `OpenAPSAIMIPlugin`
+
+---
+
+## 11. ⚠️ ASYNC IMPACT (flag ML)
+
+Aucun impact async sur les 3 engines ML ni sur le tick APS. Aucune coroutine / Flow / callback ajouté. `TrainingCircuitBreaker` utilise `AapsLock` **déjà** en production study ; les tests injectent une horloge déterministe. Pas de nouvelle course.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## FR

Ancre **P2.5.1 only**. Relecture de [PR #98](https://github.com/MTR93600/OpenApsAIMI/pull/98) contre `origin/dev_OAPSAIMI` @ `fe96b64f12`. **Aucun changement clinique.**

### SHA
- Study base = `kmp-aimi-migration-study` `c19eccfb14c691e76c6f2de2162938b0837800a3`
- PR #98 head = `43cf1a4eb1ed4bce1b6d4ce019970ab338786361` (+350/−0, 3 fichiers `commonTest`, 1 commit)
- Référence = `fe96b64f12f2f691ec6cfeeebf5c39bd446bedbc`

### Verdict : **GO**

9 tests AIMI purs portés, locks identiques à la ref. Zéro prod / zéro dose. Hors-scope P2.5.2 (15 tests SMB policy) / Metro / Garmin respecté.

Ne pas classer GO_WITH_CAVEATS (réservé aux lots mixed dose/ombre). Ne pas classer NO_GO (les 9 `@Test` de la ref sont là).

`jvmTest` relancé ici @ `43cf1a4eb1` : **9/9**, 0 fail. CI GitHub `ios` rouge = dette study (`:plugins:libre3` variants), pas ce diff.

### Reco
1. Merger PR #98. Ne pas attendre le job iOS `:ios:shell` ni `claude-review`.
2. Pas de fix clinique.
3. Suite : P2.5.2 SMB policy math (15 tests), lot séparé.

Doc : `_docs/kmp/P2.5.1-ANCHOR.md`

## EN

P2.5.1 anchor vs `fe96b64f12`. **GO**. Nine `commonTest` locks match the ref. Zero dose. `jvmTest` 9/9 re-run on this anchor. No clinical code in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-007769e1-4af7-4938-9298-b4297c00a8f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-007769e1-4af7-4938-9298-b4297c00a8f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

